### PR TITLE
Properly encode characters in line://oaMessage URL schemes

### DIFF
--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -80,7 +80,7 @@ Object {
               "action": Object {
                 "label": "⌨️ 傳理由給我們",
                 "type": "uri",
-                "uri": "line://oaMessage/@cofacts/?因為⋯⋯",
+                "uri": "line://oaMessage/@cofacts/?%E5%9B%A0%E7%82%BA%E2%8B%AF%E2%8B%AF",
               },
               "style": "primary",
               "type": "button",
@@ -661,7 +661,7 @@ Object {
               "action": Object {
                 "label": "⌨️ 傳理由給我們",
                 "type": "uri",
-                "uri": "line://oaMessage/@cofacts/?因為⋯⋯",
+                "uri": "line://oaMessage/@cofacts/?%E5%9B%A0%E7%82%BA%E2%8B%AF%E2%8B%AF",
               },
               "style": "primary",
               "type": "button",

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -246,7 +246,7 @@ Object {
               "action": Object {
                 "label": "⌨️ 傳理由給我們",
                 "type": "uri",
-                "uri": "line://oaMessage/@cofacts/?因為⋯⋯",
+                "uri": "line://oaMessage/@cofacts/?%E5%9B%A0%E7%82%BA%E2%8B%AF%E2%8B%AF",
               },
               "style": "primary",
               "type": "button",

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -287,7 +287,9 @@ export default async function choosingArticle(params) {
                   action: {
                     type: 'uri',
                     label: '⌨️ 傳理由給我們',
-                    uri: `line://oaMessage/@${accountId}/?${encodeURIComponent(REASON_PLACEHOLDER)}`,
+                    uri: `line://oaMessage/@${accountId}/?${encodeURIComponent(
+                      REASON_PLACEHOLDER
+                    )}`,
                   },
                 },
               ],

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -287,7 +287,7 @@ export default async function choosingArticle(params) {
                   action: {
                     type: 'uri',
                     label: '⌨️ 傳理由給我們',
-                    uri: `line://oaMessage/@${accountId}/?${REASON_PLACEHOLDER}`,
+                    uri: `line://oaMessage/@${accountId}/?${encodeURIComponent(REASON_PLACEHOLDER)}`,
                   },
                 },
               ],

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -152,7 +152,7 @@ export function createAskArticleSubmissionReply(issuedAt) {
               action: {
                 type: 'uri',
                 label: '⌨️ 傳理由給我們',
-                uri: `line://oaMessage/@${accountName}/?${REASON_PLACEHOLDER}`,
+                uri: `line://oaMessage/@${accountName}/?${encodeURIComponent(REASON_PLACEHOLDER)}`,
               },
             },
           ],

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -152,7 +152,9 @@ export function createAskArticleSubmissionReply(issuedAt) {
               action: {
                 type: 'uri',
                 label: '⌨️ 傳理由給我們',
-                uri: `line://oaMessage/@${accountName}/?${encodeURIComponent(REASON_PLACEHOLDER)}`,
+                uri: `line://oaMessage/@${accountName}/?${encodeURIComponent(
+                  REASON_PLACEHOLDER
+                )}`,
               },
             },
           ],


### PR DESCRIPTION
As title.

The URL encoding seems not affecting the `input === REASON_PLACEHOLDER` detection:

![screenshot_20181016-133038](https://user-images.githubusercontent.com/108608/46994852-bb002700-d148-11e8-9a0b-01feecef1fa9.png)


Fixes #105 