### PR TITLE
#89: flex message submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Create .env file, copy the template below and `LINE_CHANNEL_SECRET`, `LINE_CHANN
 API_URL=https://cofacts-api.g0v.tw/graphql
 LINE_CHANNEL_SECRET=<paste LINE@'s channel secret here>
 LINE_CHANNEL_TOKEN=<paste LINE@'s channel token here>
+LINE_AT_ID=<paste LINE@'s id without '@' here>
 ```
 
 Other customizable env vars are:

--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -23,28 +23,88 @@ Object {
   "issuedAt": 1511633232970,
   "replies": Array [
     Object {
-      "text": "【送出訊息到公開資料庫？】
+      "altText": "【送出訊息到公開資料庫？】
 若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。
 
 雖然您不會立刻收到查證結果，但可以幫助到未來同樣收到這份訊息的人。
 
-請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。",
-      "type": "text",
-    },
-    Object {
-      "altText": "若要放棄請輸入「n」。",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1511633232970}",
-            "label": "放棄送出",
-            "type": "postback",
-          },
-        ],
-        "text": "若要放棄，請按「放棄送出」。",
-        "type": "buttons",
+請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。
+若想放棄，請輸入「n」。",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "size": "xxs",
+              "text": "若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "size": "xxs",
+              "text": "雖然您不會立刻收到查證結果，但可以幫助到未來同樣收到這份訊息的人。",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "color": "#990000",
+              "size": "md",
+              "text": "請打字告訴我們：",
+              "type": "text",
+              "weight": "bold",
+              "wrap": true,
+            },
+            Object {
+              "color": "#ff0000",
+              "size": "xxl",
+              "text": "為何您會覺得這是一則謠言？",
+              "type": "text",
+              "weight": "bold",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1511633232970}",
+                "label": "放棄送出",
+                "type": "postback",
+              },
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "⌨️ 傳理由給我們",
+                "type": "uri",
+                "uri": "line://oaMessage/@cofacts/?因為⋯⋯",
+              },
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "header": Object {
+          "contents": Array [
+            Object {
+              "color": "#009900",
+              "size": "sm",
+              "text": "送出訊息到公開資料庫？",
+              "type": "text",
+              "weight": "bold",
+            },
+          ],
+          "layout": "horizontal",
+          "type": "box",
+        },
+        "type": "bubble",
       },
-      "type": "template",
+      "type": "flex",
     },
   ],
   "state": "ASKING_ARTICLE_SUBMISSION_REASON",
@@ -535,29 +595,88 @@ Object {
   "issuedAt": 1511702208730,
   "replies": Array [
     Object {
-      "text": "【跟編輯說您的疑惑】
+      "altText": "【跟編輯說您的疑惑】
 抱歉這篇訊息還沒有人回應過唷！
 
 若您覺得這是一則謠言，請指出您有疑惑之處，說服編輯這是一份應該被闢謠的訊息。
 
-請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處；
-若想跳過，請按「我不想填理由」按鈕。",
-      "type": "text",
-    },
-    Object {
-      "altText": "若要放棄請輸入「n」。",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1511702208730}",
-            "label": "我不想填理由",
-            "type": "postback",
-          },
-        ],
-        "text": "若要放棄，請按「我不想填理由」。",
-        "type": "buttons",
+請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您的疑惑；
+若想跳過，請輸入「n」。",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "size": "xxs",
+              "text": "抱歉這篇訊息還沒有人回應過唷！",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "size": "xxs",
+              "text": "若您覺得這是一則謠言，請指出您有疑惑之處，說服編輯這是一份應該被闢謠的訊息，幫助闢謠編輯釐清您有疑惑之處。",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "color": "#990000",
+              "size": "md",
+              "text": "請打字告訴我們：",
+              "type": "text",
+              "weight": "bold",
+              "wrap": true,
+            },
+            Object {
+              "color": "#ff0000",
+              "size": "xxl",
+              "text": "為何您會覺得這是一則謠言？",
+              "type": "text",
+              "weight": "bold",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1511702208730}",
+                "label": "我不想填理由",
+                "type": "postback",
+              },
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "⌨️ 傳理由給我們",
+                "type": "uri",
+                "uri": "line://oaMessage/@cofacts/?因為⋯⋯",
+              },
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "header": Object {
+          "contents": Array [
+            Object {
+              "color": "#009900",
+              "size": "sm",
+              "text": "跟編輯說您的疑惑",
+              "type": "text",
+              "weight": "bold",
+            },
+          ],
+          "layout": "horizontal",
+          "type": "box",
+        },
+        "type": "bubble",
       },
-      "type": "template",
+      "type": "flex",
     },
   ],
   "state": "ASKING_REPLY_REQUEST_REASON",

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -189,28 +189,88 @@ Object {
       "type": "text",
     },
     Object {
-      "text": "【送出訊息到公開資料庫？】
+      "altText": "【送出訊息到公開資料庫？】
 若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。
 
 雖然您不會立刻收到查證結果，但可以幫助到未來同樣收到這份訊息的人。
 
-請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。",
-      "type": "text",
-    },
-    Object {
-      "altText": "若要放棄請輸入「n」。",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1497994017447}",
-            "label": "放棄送出",
-            "type": "postback",
-          },
-        ],
-        "text": "若要放棄，請按「放棄送出」。",
-        "type": "buttons",
+請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。
+若想放棄，請輸入「n」。",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "size": "xxs",
+              "text": "若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "size": "xxs",
+              "text": "雖然您不會立刻收到查證結果，但可以幫助到未來同樣收到這份訊息的人。",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "color": "#990000",
+              "size": "md",
+              "text": "請打字告訴我們：",
+              "type": "text",
+              "weight": "bold",
+              "wrap": true,
+            },
+            Object {
+              "color": "#ff0000",
+              "size": "xxl",
+              "text": "為何您會覺得這是一則謠言？",
+              "type": "text",
+              "weight": "bold",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"n\\",\\"issuedAt\\":1497994017447}",
+                "label": "放棄送出",
+                "type": "postback",
+              },
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "⌨️ 傳理由給我們",
+                "type": "uri",
+                "uri": "line://oaMessage/@cofacts/?因為⋯⋯",
+              },
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "header": Object {
+          "contents": Array [
+            Object {
+              "color": "#009900",
+              "size": "sm",
+              "text": "送出訊息到公開資料庫？",
+              "type": "text",
+              "weight": "bold",
+            },
+          ],
+          "layout": "horizontal",
+          "type": "box",
+        },
+        "type": "bubble",
       },
-      "type": "template",
+      "type": "flex",
     },
   ],
   "state": "ASKING_ARTICLE_SUBMISSION_REASON",

--- a/src/handlers/askingArticleSubmissionReason.js
+++ b/src/handlers/askingArticleSubmissionReason.js
@@ -3,7 +3,16 @@ import { createPostbackAction, REASON_PLACEHOLDER } from './utils';
 
 export default async function askingArticleSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
-  if (event.input !== 'n' && event.input !== REASON_PLACEHOLDER) {
+  if (event.input === REASON_PLACEHOLDER) {
+    // if the user submits the prefilled 「因為......」 directly, ask him to resubmit
+    replies = [{ type: 'text', text: '您的理由不夠充分，請重新填寫。' }];
+  } else if (event.input === 'n') {
+    // Track whether user create Article or not if the Article is not found in DB.
+    ga(userId, { ec: 'Article', ea: 'Create', el: 'No' });
+
+    replies = [{ type: 'text', text: '訊息沒有送出，謝謝您的使用。' }];
+    state = '__INIT__';
+  } else {
     const reason = event.input;
     const text =
       `以下是您所填寫的理由：\n「\n${reason}\n」\n` +
@@ -99,15 +108,6 @@ export default async function askingArticleSubmission(params) {
     ];
     data.reasonText = reason;
     state = 'ASKING_ARTICLE_SUBMISSION';
-  } else if (event.input !== REASON_PLACEHOLDER) {
-    // Track whether user create Article or not if the Article is not found in DB.
-    ga(userId, { ec: 'Article', ea: 'Create', el: 'No' });
-
-    replies = [{ type: 'text', text: '訊息沒有送出，謝謝您的使用。' }];
-    state = '__INIT__';
-  } else {
-    // if the user submits the prefilled 「因為......」 directly, ask him to resubmit
-    replies = [{ type: 'text', text: '您的理由不夠充分，請重新填寫。' }];
   }
 
   return { data, state, event, issuedAt, userId, replies, isSkipUser };

--- a/src/handlers/askingArticleSubmissionReason.js
+++ b/src/handlers/askingArticleSubmissionReason.js
@@ -3,33 +3,96 @@ import { createPostbackAction } from './utils';
 
 export default async function askingArticleSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
-
   if (event.input !== 'n') {
     const reason = event.input;
+    const text =
+      `以下是您所填寫的理由：\n「\n${reason}\n」\n` +
+      '我們即將把此訊息與您填寫的理由送至資料庫。' +
+      '若您送出的訊息或理由意味不明、造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。' +
+      '若要確認請輸入「y」、若要放棄請輸入「n」、若要重新填寫理由請輸入「r」';
 
     replies = [
       {
-        type: 'text',
-        text: `以下是您所填寫的理由：\n「\n${reason}\n」`,
-      },
-      {
-        type: 'text',
-        text:
-          '我們即將把此訊息與您填寫的理由送至資料庫。若您送出的訊息或理由意味不明、' +
-          '造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。',
-      },
-      {
-        type: 'template',
-        altText:
-          '若要確認請輸入「y」、若要放棄請輸入「n」、若要重新填寫理由請輸入「r」',
-        template: {
-          type: 'buttons',
-          text: '請確認',
-          actions: [
-            createPostbackAction('明白我要送出', 'y', issuedAt),
-            createPostbackAction('重寫送出的理由', 'r', issuedAt),
-            createPostbackAction('放棄送出', 'n', issuedAt),
-          ],
+        type: 'flex',
+        altText: text,
+        contents: {
+          type: 'bubble',
+          styles: {
+            footer: {
+              separator: true,
+            },
+          },
+          body: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              {
+                type: 'text',
+                text: '把訊息送進資料庫',
+                weight: 'bold',
+                color: '#1DB446',
+                size: 'sm',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'text',
+                text: '訊息',
+                weight: 'bold',
+                size: 'xl',
+                margin: 'xl',
+              },
+              {
+                type: 'text',
+                text: data.searchedText,
+                size: 'xs',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'text',
+                text: '覺得是謠言的理由',
+                weight: 'bold',
+                size: 'xl',
+                margin: 'xl',
+              },
+              {
+                type: 'text',
+                text: reason,
+                size: 'xxs',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'text',
+                text:
+                  '若您送出的訊息或理由意味不明、造成闢謠編輯的困擾，未來您將無法送出文章。',
+                color: '#ff0000',
+                wrap: true,
+                margin: 'xxl',
+              },
+              {
+                type: 'button',
+                margin: 'xl',
+                style: 'primary',
+                action: createPostbackAction('放棄送出', 'n', issuedAt),
+              },
+              {
+                type: 'button',
+                action: createPostbackAction('重寫送出的理由', 'r', issuedAt),
+              },
+              {
+                type: 'button',
+                action: createPostbackAction('明白我要送出', 'y', issuedAt),
+              },
+            ],
+          },
         },
       },
     ];

--- a/src/handlers/askingReplyRequestReason.js
+++ b/src/handlers/askingReplyRequestReason.js
@@ -8,29 +8,82 @@ export default async function askingArticleSubmission(params) {
   if (event.input !== 'n') {
     const reason = event.input;
 
+    const text =
+      `以下是您所填寫的理由：\n「\n${reason}\n」\n` +
+      '我們即將把此訊息與您填寫的理由送至資料庫。' +
+      '若您送出的訊息或理由意味不明、造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。' +
+      '若要確認請輸入「y」、若不想填寫請輸入「n」、若要重新填寫理由請輸入「r」';
+
     replies = [
       {
-        type: 'text',
-        text: `以下是您所填寫的理由：\n「\n${reason}\n」`,
-      },
-      {
-        type: 'text',
-        text:
-          '我們即將把此訊息與您填寫的理由送至資料庫。若您送出的訊息或理由意味不明、' +
-          '造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。',
-      },
-      {
-        type: 'template',
-        altText:
-          '若要確認請輸入「y」、若要放棄請輸入「n」、若要重新填寫理由請輸入「r」',
-        template: {
-          type: 'buttons',
-          text: '請確認',
-          actions: [
-            createPostbackAction('明白我要送出', 'y', issuedAt),
-            createPostbackAction('重寫送出的理由', 'r', issuedAt),
-            createPostbackAction('我不想填理由', 'n', issuedAt),
-          ],
+        type: 'flex',
+        altText: text,
+        contents: {
+          type: 'bubble',
+          styles: {
+            footer: {
+              separator: true,
+            },
+          },
+          body: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              {
+                type: 'text',
+                text: '把您的理由送進資料庫',
+                weight: 'bold',
+                color: '#1DB446',
+                size: 'sm',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'text',
+                text: '覺得是謠言的理由',
+                weight: 'bold',
+                size: 'xl',
+                margin: 'xl',
+              },
+              {
+                type: 'text',
+                text: reason,
+                size: 'xxs',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'text',
+                text:
+                  '若您送出的理由意味不明、造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。',
+                color: '#ff0000',
+                wrap: true,
+                margin: 'xxl',
+              },
+              {
+                type: 'button',
+                margin: 'xl',
+                style: 'primary',
+                action: createPostbackAction('我不想填理由', 'n', issuedAt),
+              },
+              {
+                type: 'button',
+                action: createPostbackAction('重寫送出的理由', 'r', issuedAt),
+              },
+              {
+                type: 'button',
+                action: createPostbackAction('明白我要送出', 'y', issuedAt),
+              },
+            ],
+          },
         },
       },
     ];

--- a/src/handlers/askingReplyRequestReason.js
+++ b/src/handlers/askingReplyRequestReason.js
@@ -1,11 +1,15 @@
 import gql from '../gql';
-import { createPostbackAction, getArticleURL } from './utils';
+import {
+  createPostbackAction,
+  getArticleURL,
+  REASON_PLACEHOLDER,
+} from './utils';
 
 export default async function askingArticleSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
   const { selectedArticleId } = data;
 
-  if (event.input !== 'n') {
+  if (event.input !== 'n' && event.input !== REASON_PLACEHOLDER) {
     const reason = event.input;
 
     const text =
@@ -13,6 +17,18 @@ export default async function askingArticleSubmission(params) {
       '我們即將把您填寫的理由送至資料庫。' +
       '若您送出的訊息或理由意味不明、造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。' +
       '若要確認請輸入「y」、若不想填寫請輸入「n」、若要重新填寫理由請輸入「r」';
+
+    const {
+      data: { GetArticle },
+    } = await gql`
+      query($id: String!) {
+        GetArticle(id: $id) {
+          text
+        }
+      }
+    `({
+      id: data.selectedArticleId,
+    });
 
     replies = [
       {
@@ -35,6 +51,22 @@ export default async function askingArticleSubmission(params) {
                 weight: 'bold',
                 color: '#1DB446',
                 size: 'sm',
+              },
+              {
+                type: 'separator',
+                margin: 'xxl',
+              },
+              {
+                type: 'text',
+                text: '您之前傳送的訊息',
+                weight: 'bold',
+                size: 'xl',
+                margin: 'xl',
+              },
+              {
+                type: 'text',
+                text: GetArticle.text,
+                size: 'xs',
               },
               {
                 type: 'separator',

--- a/src/handlers/askingReplyRequestReason.js
+++ b/src/handlers/askingReplyRequestReason.js
@@ -10,7 +10,7 @@ export default async function askingArticleSubmission(params) {
 
     const text =
       `以下是您所填寫的理由：\n「\n${reason}\n」\n` +
-      '我們即將把此訊息與您填寫的理由送至資料庫。' +
+      '我們即將把您填寫的理由送至資料庫。' +
       '若您送出的訊息或理由意味不明、造成闢謠編輯的困擾，可能會影響到您未來送出文章的權利。' +
       '若要確認請輸入「y」、若不想填寫請輸入「n」、若要重新填寫理由請輸入「r」';
 
@@ -35,10 +35,6 @@ export default async function askingArticleSubmission(params) {
                 weight: 'bold',
                 color: '#1DB446',
                 size: 'sm',
-              },
-              {
-                type: 'separator',
-                margin: 'xxl',
               },
               {
                 type: 'separator',
@@ -72,7 +68,7 @@ export default async function askingArticleSubmission(params) {
                 type: 'button',
                 margin: 'xl',
                 style: 'primary',
-                action: createPostbackAction('我不想填理由', 'n', issuedAt),
+                action: createPostbackAction('我不想填了', 'n', issuedAt),
               },
               {
                 type: 'button',

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -6,6 +6,7 @@ import {
   isNonsenseText,
   getArticleURL,
   createAskArticleSubmissionReply,
+  REASON_PLACEHOLDER,
 } from './utils';
 import ga from '../ga';
 
@@ -262,7 +263,7 @@ export default async function choosingArticle(params) {
               contents: [
                 {
                   type: 'button',
-                  action: createPostbackAction('放棄送出', 'n', issuedAt),
+                  action: createPostbackAction('我不想填理由', 'n', issuedAt),
                 },
                 {
                   type: 'button',
@@ -270,7 +271,7 @@ export default async function choosingArticle(params) {
                   action: {
                     type: 'uri',
                     label: '⌨️ 傳理由給我們',
-                    uri: `line://oaMessage/@${accountName}/?因為⋯⋯`,
+                    uri: `line://oaMessage/@${accountName}/?${REASON_PLACEHOLDER}`,
                   },
                 },
               ],

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -191,28 +191,90 @@ export default async function choosingArticle(params) {
 
       // Track not yet reply Articles.
       ga(userId, { ec: 'Article', ea: 'NoReply', el: selectedArticleId });
-
       const text =
         '【跟編輯說您的疑惑】\n' +
         '抱歉這篇訊息還沒有人回應過唷！\n' +
         '\n' +
         '若您覺得這是一則謠言，請指出您有疑惑之處，說服編輯這是一份應該被闢謠的訊息。\n' +
         '\n' +
-        '請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處；\n' +
-        '若想跳過，請按「我不想填理由」按鈕。';
+        '請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您的疑惑；\n' +
+        '若想跳過，請輸入「n」。';
+      let accountName = process.env.LINE_AT_NAME || 'cofacts';
 
       replies = [
         {
-          type: 'text',
-          text,
-        },
-        {
-          type: 'template',
-          altText: '若要放棄請輸入「n」。',
-          template: {
-            type: 'buttons',
-            text: '若要放棄，請按「我不想填理由」。',
-            actions: [createPostbackAction('我不想填理由', 'n', issuedAt)],
+          type: 'flex',
+          altText: text,
+          contents: {
+            type: 'bubble',
+            header: {
+              type: 'box',
+              layout: 'horizontal',
+              contents: [
+                {
+                  type: 'text',
+                  text: '跟編輯說您的疑惑',
+                  weight: 'bold',
+                  color: '#009900',
+                  size: 'sm',
+                },
+              ],
+            },
+            body: {
+              type: 'box',
+              layout: 'vertical',
+              spacing: 'md',
+              contents: [
+                {
+                  type: 'text',
+                  text: '抱歉這篇訊息還沒有人回應過唷！',
+                  wrap: true,
+                  size: 'xxs',
+                },
+                {
+                  type: 'text',
+                  text:
+                    '若您覺得這是一則謠言，請指出您有疑惑之處，說服編輯這是一份應該被闢謠的訊息，幫助闢謠編輯釐清您有疑惑之處。',
+                  wrap: true,
+                  size: 'xxs',
+                },
+                {
+                  type: 'text',
+                  text: '請打字告訴我們：',
+                  weight: 'bold',
+                  wrap: true,
+                  color: '#990000',
+                  size: 'md',
+                },
+                {
+                  type: 'text',
+                  text: '為何您會覺得這是一則謠言？',
+                  weight: 'bold',
+                  color: '#ff0000',
+                  wrap: true,
+                  size: 'xxl',
+                },
+              ],
+            },
+            footer: {
+              type: 'box',
+              layout: 'vertical',
+              contents: [
+                {
+                  type: 'button',
+                  action: createPostbackAction('放棄送出', 'n', issuedAt),
+                },
+                {
+                  type: 'button',
+                  style: 'primary',
+                  action: {
+                    type: 'uri',
+                    label: '⌨️ 傳理由給我們',
+                    uri: `line://oaMessage/@${accountName}/?因為⋯⋯`,
+                  },
+                },
+              ],
+            },
           },
         },
       ];

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -200,7 +200,7 @@ export default async function choosingArticle(params) {
         '\n' +
         '請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您的疑惑；\n' +
         '若想跳過，請輸入「n」。';
-      let accountName = process.env.LINE_AT_NAME || 'cofacts';
+      const accountId = process.env.LINE_AT_ID || 'cofacts';
 
       replies = [
         {
@@ -271,7 +271,7 @@ export default async function choosingArticle(params) {
                   action: {
                     type: 'uri',
                     label: '⌨️ 傳理由給我們',
-                    uri: `line://oaMessage/@${accountName}/?${REASON_PLACEHOLDER}`,
+                    uri: `line://oaMessage/@${accountId}/?${REASON_PLACEHOLDER}`,
                   },
                 },
               ],

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -52,6 +52,11 @@ export function createReferenceWords({ reference, type }) {
 }
 
 /**
+ * prefilled text for reasons
+ */
+export const REASON_PLACEHOLDER = '因為⋯⋯';
+
+/**
  * @param {number} issuedAt The "issuedAt" to put in postback action
  * @returns {array} an array of reply message instances
  */
@@ -137,7 +142,7 @@ export function createAskArticleSubmissionReply(issuedAt) {
               action: {
                 type: 'uri',
                 label: '⌨️ 傳理由給我們',
-                uri: `line://oaMessage/@${accountName}/?因為⋯⋯`,
+                uri: `line://oaMessage/@${accountName}/?${REASON_PLACEHOLDER}`,
               },
             },
           ],

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -62,20 +62,86 @@ export function createAskArticleSubmissionReply(issuedAt) {
     '\n' +
     '雖然您不會立刻收到查證結果，但可以幫助到未來同樣收到這份訊息的人。\n' +
     '\n' +
-    '請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。';
+    '請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。' +
+    '\n' +
+    '若想放棄，請輸入「n」。';
+  let accountName = process.env.LINE_AT_NAME || 'cofacts';
 
   return [
     {
-      type: 'text',
-      text,
-    },
-    {
-      type: 'template',
-      altText: '若要放棄請輸入「n」。',
-      template: {
-        type: 'buttons',
-        text: '若要放棄，請按「放棄送出」。',
-        actions: [createPostbackAction('放棄送出', 'n', issuedAt)],
+      type: 'flex',
+      altText: text,
+      contents: {
+        type: 'bubble',
+        header: {
+          type: 'box',
+          layout: 'horizontal',
+          contents: [
+            {
+              type: 'text',
+              text: '送出訊息到公開資料庫？',
+              weight: 'bold',
+              color: '#009900',
+              size: 'sm',
+            },
+          ],
+        },
+        body: {
+          type: 'box',
+          layout: 'vertical',
+          spacing: 'md',
+          contents: [
+            {
+              type: 'text',
+              text:
+                '若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。',
+              wrap: true,
+              size: 'xxs',
+            },
+            {
+              type: 'text',
+              text:
+                '雖然您不會立刻收到查證結果，但可以幫助到未來同樣收到這份訊息的人。',
+              wrap: true,
+              size: 'xxs',
+            },
+            {
+              type: 'text',
+              text: '請打字告訴我們：',
+              weight: 'bold',
+              wrap: true,
+              color: '#990000',
+              size: 'md',
+            },
+            {
+              type: 'text',
+              text: '為何您會覺得這是一則謠言？',
+              weight: 'bold',
+              color: '#ff0000',
+              wrap: true,
+              size: 'xxl',
+            },
+          ],
+        },
+        footer: {
+          type: 'box',
+          layout: 'vertical',
+          contents: [
+            {
+              type: 'button',
+              action: createPostbackAction('放棄送出', 'n', issuedAt),
+            },
+            {
+              type: 'button',
+              style: 'primary',
+              action: {
+                type: 'uri',
+                label: '⌨️ 傳理由給我們',
+                uri: `line://oaMessage/@${accountName}/?因為⋯⋯`,
+              },
+            },
+          ],
+        },
       },
     },
   ];

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -70,7 +70,7 @@ export function createAskArticleSubmissionReply(issuedAt) {
     '請按左下角「⌨️」鈕，把「為何您會覺得這是一則謠言」的理由傳給我們，幫助闢謠編輯釐清您有疑惑之處。' +
     '\n' +
     '若想放棄，請輸入「n」。';
-  let accountName = process.env.LINE_AT_NAME || 'cofacts';
+  const accountName = process.env.LINE_AT_ID || 'cofacts';
 
   return [
     {


### PR DESCRIPTION
Fix #89.

Using flex messages when
* in state ASKING_ARTICLE_SUBMISSION_REASON.
* no one has replied to a certain article yet (state CHOOSING_ARTICLE).

Since we have a pre-filled reason `因為⋯⋯`, I ask a user to resubmit his reason if he submit this directly. Also, this phrase is now used in many different places, so I made it a constant in `utils.js`.