### PR TITLE
LIFF now checks if button is outdated

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,3 +33,4 @@ USERID_BLACKLIST=
 
 # LIFF URL for reason input
 LIFF_URL=line://app/1631030389-xb5mnDdN
+LIFF_CORS_ORIGIN=https://cofacts.github.io

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ config/local-*
 client_secret.json
 
 *.log
+
+liff/*.build.html

--- a/build-liff.sh
+++ b/build-liff.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This file replaces liff/index.html's endpoint to staging & production LINE bot servers
+
+sed 's/rumor-line-bot.ngrok.io/rumors-line-bot-staging.herokuapp.com/g' <liff/index.html >liff/staging.build.html
+sed 's/rumor-line-bot.ngrok.io/rumors-line-bot.herokuapp.com/g' <liff/index.html >liff/production.build.html

--- a/liff/index.html
+++ b/liff/index.html
@@ -115,7 +115,7 @@
         toggleForm(true);
         fetch(`https://rumor-line-bot.ngrok.io/context/${userId}`).then(resp => resp.json()).then(data => {
           if(!data || data.state !== state || data.issuedAt.toString() !== issuedAt ) {
-            alert('這個按鈕已經失效囉！');
+            alert('因為您傳了新的訊息進來，所以這顆舊按鈕已經不會動囉！');
             liff.closeWindow();
           }
         }).catch(alert)

--- a/liff/index.html
+++ b/liff/index.html
@@ -65,6 +65,7 @@
       const text = searchParams.get('text');
       const state = searchParams.get('state');
       const prefix = searchParams.get('prefix');
+      const issuedAt = searchParams.get('issuedAt');
 
       // Insert prompt
       const $prompt = document.querySelector('#prompt');
@@ -95,8 +96,14 @@
         }).catch(handleError);
       });
 
-      liff.init(() => {
+      liff.init(({context: {userId}}) => {
         toggleForm(true);
+        fetch(`https://rumor-line-bot.ngrok.io/context/${userId}`).then(resp => resp.json()).then(data => {
+          if(!data || data.state !== state || data.issuedAt.toString() !== issuedAt ) {
+            alert('這個按鈕已經失效囉！');
+            liff.closeWindow();
+          }
+        }).catch(alert)
       }, handleError);
 
       function handleError(err) {

--- a/liff/index.html
+++ b/liff/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <title>送出新文章</title>
+  <title>傳訊息給 Cofacts</title>
   <style>
     * {
       box-sizing: border-box;
@@ -115,7 +115,7 @@
         toggleForm(true);
         fetch(`https://rumor-line-bot.ngrok.io/context/${userId}`).then(resp => resp.json()).then(data => {
           if(!data || data.state !== state || data.issuedAt.toString() !== issuedAt ) {
-            alert('因為您傳了新的訊息進來，所以這顆舊按鈕已經不會動囉！');
+            alert('這個按鈕已經失效囉！');
             liff.closeWindow();
           }
         }).catch(alert)

--- a/liff/index.html
+++ b/liff/index.html
@@ -30,6 +30,13 @@
       width: 100%;
       flex: 1;
     }
+    #prompt {
+      margin: 0 0 8px;
+    }
+    #reason-label {
+      color: firebrick;
+      font-weight: bold;
+    }
     .submit {
       height: 44px;
       width: 100%;
@@ -51,7 +58,8 @@
   <aside id="errors"></aside>
 
   <form class="form" id="form">
-    <label for="reason" id="prompt"></label>
+    <p id="prompt"></p>
+    <label for="reason" id="reason-label"></label>
     <textarea class="reason" name="reason" placeholder="請在這裡輸入文字" required></textarea>
     <div class="buttons">
       <button class="submit" type="submit">確定送出</button>
@@ -69,15 +77,22 @@
 
       // Insert prompt
       const $prompt = document.querySelector('#prompt');
+      const $reasonLabel = document.querySelector('#reason-label');
+      const $textarea = document.querySelector('.reason');
       switch(state){
         case 'ASKING_ARTICLE_SUBMISSION_REASON':
-          $prompt.innerText = `您即將把「${text}」送入公開資料庫建檔。請主動查證並且在這裡輸入你查到的初步結果，就能對查證有幫助。`;
+          $prompt.innerText = `您即將把「${text}」送入公開資料庫建檔。為了協助查證，請告訴闢謠編輯：`;
+          $reasonLabel.innerText = '為何您覺得這是謠言？';
+          $textarea.placeholder = '例：我用 OO 關鍵字查詢 Facebook，發現⋯⋯ / 我在 XX 官網上找到不一樣的說法如下⋯⋯'
           break;
         case 'ASKING_REPLY_REQUEST_REASON':
-          $prompt.innerText = `有人跟你一樣對「${text}」有疑問，請提供更多資訊，分享你的初步查證結果。`;
+          $prompt.innerText = `有人跟你一樣對「${text}」有疑問。為了協助查證，請告訴闢謠編輯：`;
+          $reasonLabel.innerText = '為何您覺得這是謠言？';
+          $textarea.placeholder = '例：我用 OO 關鍵字查詢 Facebook，發現⋯⋯ / 我在 XX 官網上找到不一樣的說法如下⋯⋯'
           break;
         case 'ASKING_REPLY_FEEDBACK':
-          $prompt.innerText = `請問您覺得「${text} 」的回應應該怎麼改會更有幫助呢？`;
+          $prompt.innerText = `很遺憾您覺得「${text} 」這則回應沒有幫助。`;
+          $reasonLabel.innerText = '請問您覺得怎麼改才會更有幫助呢？'
           break;
         default:
           $prompt.innerText = '請提供理由：';

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,14 @@
         }
       }
     },
+    "@koa/cors": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-2.2.3.tgz",
+      "integrity": "sha512-tCVVXa39ETsit5kGBtEWWimjLn1sDaeu8+0phgb8kT3GmBDZOykkI3ZO8nMjV2p3MGkJI4K5P+bxR8Ztq0bwsA==",
+      "requires": {
+        "vary": "1.1.2"
+      }
+    },
     "@line/bot-sdk": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/cofacts/rumors-line-bot#readme",
   "dependencies": {
+    "@koa/cors": "^2.2.3",
     "@line/bot-sdk": "^6.0.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postinstall": "babel src -d build",
     "lint:fix": "eslint --fix .",
     "lint": "eslint .",
+    "preliff": "bash build-liff.sh",
     "liff": "gh-pages -d liff"
   },
   "repository": {

--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -53,7 +53,7 @@ Object {
               "action": Object {
                 "label": "🆕 我要送出訊息",
                 "type": "uri",
-                "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=%E9%80%99%E4%B8%80%E7%AF%87%E6%96%87%E7%AB%A0%E7%A2%BA%E5%AF%A6%E6%98%AF%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E6%9F%A5%E5%88%B0%E7%9A%84%E6%98%AF%EF%BC%9A%0A&cancel=%E2%9C%96%EF%B8%8F%20%E6%88%91%E6%94%BE%E6%A3%84%E9%80%81%E5%87%BA",
+                "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=%E9%80%99%E4%B8%80%E7%AF%87%E6%96%87%E7%AB%A0%E7%A2%BA%E5%AF%A6%E6%98%AF%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1511633232970",
               },
               "style": "primary",
               "type": "button",
@@ -609,7 +609,7 @@ Object {
               "action": Object {
                 "label": "🙋 我也想知道",
                 "type": "uri",
-                "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_REPLY_REQUEST_REASON&text=%E8%80%81%E5%8F%B8%E6%A9%9F%E8%BB%8A%E8%A3%A1%E7%B8%BD%E5%82%99%E4%B8%80%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E6%9F%A5%E5%88%B0%E7%9A%84%E6%98%AF%EF%BC%9A%0A&cancel=%E2%9C%96%EF%B8%8F%20%E6%88%91%E6%94%BE%E6%A3%84%E9%80%81%E5%87%BA",
+                "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_REPLY_REQUEST_REASON&text=%E8%80%81%E5%8F%B8%E6%A9%9F%E8%BB%8A%E8%A3%A1%E7%B8%BD%E5%82%99%E4%B8%80%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1511702208730",
               },
               "style": "primary",
               "type": "button",

--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -33,7 +33,13 @@ Object {
         "body": Object {
           "contents": Array [
             Object {
-              "text": "若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。",
+              "text": "目前資料庫裡沒有您傳的訊息。若這是「轉傳訊息」，而且您覺得它很可能是一則「謠言」，",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "color": "#009900",
+              "text": "請按「🆕 送進公開資料庫」，公開這則訊息、讓好心人查證與回覆。",
               "type": "text",
               "wrap": true,
             },
@@ -51,7 +57,7 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "label": "🆕 我要送出訊息",
+                "label": "🆕 送進公開資料庫",
                 "type": "uri",
                 "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=%E9%80%99%E4%B8%80%E7%AF%87%E6%96%87%E7%AB%A0%E7%A2%BA%E5%AF%A6%E6%98%AF%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1511633232970",
               },
@@ -66,8 +72,7 @@ Object {
           "contents": Array [
             Object {
               "color": "#009900",
-              "size": "sm",
-              "text": "送出訊息到公開資料庫？",
+              "text": "🥇 成為全球首位回報此訊息的人",
               "type": "text",
               "weight": "bold",
             },

--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -80,6 +80,11 @@ Object {
           "layout": "horizontal",
           "type": "box",
         },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
       },
       "type": "flex",

--- a/src/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
@@ -89,7 +89,7 @@ Object {
           Object {
             "label": "否",
             "type": "uri",
-            "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_REPLY_FEEDBACK&text=%E9%80%99%E6%98%AF%E5%95%86%E6%A5%AD%E6%B4%BB%E5%8B%95%E5%BB%A3%E5%91%8A%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%A1%20%E6%88%91%E8%A6%BA%E5%BE%97%E5%9B%9E%E6%87%89%E6%B2%92%E6%9C%89%E5%B9%AB%E5%8A%A9%EF%BC%8C%E5%8F%AF%E4%BB%A5%E9%80%99%E6%A8%A3%E6%94%B9%E9%80%B2%EF%BC%9A%0A&cancel=%E2%9C%96%EF%B8%8F%20%E6%88%91%E6%94%BE%E6%A3%84%E9%80%81%E5%87%BA",
+            "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_REPLY_FEEDBACK&text=%E9%80%99%E6%98%AF%E5%95%86%E6%A5%AD%E6%B4%BB%E5%8B%95%E5%BB%A3%E5%91%8A%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%A1%20%E6%88%91%E8%A6%BA%E5%BE%97%E5%9B%9E%E6%87%89%E6%B2%92%E6%9C%89%E5%B9%AB%E5%8A%A9%EF%BC%8C%E5%8F%AF%E4%BB%A5%E9%80%99%E6%A8%A3%E6%94%B9%E9%80%B2%EF%BC%9A%0A&issuedAt=1518964688672",
           },
         ],
         "text": "請問上面回應是否有幫助？",

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -199,7 +199,13 @@ Object {
         "body": Object {
           "contents": Array [
             Object {
-              "text": "若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。",
+              "text": "目前資料庫裡沒有您傳的訊息。若這是「轉傳訊息」，而且您覺得它很可能是一則「謠言」，",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "color": "#009900",
+              "text": "請按「🆕 送進公開資料庫」，公開這則訊息、讓好心人查證與回覆。",
               "type": "text",
               "wrap": true,
             },
@@ -217,7 +223,7 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "label": "🆕 我要送出訊息",
+                "label": "🆕 送進公開資料庫",
                 "type": "uri",
                 "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=YouTube%20%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1497994017447",
               },
@@ -232,8 +238,7 @@ Object {
           "contents": Array [
             Object {
               "color": "#009900",
-              "size": "sm",
-              "text": "送出訊息到公開資料庫？",
+              "text": "🥇 成為全球首位回報此訊息的人",
               "type": "text",
               "weight": "bold",
             },

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -246,6 +246,11 @@ Object {
           "layout": "horizontal",
           "type": "box",
         },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
       },
       "type": "flex",

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -219,7 +219,7 @@ Object {
               "action": Object {
                 "label": "🆕 我要送出訊息",
                 "type": "uri",
-                "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=YouTube%20%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E6%9F%A5%E5%88%B0%E7%9A%84%E6%98%AF%EF%BC%9A%0A&cancel=%E2%9C%96%EF%B8%8F%20%E6%88%91%E6%94%BE%E6%A3%84%E9%80%81%E5%87%BA",
+                "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=YouTube%20%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1497994017447",
               },
               "style": "primary",
               "type": "button",

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -71,7 +71,8 @@ export default async function choosingArticle(params) {
     replies = createAskArticleSubmissionReply(
       'ASKING_ARTICLE_SUBMISSION_REASON',
       ellipsis(data.searchedText, 10),
-      REASON_PREFIX
+      REASON_PREFIX,
+      issuedAt
     );
 
     state = 'ASKING_ARTICLE_SUBMISSION_REASON';
@@ -274,7 +275,8 @@ export default async function choosingArticle(params) {
                     uri: getLIFFURL(
                       'ASKING_REPLY_REQUEST_REASON',
                       ellipsis(data.searchedText, 10),
-                      REASON_PREFIX
+                      REASON_PREFIX,
+                      issuedAt
                     ),
                   },
                 },

--- a/src/handlers/choosingReply.js
+++ b/src/handlers/choosingReply.js
@@ -78,7 +78,8 @@ export default async function choosingReply(params) {
               uri: getLIFFURL(
                 'ASKING_REPLY_FEEDBACK',
                 ellipsis(GetReply.text, 10),
-                DOWNVOTE_PREFIX
+                DOWNVOTE_PREFIX,
+                issuedAt
               ),
             },
           ],

--- a/src/handlers/initState.js
+++ b/src/handlers/initState.js
@@ -174,7 +174,8 @@ export default async function initState(params) {
         createAskArticleSubmissionReply(
           'ASKING_ARTICLE_SUBMISSION_REASON',
           ellipsis(articleSummary, 10),
-          REASON_PREFIX
+          REASON_PREFIX,
+          issuedAt
         )
       );
       state = 'ASKING_ARTICLE_SUBMISSION_REASON';

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -153,6 +153,11 @@ export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
             },
           ],
         },
+        styles: {
+          body: {
+            separator: true,
+          },
+        },
       },
     },
   ];

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -69,21 +69,23 @@ export const DOWNVOTE_PREFIX = '💡 我覺得回應沒有幫助，可以這樣�
  * @param {string} state The current state
  * @param {string} text The prompt text
  * @param {string} prefix The prefix to use in the result text
+ * @param {number} issuedAt The issuedAt that created this URL
  * @returns {string}
  */
-export function getLIFFURL(state, text, prefix) {
+export function getLIFFURL(state, text, prefix, issuedAt) {
   return `${process.env.LIFF_URL}?state=${state}&text=${encodeURIComponent(
     text
-  )}&prefix=${encodeURIComponent(prefix)}`;
+  )}&prefix=${encodeURIComponent(prefix)}&issuedAt=${issuedAt}`;
 }
 
 /**
  * @param {string} state The current state
  * @param {string} text The prompt text
  * @param {string} prefix The prefix to use in the result text
+ * @param {string} issuedAt The current issuedAt
  * @returns {array} an array of reply message instances
  */
-export function createAskArticleSubmissionReply(state, text, prefix) {
+export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
   const altText =
     '【送出訊息到公開資料庫？】\n' +
     '若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。\n' +
@@ -140,7 +142,7 @@ export function createAskArticleSubmissionReply(state, text, prefix) {
               action: {
                 type: 'uri',
                 label: '🆕 我要送出訊息',
-                uri: getLIFFURL(state, text, prefix),
+                uri: getLIFFURL(state, text, prefix, issuedAt),
               },
             },
           ],

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -106,10 +106,9 @@ export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
           contents: [
             {
               type: 'text',
-              text: '送出訊息到公開資料庫？',
+              text: '🥇 成為全球首位回報此訊息的人',
               weight: 'bold',
               color: '#009900',
-              size: 'sm',
             },
           ],
         },
@@ -121,7 +120,14 @@ export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
             {
               type: 'text',
               text:
-                '若這是「轉傳訊息」，而且您覺得這很可能是一則「謠言」，請將這則訊息送進公開資料庫建檔，讓好心人查證與回覆。',
+                '目前資料庫裡沒有您傳的訊息。若這是「轉傳訊息」，而且您覺得它很可能是一則「謠言」，',
+              wrap: true,
+            },
+            {
+              type: 'text',
+              text:
+                '請按「🆕 送進公開資料庫」，公開這則訊息、讓好心人查證與回覆。',
+              color: '#009900',
               wrap: true,
             },
             {
@@ -141,7 +147,7 @@ export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
               style: 'primary',
               action: {
                 type: 'uri',
-                label: '🆕 我要送出訊息',
+                label: '🆕 送進公開資料庫',
                 uri: getLIFFURL(state, text, prefix, issuedAt),
               },
             },

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -62,7 +62,7 @@ export function createReferenceWords({ reference, type }) {
 /**
  * prefilled text for reasons
  */
-export const REASON_PREFIX = '💁 我查到的是：\n';
+export const REASON_PREFIX = '💁 我的理由是：\n';
 export const DOWNVOTE_PREFIX = '💡 我覺得回應沒有幫助，可以這樣改進：\n';
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import Koa from 'koa';
 import Router from 'koa-router';
+import cors from '@koa/cors';
+
 import rollbar from './rollbar';
 import { version } from '../package.json';
 
@@ -26,6 +28,21 @@ app.use(async (ctx, next) => {
 router.get('/', ctx => {
   ctx.body = JSON.stringify({ version });
 });
+
+router.get(
+  '/context/:userId',
+  cors({
+    origin: process.env.LIFF_CORS_ORIGIN,
+  }),
+  async ctx => {
+    const { state, issuedAt } = (await redis.get(ctx.params.userId)) || {};
+
+    ctx.body = {
+      state,
+      issuedAt,
+    };
+  }
+);
 
 const singleUserHandler = async (
   req,


### PR DESCRIPTION
1. Prevent user from using old LIFF buttons.
2. Wording change back to reason, but instruct user to check for themselves

The branch has deployed to staging.

Fixes #117.

## Screenshots - new button pressed

![screenshot_20181223-111152](https://user-images.githubusercontent.com/108608/50380523-c6218700-06a4-11e9-88a1-bd8ebb44a5cf.png)

## Screenshot - old button pressed

The LIFF opens, but after ~1s (API returns) the alert shows up. When the user dismiss the alert box, the LIFF also closes.
![screenshot_20181223-145532](https://user-images.githubusercontent.com/108608/50381485-2f17f780-06c3-11e9-8994-c677d65f79d3.png)

