### PR TITLE
Remove “詳情請見”

### DIFF
--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -119,10 +119,6 @@ Object {
       },
       "type": "template",
     },
-    Object {
-      "text": "詳情請見：https://cofacts.g0v.tw//article/AV8d2-YtyCdS-nWhuhdi",
-      "type": "text",
-    },
   ],
   "state": "CHOOSING_REPLY",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
@@ -473,10 +469,6 @@ Object {
         "type": "carousel",
       },
       "type": "template",
-    },
-    Object {
-      "text": "詳情請見：https://cofacts.g0v.tw//article/AVyyB61NyCdS-nWhuakC",
-      "type": "text",
     },
   ],
   "state": "CHOOSING_REPLY",

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -168,19 +168,16 @@ export default async function choosingArticle(params) {
                 '\n' +
                 versions[0].text.slice(0, 80),
               actions: [createPostbackAction('閱讀此回應', idx + 1, issuedAt)],
-          })),
+            })),
         },
       });
-      let endText;
+
       if (articleReplies.length > 10) {
-        endText = '更多回應請到：';
-      } else {
-        endText = '詳情請見：';
+        replies.push({
+          type: 'text',
+          text: `更多回應請到：${SITE_URL}/article/${selectedArticleId}`,
+        });
       }
-      replies.push({
-        type: 'text',
-        text: `${endText}${SITE_URL}/article/${selectedArticleId}`,
-      });
     } else {
       // No one has replied to this yet.
       const { data: { CreateReplyRequest }, errors } = await gql`


### PR DESCRIPTION
From https://g0v-tw.slackarchive.io/cofacts/page-26/ts-1511774885000009 

## Before

![2017-12-03 8 55 26](https://user-images.githubusercontent.com/108608/33525570-5245eba2-d86d-11e7-8668-894e2a130371.png)

"詳情請見" link is somewhat distracting, because the line bot is asking the user for next input.

## After

![2017-12-03 8 55 00](https://user-images.githubusercontent.com/108608/33525574-5d3c8584-d86d-11e7-9172-0109a9b3653e.png)

Removing "詳情請見" helps users to focus on choosing article.