### PR TITLE
Submission of comments on useless reply

### DIFF
--- a/src/handleInput.js
+++ b/src/handleInput.js
@@ -7,6 +7,7 @@ import askingArticleSubmissionReason from './handlers/askingArticleSubmissionRea
 import askingReplyRequestReason from './handlers/askingReplyRequestReason';
 import askingReplyRequestSubmission from './handlers/askingReplyRequestSubmission';
 import askingNotUsefulFeedback from './handlers/askingNotUsefulFeedback';
+import askingNotUsefulFeedbackSubmission from './handlers/askingNotUsefulFeedbackSubmission';
 import defaultState from './handlers/defaultState';
 
 /**
@@ -77,6 +78,10 @@ export default async function handleInput(
       }
       case 'ASKING_NOT_USEFUL_FEEDBACK': {
         params = await askingNotUsefulFeedback(params);
+        break;
+      }
+      case 'ASKING_NOT_USEFUL_FEEDBACK_SUBMISSION': {
+        params = await askingNotUsefulFeedbackSubmission(params);
         break;
       }
       case 'ASKING_ARTICLE_SUBMISSION': {

--- a/src/handlers/__tests__/__snapshots__/askingNotUsefulFeedbackSubmission.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/askingNotUsefulFeedbackSubmission.test.js.snap
@@ -82,10 +82,9 @@ Object {
 }
 `;
 
-exports[`handles text comment with other existing feedbacks 1`] = `
+exports[`handles text comment with no other existing feedbacks 1`] = `
 Object {
   "data": Object {
-    "comment": "comment",
     "foundArticleIds": Array [
       "AWDZYXxAyCdS-nWhumlz",
       "5483323992880-rumor",
@@ -100,47 +99,115 @@ Object {
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
   },
   "event": Object {
-    "input": "comment",
+    "input": "y",
     "postback": Object {
-      "data": "{\\"input\\":\\"comment\\",\\"issuedAt\\":1519019701265}",
+      "data": "{\\"input\\":\\"y\\",\\"issuedAt\\":1519019701265}",
     },
     "timestamp": 1519019734813,
-    "type": "text",
+    "type": "postback",
   },
   "isSkipUser": false,
   "issuedAt": 1519019735467,
   "replies": Array [
     Object {
-      "text": "以下是您所填寫的理由：「comment」",
+      "text": "感謝您的回饋，您是第一個評論這個回應的人 :)",
       "type": "text",
     },
     Object {
-      "altText": "我們會把您覺得回應沒幫助的原因呈現給編輯們看。請確認：",
+      "text": "💁 若您認為自己能回應得更好，歡迎到 https://cofacts.g0v.tw/article/AWDZYXxAyCdS-nWhumlz 提交新的回應唷！",
+      "type": "text",
+    },
+  ],
+  "state": "__INIT__",
+  "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
+}
+`;
+
+exports[`handles text comment with other existing feedbacks 1`] = `
+Object {
+  "data": Object {
+    "foundArticleIds": Array [
+      "AWDZYXxAyCdS-nWhumlz",
+      "5483323992880-rumor",
+      "AV-Urc0jyCdS-nWhuity",
+      "AVsh8u7StKp96s659Dgq",
+    ],
+    "foundReplyIds": Array [
+      "AWDZeeV0yCdS-nWhuml8",
+    ],
+    "searchedText": "貼圖",
+    "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
+    "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
+  },
+  "event": Object {
+    "input": "y",
+    "postback": Object {
+      "data": "{\\"input\\":\\"y\\",\\"issuedAt\\":1519019701265}",
+    },
+    "timestamp": 1519019734813,
+    "type": "postback",
+  },
+  "isSkipUser": false,
+  "issuedAt": 1519019735467,
+  "replies": Array [
+    Object {
+      "text": "感謝您與其他 1 人的回饋。",
+      "type": "text",
+    },
+    Object {
+      "text": "💁 若您認為自己能回應得更好，歡迎到 https://cofacts.g0v.tw/article/AWDZYXxAyCdS-nWhumlz 提交新的回應唷！",
+      "type": "text",
+    },
+  ],
+  "state": "__INIT__",
+  "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
+}
+`;
+
+exports[`handles that the user wants to modify his comments 1`] = `
+Object {
+  "data": Object {
+    "foundArticleIds": Array [
+      "AWDZYXxAyCdS-nWhumlz",
+      "5483323992880-rumor",
+      "AV-Urc0jyCdS-nWhuity",
+      "AVsh8u7StKp96s659Dgq",
+    ],
+    "foundReplyIds": Array [
+      "AWDZeeV0yCdS-nWhuml8",
+    ],
+    "searchedText": "貼圖",
+    "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
+    "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
+  },
+  "event": Object {
+    "input": "r",
+    "postback": Object {
+      "data": "{\\"input\\":\\"r\\",\\"issuedAt\\":1519019701265}",
+    },
+    "timestamp": 1519019734813,
+    "type": "postback",
+  },
+  "isSkipUser": false,
+  "issuedAt": 1519019735467,
+  "replies": Array [
+    Object {
+      "altText": "好的，請重新填寫理由",
       "template": Object {
         "actions": Array [
           Object {
-            "data": "{\\"input\\":\\"y\\",\\"issuedAt\\":1519019735467}",
-            "label": "明白，我要送出",
-            "type": "postback",
-          },
-          Object {
-            "data": "{\\"input\\":\\"r\\",\\"issuedAt\\":1519019735467}",
-            "label": "重寫送出的理由",
-            "type": "postback",
-          },
-          Object {
             "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1519019735467}",
-            "label": "算了，我不想填",
+            "label": "我不想填了",
             "type": "postback",
           },
         ],
-        "text": "我們會把您覺得回應沒幫助的原因呈現給編輯們看。請確認：",
+        "text": "好的，請重新填寫理由",
         "type": "buttons",
       },
       "type": "template",
     },
   ],
-  "state": "ASKING_NOT_USEFUL_FEEDBACK_SUBMISSION",
+  "state": "ASKING_NOT_USEFUL_FEEDBACK",
   "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
 }
 `;

--- a/src/handlers/__tests__/__snapshots__/askingReplyFeedback.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/askingReplyFeedback.test.js.snap
@@ -32,7 +32,7 @@ Object {
       "template": Object {
         "actions": Array [
           Object {
-            "data": "{\\"input\\":\\"none\\",\\"issuedAt\\":1519019735467}",
+            "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1519019735467}",
             "label": "我不想填理由",
             "type": "postback",
           },

--- a/src/handlers/__tests__/askingNotUsefulFeedback.test.js
+++ b/src/handlers/__tests__/askingNotUsefulFeedback.test.js
@@ -4,7 +4,7 @@ import askingNotUsefulFeedback from '../askingNotUsefulFeedback';
 import * as apiResult from '../__fixtures__/askingNotUsefulFeedback';
 import gql from '../../gql';
 
-let commonParamsNone = {
+const commonParamsNone = {
   data: {
     searchedText: '貼圖',
     foundArticleIds: [
@@ -42,7 +42,7 @@ it('handles "none" postback with other existing feedbacks', async () => {
   expect(await askingNotUsefulFeedback(commonParamsNone)).toMatchSnapshot();
 });
 
-let commonParamsComment = JSON.parse(JSON.stringify(commonParamsNone));
+const commonParamsComment = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsComment.event = {
   type: 'text',
   input: 'comment',
@@ -54,7 +54,7 @@ it('handles text comment with other existing feedbacks', async () => {
   expect(await askingNotUsefulFeedback(commonParamsComment)).toMatchSnapshot();
 });
 
-let commonParamsNoId = JSON.parse(JSON.stringify(commonParamsNone));
+const commonParamsNoId = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsNoId.data.selectedReplyId = undefined;
 
 it('handles undefined reply id', () => {

--- a/src/handlers/__tests__/askingNotUsefulFeedbackSubmission.test.js
+++ b/src/handlers/__tests__/askingNotUsefulFeedbackSubmission.test.js
@@ -4,7 +4,7 @@ import askingNotUsefulFeedbackSubmission from '../askingNotUsefulFeedbackSubmiss
 import * as apiResult from '../__fixtures__/askingNotUsefulFeedback';
 import gql from '../../gql';
 
-let commonParamsNone = {
+const commonParamsNone = {
   data: {
     searchedText: '貼圖',
     foundArticleIds: [
@@ -46,7 +46,7 @@ it('handles "none" postback with other existing feedbacks', async () => {
   ).toMatchSnapshot();
 });
 
-let commonParamsComment = JSON.parse(JSON.stringify(commonParamsNone));
+const commonParamsComment = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsComment.event = {
   type: 'postback',
   input: 'y',
@@ -70,7 +70,7 @@ it('handles text comment with other existing feedbacks', async () => {
   ).toMatchSnapshot();
 });
 
-let commonParamsModify = JSON.parse(JSON.stringify(commonParamsNone));
+const commonParamsModify = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsModify.event = {
   type: 'postback',
   input: 'r',
@@ -84,7 +84,7 @@ it('handles that the user wants to modify his comments', async () => {
   ).toMatchSnapshot();
 });
 
-let commonParamsNoId = JSON.parse(JSON.stringify(commonParamsNone));
+const commonParamsNoId = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsNoId.data.selectedReplyId = undefined;
 
 it('handles undefined reply id', () => {

--- a/src/handlers/__tests__/askingNotUsefulFeedbackSubmission.test.js
+++ b/src/handlers/__tests__/askingNotUsefulFeedbackSubmission.test.js
@@ -1,6 +1,6 @@
 jest.mock('../../gql');
 
-import askingNotUsefulFeedback from '../askingNotUsefulFeedback';
+import askingNotUsefulFeedbackSubmission from '../askingNotUsefulFeedbackSubmission';
 import * as apiResult from '../__fixtures__/askingNotUsefulFeedback';
 import gql from '../../gql';
 
@@ -17,7 +17,7 @@ let commonParamsNone = {
     foundReplyIds: ['AWDZeeV0yCdS-nWhuml8'],
     selectedReplyId: 'AWDZeeV0yCdS-nWhuml8',
   },
-  state: 'ASKING_NOT_USEFUL_FEEDBACK',
+  state: 'ASKING_NOT_USEFUL_FEEDBACK_SUBMISSION',
   event: {
     type: 'postback',
     input: 'n',
@@ -33,32 +33,62 @@ let commonParamsNone = {
 it('handles "none" postback with no other existing feedbacks', async () => {
   gql.__push(apiResult.oneFeedback);
 
-  expect(await askingNotUsefulFeedback(commonParamsNone)).toMatchSnapshot();
+  expect(
+    await askingNotUsefulFeedbackSubmission(commonParamsNone)
+  ).toMatchSnapshot();
 });
 
 it('handles "none" postback with other existing feedbacks', async () => {
   gql.__push(apiResult.twoFeedbacks);
 
-  expect(await askingNotUsefulFeedback(commonParamsNone)).toMatchSnapshot();
+  expect(
+    await askingNotUsefulFeedbackSubmission(commonParamsNone)
+  ).toMatchSnapshot();
 });
 
 let commonParamsComment = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsComment.event = {
-  type: 'text',
-  input: 'comment',
+  type: 'postback',
+  input: 'y',
   timestamp: 1519019734813,
-  postback: { data: '{"input":"comment","issuedAt":1519019701265}' },
+  postback: { data: '{"input":"y","issuedAt":1519019701265}' },
 };
 
+it('handles text comment with no other existing feedbacks', async () => {
+  gql.__push(apiResult.oneFeedback);
+
+  expect(
+    await askingNotUsefulFeedbackSubmission(commonParamsComment)
+  ).toMatchSnapshot();
+});
+
 it('handles text comment with other existing feedbacks', async () => {
-  expect(await askingNotUsefulFeedback(commonParamsComment)).toMatchSnapshot();
+  gql.__push(apiResult.twoFeedbacks);
+
+  expect(
+    await askingNotUsefulFeedbackSubmission(commonParamsComment)
+  ).toMatchSnapshot();
+});
+
+let commonParamsModify = JSON.parse(JSON.stringify(commonParamsNone));
+commonParamsModify.event = {
+  type: 'postback',
+  input: 'r',
+  timestamp: 1519019734813,
+  postback: { data: '{"input":"r","issuedAt":1519019701265}' },
+};
+
+it('handles that the user wants to modify his comments', async () => {
+  expect(
+    await askingNotUsefulFeedbackSubmission(commonParamsModify)
+  ).toMatchSnapshot();
 });
 
 let commonParamsNoId = JSON.parse(JSON.stringify(commonParamsNone));
 commonParamsNoId.data.selectedReplyId = undefined;
 
 it('handles undefined reply id', () => {
-  expect(askingNotUsefulFeedback(commonParamsNoId)).rejects.toThrow(
+  expect(askingNotUsefulFeedbackSubmission(commonParamsNoId)).rejects.toThrow(
     'selectedReply not set in data'
   );
 });

--- a/src/handlers/__tests__/askingReplyFeedback.test.js
+++ b/src/handlers/__tests__/askingReplyFeedback.test.js
@@ -42,7 +42,7 @@ it('handles "yes" postback with other existing feedbacks', async () => {
   expect(await askingReplyFeedback(commonParamsYes)).toMatchSnapshot();
 });
 
-let commonParamsNo = {
+const commonParamsNo = {
   data: {
     searchedText: '貼圖',
     foundArticleIds: [

--- a/src/handlers/askingNotUsefulFeedback.js
+++ b/src/handlers/askingNotUsefulFeedback.js
@@ -1,6 +1,6 @@
 import gql from '../gql';
 import ga from '../ga';
-import { getArticleURL } from './utils';
+import { getArticleURL, createPostbackAction } from './utils';
 
 export default async function askingNotUsefulFeedback(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
@@ -9,59 +9,82 @@ export default async function askingNotUsefulFeedback(params) {
     throw new Error('selectedReply not set in data');
   }
 
-  // Track when user give feedback.
-  ga(userId, {
-    ec: 'UserInput',
-    ea: 'Feedback-Vote',
-    el: `${data.selectedArticleId}/${data.selectedReplyId}`,
-  });
-
-  const {
-    data: {
-      action: { feedbackCount },
-    },
-  } = await gql`
-    mutation(
-      $comment: String!
-      $vote: FeedbackVote!
-      $articleId: String!
-      $replyId: String!
-    ) {
-      action: CreateOrUpdateArticleReplyFeedback(
-        comment: $comment
-        articleId: $articleId
-        replyId: $replyId
-        vote: $vote
+  if (event.input === 'n') {
+    ga(userId, {
+      ec: 'UserInput',
+      ea: 'Feedback-Vote',
+      el: `${data.selectedArticleId}/${data.selectedReplyId}`,
+    });
+    const {
+      data: {
+        action: { feedbackCount },
+      },
+    } = await gql`
+      mutation(
+        $comment: String!
+        $vote: FeedbackVote!
+        $articleId: String!
+        $replyId: String!
       ) {
-        feedbackCount
+        action: CreateOrUpdateArticleReplyFeedback(
+          comment: $comment
+          articleId: $articleId
+          replyId: $replyId
+          vote: $vote
+        ) {
+          feedbackCount
+        }
       }
-    }
-  `(
-    {
-      articleId: data.selectedArticleId,
-      replyId: data.selectedReplyId,
-      comment: event.input,
-      vote: 'DOWNVOTE',
-    },
-    { userId }
-  );
+    `(
+      {
+        articleId: data.selectedArticleId,
+        replyId: data.selectedReplyId,
+        comment: 'none',
+        vote: 'DOWNVOTE',
+      },
+      { userId }
+    );
 
-  replies = [
-    {
-      type: 'text',
-      text:
-        feedbackCount > 1
-          ? `感謝您與其他 ${feedbackCount - 1} 人的回饋。`
-          : '感謝您的回饋，您是第一個評論這個回應的人 :)',
-    },
-    {
-      type: 'text',
-      text: `💁 若您認為自己能回應得更好，歡迎到 ${getArticleURL(
-        data.selectedArticleId
-      )} 提交新的回應唷！`,
-    },
-  ];
+    replies = [
+      {
+        type: 'text',
+        text:
+          feedbackCount > 1
+            ? `感謝您與其他 ${feedbackCount - 1} 人的回饋。`
+            : '感謝您的回饋，您是第一個評論這個回應的人 :)',
+      },
+      {
+        type: 'text',
+        text: `💁 若您認為自己能回應得更好，歡迎到 ${getArticleURL(
+          data.selectedArticleId
+        )} 提交新的回應唷！`,
+      },
+    ];
+    state = '__INIT__';
+  } else {
+    data.comment = event.input;
 
-  state = '__INIT__';
+    replies = [
+      {
+        type: 'text',
+        text: `以下是您所填寫的理由：「${event.input}」`,
+      },
+      {
+        type: 'template',
+        altText: '我們會把您覺得回應沒幫助的原因呈現給編輯們看。請確認：',
+        template: {
+          type: 'buttons',
+          text: '我們會把您覺得回應沒幫助的原因呈現給編輯們看。請確認：',
+          actions: [
+            createPostbackAction('明白，我要送出', 'y', issuedAt),
+            createPostbackAction('重寫送出的理由', 'r', issuedAt),
+            createPostbackAction('放棄送出', 'n', issuedAt),
+          ],
+        },
+      },
+    ];
+
+    state = 'ASKING_NOT_USEFUL_FEEDBACK_SUBMISSION';
+  }
   return { data, state, event, issuedAt, userId, replies, isSkipUser };
 }

--- a/src/handlers/askingNotUsefulFeedback.js
+++ b/src/handlers/askingNotUsefulFeedback.js
@@ -1,5 +1,4 @@
 import gql from '../gql';
-import ga from '../ga';
 import { getArticleURL, createPostbackAction } from './utils';
 
 export default async function askingNotUsefulFeedback(params) {
@@ -10,11 +9,6 @@ export default async function askingNotUsefulFeedback(params) {
   }
 
   if (event.input === 'n') {
-    ga(userId, {
-      ec: 'UserInput',
-      ea: 'Feedback-Vote',
-      el: `${data.selectedArticleId}/${data.selectedReplyId}`,
-    });
     const {
       data: {
         action: { feedbackCount },
@@ -78,7 +72,7 @@ export default async function askingNotUsefulFeedback(params) {
           actions: [
             createPostbackAction('明白，我要送出', 'y', issuedAt),
             createPostbackAction('重寫送出的理由', 'r', issuedAt),
-            createPostbackAction('放棄送出', 'n', issuedAt),
+            createPostbackAction('算了，我不想填', 'n', issuedAt),
           ],
         },
       },

--- a/src/handlers/askingNotUsefulFeedbackSubmission.js
+++ b/src/handlers/askingNotUsefulFeedbackSubmission.js
@@ -1,6 +1,5 @@
 import gql from '../gql';
-import ga from '../ga';
-import { getArticleURL } from './utils';
+import { getArticleURL, createPostbackAction } from './utils';
 
 export default async function askingNotUsefulFeedbackSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
@@ -8,13 +7,6 @@ export default async function askingNotUsefulFeedbackSubmission(params) {
   if (!data.selectedReplyId) {
     throw new Error('selectedReply not set in data');
   }
-
-  // Track when user give feedback.
-  ga(userId, {
-    ec: 'UserInput',
-    ea: 'Feedback-Vote',
-    el: `${data.selectedArticleId}/${data.selectedReplyId}`,
-  });
 
   if (event.input !== 'r') {
     const {
@@ -65,7 +57,17 @@ export default async function askingNotUsefulFeedbackSubmission(params) {
 
     state = '__INIT__';
   } else {
-    replies = [{ type: 'text', text: '好的，請重新填寫理由。' }];
+    replies = [
+      {
+        type: 'template',
+        altText: `好的，請重新填寫理由`,
+        template: {
+          type: 'buttons',
+          text: '好的，請重新填寫理由',
+          actions: [createPostbackAction('我不想填了', 'n', issuedAt)],
+        },
+      },
+    ];
     state = 'ASKING_NOT_USEFUL_FEEDBACK';
   }
 

--- a/src/handlers/askingReplyFeedback.js
+++ b/src/handlers/askingReplyFeedback.js
@@ -35,7 +35,7 @@ export default async function askingReplyFeedback(params) {
       {
         articleId: data.selectedArticleId,
         replyId: data.selectedReplyId,
-        vote: event.input === 'UPVOTE',
+        vote: 'UPVOTE',
       },
       { userId }
     );


### PR DESCRIPTION
* New state: ASKING_NOT_USEFUL_FEEDBACK_SUBMISSION
  * After a user leaves his comment, we ask for confirmation. He can either submit directly, revise his comment, or simply leave without a comment.
  * Here I use 「算了，我不想填」 instead of 「放棄送出」 if the user wants to give up his comment when confirmation since the latter one implies "revision" to some extent.
* Added tests for the new state
* Added tests for exceptions
