### PR TITLE
Avoid submitting "none" when there is no comment for articleReplyFeedback

### DIFF
--- a/src/handlers/askingNotUsefulFeedback.js
+++ b/src/handlers/askingNotUsefulFeedback.js
@@ -14,14 +14,8 @@ export default async function askingNotUsefulFeedback(params) {
         action: { feedbackCount },
       },
     } = await gql`
-      mutation(
-        $comment: String
-        $vote: FeedbackVote!
-        $articleId: String!
-        $replyId: String!
-      ) {
+      mutation($vote: FeedbackVote!, $articleId: String!, $replyId: String!) {
         action: CreateOrUpdateArticleReplyFeedback(
-          comment: $comment
           articleId: $articleId
           replyId: $replyId
           vote: $vote
@@ -33,7 +27,6 @@ export default async function askingNotUsefulFeedback(params) {
       {
         articleId: data.selectedArticleId,
         replyId: data.selectedReplyId,
-        comment: '',
         vote: 'DOWNVOTE',
       },
       { userId }

--- a/src/handlers/askingNotUsefulFeedback.js
+++ b/src/handlers/askingNotUsefulFeedback.js
@@ -15,7 +15,7 @@ export default async function askingNotUsefulFeedback(params) {
       },
     } = await gql`
       mutation(
-        $comment: String!
+        $comment: String
         $vote: FeedbackVote!
         $articleId: String!
         $replyId: String!
@@ -33,7 +33,7 @@ export default async function askingNotUsefulFeedback(params) {
       {
         articleId: data.selectedArticleId,
         replyId: data.selectedReplyId,
-        comment: 'none',
+        comment: '',
         vote: 'DOWNVOTE',
       },
       { userId }

--- a/src/handlers/askingNotUsefulFeedbackSubmission.js
+++ b/src/handlers/askingNotUsefulFeedbackSubmission.js
@@ -33,7 +33,7 @@ export default async function askingNotUsefulFeedbackSubmission(params) {
       {
         articleId: data.selectedArticleId,
         replyId: data.selectedReplyId,
-        comment: event.input === 'n' ? 'none' : data.comment,
+        comment: event.input === 'n' ? '' : data.comment,
         vote: 'DOWNVOTE',
       },
       { userId }

--- a/src/handlers/askingNotUsefulFeedbackSubmission.js
+++ b/src/handlers/askingNotUsefulFeedbackSubmission.js
@@ -15,7 +15,7 @@ export default async function askingNotUsefulFeedbackSubmission(params) {
       },
     } = await gql`
       mutation(
-        $comment: String!
+        $comment: String
         $vote: FeedbackVote!
         $articleId: String!
         $replyId: String!


### PR DESCRIPTION
I am seeing that there are "none" being submitted as article reply feedback.

This PR removes the "none" string so that empty feedback remains empty.
