### PR TITLE
Facilitate share & attract new editor after user created reply request

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,3 +34,6 @@ USERID_BLACKLIST=
 # LIFF URL for reason input
 LIFF_URL=line://app/1631030389-xb5mnDdN
 LIFF_CORS_ORIGIN=https://cofacts.github.io
+
+# Facebook App ID for share dialog
+FACEBOOK_APP_ID=719656818195367

--- a/liff/after-share-fb.html
+++ b/liff/after-share-fb.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>感謝您的分享！</title>
+</head>
+<body>
+  <p>感謝您把新訊息分享給朋友看！</p>
+
+  接下來您可以：
+  <ul>
+    <li>手動關閉這一頁</li>
+    <li>看看其他人都<a href="https://www.facebook.com/hashtag/問臉友">問臉友什麼訊息</a></li>
+  </ul>
+</body>
+</html>

--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -80,6 +80,11 @@ Object {
           "layout": "horizontal",
           "type": "box",
         },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
       },
       "type": "flex",

--- a/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -39,7 +39,7 @@ Object {
             },
             Object {
               "color": "#009900",
-              "text": "請按「🆕 送進公開資料庫」，公開這則訊息、讓好心人查證與回覆。",
+              "text": "請按「🆕 送進資料庫」，公開這則訊息、讓好心人查證與回覆。",
               "type": "text",
               "wrap": true,
             },
@@ -57,7 +57,7 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "label": "🆕 送進公開資料庫",
+                "label": "🆕 送進資料庫",
                 "type": "uri",
                 "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=%E9%80%99%E4%B8%80%E7%AF%87%E6%96%87%E7%AB%A0%E7%A2%BA%E5%AF%A6%E6%98%AF%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1511633232970",
               },

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -205,7 +205,7 @@ Object {
             },
             Object {
               "color": "#009900",
-              "text": "請按「🆕 送進公開資料庫」，公開這則訊息、讓好心人查證與回覆。",
+              "text": "請按「🆕 送進資料庫」，公開這則訊息、讓好心人查證與回覆。",
               "type": "text",
               "wrap": true,
             },
@@ -223,7 +223,7 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "label": "🆕 送進公開資料庫",
+                "label": "🆕 送進資料庫",
                 "type": "uri",
                 "uri": "line://app/1631030389-xb5mnDdN?state=ASKING_ARTICLE_SUBMISSION_REASON&text=YouTube%20%E2%8B%AF%E2%8B%AF&prefix=%F0%9F%92%81%20%E6%88%91%E7%9A%84%E7%90%86%E7%94%B1%E6%98%AF%EF%BC%9A%0A&issuedAt=1497994017447",
               },

--- a/src/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -246,6 +246,11 @@ Object {
           "layout": "horizontal",
           "type": "box",
         },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
       },
       "type": "flex",

--- a/src/handlers/askingArticleSubmissionReason.js
+++ b/src/handlers/askingArticleSubmissionReason.js
@@ -29,12 +29,36 @@ export default async function askingArticleSubmission(params) {
       }
     `({ text: data.searchedText, reason }, { userId });
 
+    const articleUrl = getArticleURL(CreateArticle.id);
+
     replies = [
       {
         type: 'text',
-        text: `您回報的訊息已經被收錄至：${getArticleURL(CreateArticle.id)}`,
+        text: `您回報的訊息已經被收錄至：${articleUrl}`,
       },
-      { type: 'text', text: '感謝您的回報！' },
+      {
+        type: 'template',
+        altText: 'this is a buttons template',
+        template: {
+          type: 'buttons',
+          actions: [
+            {
+              type: 'uri',
+              label: '向 LINE 群組求救',
+              uri: `line://msg/text/?${encodeURIComponent(
+                `我收到這則訊息覺得怪怪的，請幫我看看這是真的還是假的：${articleUrl}`
+              )}`,
+            },
+            {
+              type: 'uri',
+              label: '問問臉書大神',
+              uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&href=${articleUrl}`,
+            },
+          ],
+          title: '🙏 Call out 向朋友求救',
+          text: '來向朋友們請教，這則訊息到底真的假的吧！',
+        },
+      },
     ];
     state = '__INIT__';
   }

--- a/src/handlers/askingArticleSubmissionReason.js
+++ b/src/handlers/askingArticleSubmissionReason.js
@@ -52,11 +52,14 @@ export default async function askingArticleSubmission(params) {
             {
               type: 'uri',
               label: '問問臉書大神',
-              uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&href=${articleUrl}`,
+              uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=${
+                process.env.FACEBOOK_APP_ID
+              }&display=popup&quote=QAQAQ&href=${articleUrl}`,
             },
           ],
           title: '🙏 Call out 向朋友求救',
-          text: '來向朋友們請教，這則訊息到底真的假的吧！',
+          text:
+            '遠親不如近鄰。說不定你的朋友裡，就有能替你解惑的人唷！\n\n來向朋友們請教，這則訊息到底是真是假吧！',
         },
       },
     ];

--- a/src/handlers/askingArticleSubmissionReason.js
+++ b/src/handlers/askingArticleSubmissionReason.js
@@ -1,6 +1,6 @@
 import ga from '../ga';
 import gql from '../gql';
-import { REASON_PREFIX, getArticleURL } from './utils';
+import { REASON_PREFIX, getArticleURL, createArticleShareReply } from './utils';
 
 export default async function askingArticleSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
@@ -36,32 +36,7 @@ export default async function askingArticleSubmission(params) {
         type: 'text',
         text: `您回報的訊息已經被收錄至：${articleUrl}`,
       },
-      {
-        type: 'template',
-        altText: 'this is a buttons template',
-        template: {
-          type: 'buttons',
-          actions: [
-            {
-              type: 'uri',
-              label: '向 LINE 群組求救',
-              uri: `line://msg/text/?${encodeURIComponent(
-                `我收到這則訊息覺得怪怪的，請幫我看看這是真的還是假的：${articleUrl}`
-              )}`,
-            },
-            {
-              type: 'uri',
-              label: '問問臉書大神',
-              uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=${
-                process.env.FACEBOOK_APP_ID
-              }&display=popup&quote=QAQAQ&href=${articleUrl}`,
-            },
-          ],
-          title: '🙏 Call out 向朋友求救',
-          text:
-            '遠親不如近鄰。說不定你的朋友裡，就有能替你解惑的人唷！\n\n來向朋友們請教，這則訊息到底是真是假吧！',
-        },
-      },
+      createArticleShareReply(articleUrl, reason),
     ];
     state = '__INIT__';
   }

--- a/src/handlers/askingReplyRequestReason.js
+++ b/src/handlers/askingReplyRequestReason.js
@@ -1,5 +1,5 @@
 import gql from '../gql';
-import { getArticleURL, REASON_PREFIX } from './utils';
+import { getArticleURL, REASON_PREFIX, createArticleShareReply } from './utils';
 
 export default async function askingArticleSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
@@ -25,15 +25,16 @@ export default async function askingArticleSubmission(params) {
       }
     `({ id: selectedArticleId, reason }, { userId });
 
+    const articleUrl = getArticleURL(selectedArticleId);
+
     replies = [
       {
         type: 'text',
         text: `已經將您的需求記錄下來了，共有 ${
           CreateReplyRequest.replyRequestCount
-        } 人跟您一樣渴望看到針對這篇訊息的回應。若有最新回應，會寫在這個地方：${getArticleURL(
-          selectedArticleId
-        )}`,
+        } 人跟您一樣渴望看到針對這篇訊息的回應。若有最新回應，會寫在這個地方：${articleUrl}`,
       },
+      createArticleShareReply(articleUrl, reason),
     ];
     state = '__INIT__';
   }

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -125,8 +125,7 @@ export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
             },
             {
               type: 'text',
-              text:
-                '請按「🆕 送進公開資料庫」，公開這則訊息、讓好心人查證與回覆。',
+              text: '請按「🆕 送進資料庫」，公開這則訊息、讓好心人查證與回覆。',
               color: '#009900',
               wrap: true,
             },
@@ -147,7 +146,7 @@ export function createAskArticleSubmissionReply(state, text, prefix, issuedAt) {
               style: 'primary',
               action: {
                 type: 'uri',
-                label: '🆕 送進公開資料庫',
+                label: '🆕 送進資料庫',
                 uri: getLIFFURL(state, text, prefix, issuedAt),
               },
             },
@@ -190,4 +189,42 @@ const SITE_URL = process.env.SITE_URL || 'https://cofacts.g0v.tw';
  */
 export function getArticleURL(articleId) {
   return `${SITE_URL}/article/${articleId}`;
+}
+
+/**
+ * @param {string} articleUrl
+ * @param {string} reason
+ * @returns {object} Reply object with sharing buttings
+ */
+export function createArticleShareReply(articleUrl, reason) {
+  return {
+    type: 'template',
+    altText:
+      '遠親不如近鄰🌟問問親友總沒錯。把訊息分享給朋友們，說不定有人能幫你解惑！',
+    template: {
+      type: 'buttons',
+      actions: [
+        {
+          type: 'uri',
+          label: 'LINE 群組',
+          uri: `line://msg/text/?${encodeURIComponent(
+            `我收到這則訊息的想法是：\n${reason}\n\n請幫我看看這是真的還是假的：${articleUrl}`
+          )}`,
+        },
+        {
+          type: 'uri',
+          label: '臉書大神',
+          uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=${
+            process.env.FACEBOOK_APP_ID
+          }&display=popup&quote=${encodeURIComponent(
+            reason
+          )}&hashtag=${encodeURIComponent(
+            '#Cofacts求解惑'
+          )}&href=${encodeURIComponent(articleUrl)}`,
+        },
+      ],
+      title: '遠親不如近鄰🌟問問親友總沒錯',
+      text: '說不定你的朋友裡，就有能替你解惑的人唷！\n你想要 Call-out 誰呢？',
+    },
+  };
 }


### PR DESCRIPTION
After the user submits reason for their new reply request (articles with no reply yet), the user are prompted to share the message to their friends to attract more editors.

Discussions here:
- https://www.facebook.com/groups/cofacts/permalink/2295896103975539/
- https://g0v.hackmd.io/STB6wBxHQimcOH-Kx4728A#%E6%BA%96%E5%82%99%E4%B8%8A%E7%B7%9A%EF%BC%9A-LIFF

## Screenshots

### The share buttons

![screenshot_20181227-013143](https://user-images.githubusercontent.com/108608/50452884-da50d700-0977-11e9-8385-4af5db56b383.png)


### LINE share
Reasons & article link pre-filled.

![screenshot_20181227-013158](https://user-images.githubusercontent.com/108608/50452889-df158b00-0977-11e9-9920-633f9ae1bfd5.png)


### Facebook share
Reason as quote, article link as share target, and a constant hashtag `#Cofacts求闢謠` so that we can get a list of open shares on Facebook in the future.

![screenshot_20181227-013229](https://user-images.githubusercontent.com/108608/50452892-e3da3f00-0977-11e9-9a10-daef7d049ef3.png)
