### PR TITLE
Add dockerfile so that it is possible to dockerize line bot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!src/*
+!build/*
+!package.json
+!package-lock.json
+!main.js

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,33 @@
+# From LINE developer console
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_TOKEN=
+LINE_AT_ID=
+
+# Redis stores chatbot's conversation context among HTTP requests
+REDIS_URL=redis://localhost:6379
+
+# Chatbot server
+PORT=5001
+
+# Rollbar error logging
+ROLLBAR_ENV=localhost
+ROLLBAR_TOKEN=
+
+# This should match rumors-api's RUMORS_LINE_BOT_SECRET
+APP_SECRET=CHANGE_ME
+
+# Cofacst API URL
+API_URL=https://cofacts-api.hacktabl.org/graphql
+
+# Cofacts web page URL base
+SITE_URL=https://cofacts.hacktabl.org
+
+# Google drive
+GOOGLE_CREDENTIALS=
+GOOGLE_DRIVE_IMAGE_FOLDER=
+
+# Google analytics ID
+GA_ID=
+
+# Block certain users by ID
+USERID_BLACKLIST=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:carbon
+WORKDIR /srv/www
+
+# make node_modules cached.
+# Src: https://nodesource.com/blog/8-protips-to-start-killing-it-when-dockerizing-node-js/
+#
+COPY package.json package-lock.json ./
+
+# When running with --production --pure-lockfile,
+# There will always be some missing modules. Dunno why...
+#
+RUN npm install --production
+
+# Other files, so that other files do not interfere with node_modules cache
+#
+COPY . .
+
+EXPOSE 5001
+
+ENTRYPOINT NODE_ENV=production node build/index

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please follow all the steps in [LINE official tutorial](https://developers.line.
 
 First, install heroku toolbelt.
 
-Create .env file, copy the template below and `LINE_CHANNEL_SECRET`, `LINE_CHANNEL_TOKEN` inside.
+Create .env file from `.env.sample` template, at least fill in:
 ```
 API_URL=https://cofacts-api.g0v.tw/graphql
 LINE_CHANNEL_SECRET=<paste LINE@'s channel secret here>

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ With Heroku toolbelt installed, just do this:
 $ heroku local
 ```
 
-and the server will be started on `localhost:5000`. (Or the `PORT` you specified in your `.env` file.)
+and the server will be started on `localhost:5001`. (Or the `PORT` you specified in your `.env` file.)
 
 ### Get LINE messages to your local machine
 
 We recommend [using `ngrok`](https://medium.com/@Oskarr3/developing-messenger-bot-with-ngrok-5d23208ed7c8#.csc8rum8s) to create a public address that directs the traffic from LINE server to your local machine. With `ngrok` in your path, just
 
 ```
-$ ngrok http 5000
+$ ngrok http 5001
 ```
 
 `ngrok` will give you a public URL. Use this to set the webhook URL of your Channel (See the section "Channel Console" in [LINE official tutorial](https://developers.line.me/messaging-api/getting-started)).


### PR DESCRIPTION
Although in production environment we still deploy line bot to Heroku, adding a Dockerfile would be helpful for those who want to have a whole set of Cofacts on their laptop.

Note that in this PR we changed the default port to `5001`. This is to avoid collision with API server in `rumors-deploy`'s [`docker-compose.sample.yml`](https://github.com/cofacts/rumors-deploy/blob/master/docker-compose.sample.yml#L43).