### PR TITLE
Fixes emoji splitting error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -749,13 +749,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3480,7 +3482,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3498,11 +3501,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3515,15 +3520,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3626,7 +3634,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3636,6 +3645,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3648,17 +3658,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3675,6 +3688,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3747,7 +3761,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3757,6 +3772,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3832,7 +3848,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3862,6 +3879,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3879,6 +3897,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3917,11 +3936,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -4287,6 +4308,11 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "growl": {
       "version": "1.10.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.22.0",
     "googleapis": "^36.0.0",
+    "grapheme-splitter": "^1.0.4",
     "koa": "^2.5.0",
     "koa-router": "^7.4.0",
     "koa-static": "^5.0.0",

--- a/src/ga.js
+++ b/src/ga.js
@@ -1,4 +1,6 @@
 import ua from 'universal-analytics';
+import GraphemeSplitter from 'grapheme-splitter';
+const splitter = new GraphemeSplitter();
 
 // When document title is too long, event will be dropped.
 // See: https://github.com/cofacts/rumors-line-bot/issues/97
@@ -22,7 +24,13 @@ export default function ga(userId, state = 'N/A', documentTitle = '') {
   visitor.screenview(state, 'rumors-line-bot');
 
   if (documentTitle) {
-    visitor.set('dt', documentTitle.slice(0, DOCUMENT_TITLE_LENGTH));
+    visitor.set(
+      'dt',
+      splitter
+        .splitGraphemes(documentTitle)
+        .slice(0, DOCUMENT_TITLE_LENGTH)
+        .join('')
+    );
   }
 
   return visitor;

--- a/src/handlers/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/utils.test.js.snap
@@ -22,3 +22,7 @@ Object {
 exports[`createReferenceWords() should create reference for opinions 1`] = `"不同觀點請見：This is refering to different opinions"`;
 
 exports[`createReferenceWords() should create reference for rumors 1`] = `"出處：This is a reference"`;
+
+exports[`ellipsis() should ellipsis when text is too long 1`] = `"123⋯⋯"`;
+
+exports[`ellipsis() should properly cut emojis 1`] = `"🏳️‍🌈🏳️‍🌈🏳️‍🌈⋯⋯"`;

--- a/src/handlers/__tests__/utils.test.js
+++ b/src/handlers/__tests__/utils.test.js
@@ -3,7 +3,25 @@ import {
   createFeedbackWords,
   isNonsenseText,
   createReferenceWords,
+  ellipsis,
 } from '../utils';
+
+describe('ellipsis()', () => {
+  it('should not ellipsis when text is short', () => {
+    expect(ellipsis('12345', 10)).toBe('12345');
+  });
+
+  it('should ellipsis when text is too long', () => {
+    const limit = 5;
+    const processed = ellipsis('1234567890', limit);
+    expect(processed).toHaveLength(limit);
+    expect(processed).toMatchSnapshot();
+  });
+
+  it('should properly cut emojis', () => {
+    expect(ellipsis('🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈', 5)).toMatchSnapshot();
+  });
+});
 
 describe('createPostbackAction()', () => {
   it('should return postback message body', () => {

--- a/src/handlers/__tests__/utils.test.js
+++ b/src/handlers/__tests__/utils.test.js
@@ -21,6 +21,10 @@ describe('ellipsis()', () => {
   it('should properly cut emojis', () => {
     expect(ellipsis('🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈', 5)).toMatchSnapshot();
   });
+
+  it('should be able to customize ellipsis', () => {
+    expect(ellipsis('1234567890', 5, '')).toBe('12345');
+  });
 });
 
 describe('createPostbackAction()', () => {

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -40,7 +40,7 @@ function createAltText(articleReplies) {
       const prefix = `閱讀請傳 ${idx + 1}> ${createTypeWords(
         reply.type
       )}\n${createFeedbackWords(positiveFeedbackCount, negativeFeedbackCount)}`;
-      const content = reply.text.slice(0, eachLimit - prefix.length);
+      const content = ellipsis(reply.text, eachLimit - prefix.length, '');
       return `${prefix}\n${content}`;
     })
     .join('\n\n');
@@ -190,7 +190,7 @@ export default async function choosingArticle(params) {
                     negativeFeedbackCount
                   ) +
                   '\n' +
-                  reply.text.slice(0, 80),
+                  ellipsis(reply.text, 80, ''),
                 actions: [
                   createPostbackAction('閱讀此回應', idx + 1, issuedAt),
                 ],

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -70,7 +70,7 @@ export default async function choosingArticle(params) {
   } else if (doesNotContainMyArticle) {
     replies = createAskArticleSubmissionReply(
       'ASKING_ARTICLE_SUBMISSION_REASON',
-      ellipsis(data.searchedText, 10),
+      data.searchedText,
       REASON_PREFIX,
       issuedAt
     );
@@ -274,7 +274,7 @@ export default async function choosingArticle(params) {
                     label: '🙋 我也想知道',
                     uri: getLIFFURL(
                       'ASKING_REPLY_REQUEST_REASON',
-                      ellipsis(data.searchedText, 10),
+                      data.searchedText,
                       REASON_PREFIX,
                       issuedAt
                     ),

--- a/src/handlers/choosingReply.js
+++ b/src/handlers/choosingReply.js
@@ -83,7 +83,7 @@ export default async function choosingReply(params) {
               label: '否',
               uri: getLIFFURL(
                 'ASKING_REPLY_FEEDBACK',
-                ellipsis(GetReply.text, 10),
+                GetReply.text,
                 DOWNVOTE_PREFIX,
                 issuedAt
               ),

--- a/src/handlers/initState.js
+++ b/src/handlers/initState.js
@@ -43,9 +43,7 @@ export default async function initState(params) {
     text: event.input,
   });
 
-  const articleSummary = `${event.input.slice(0, 10)}${
-    event.input.length > 10 ? '⋯⋯' : ''
-  }`;
+  const articleSummary = ellipsis(event.input, 12);
 
   if (ListArticles.edges.length) {
     // Track if find similar Articles in DB.
@@ -102,7 +100,7 @@ export default async function initState(params) {
       altText: edgesSortedWithSimilarity
         .map(
           ({ node: { text } }, idx) =>
-            `選擇請打 ${idx + 1}> ${text.slice(0, 20)}`
+            `選擇請打 ${idx + 1}> ${ellipsis(text, 20, '')}`
         )
         .concat(hasIdenticalDocs ? [] : ['若以上皆非，請打 0。'])
         .join('\n\n'),
@@ -111,7 +109,7 @@ export default async function initState(params) {
         columns: edgesSortedWithSimilarity
           .map(({ node: { text }, similarity }, idx) => ({
             text: `[相似度:${(similarity * 100).toFixed(2) +
-              '%'}] \n ${text.slice(0, 100)}`,
+              '%'}] \n ${ellipsis(text, 100, '')}`,
             actions: [createPostbackAction('選擇此則', idx + 1, issuedAt)],
           }))
           .concat(
@@ -173,7 +171,7 @@ export default async function initState(params) {
       ].concat(
         createAskArticleSubmissionReply(
           'ASKING_ARTICLE_SUBMISSION_REASON',
-          ellipsis(articleSummary, 10),
+          articleSummary,
           REASON_PREFIX,
           issuedAt
         )

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -32,7 +32,7 @@ export function createFeedbackWords(positive, negative) {
 export function createFlexMessageText(text = '') {
   // Actually the upper limit is 2000, but 100 should be enough
   // because we only show the first line
-  return text.slice(0, 100);
+  return ellipsis(text, 100, '');
 }
 
 export function createTypeWords(type) {
@@ -170,22 +170,20 @@ export function isNonsenseText(/* text */) {
   return false; // according to 20181017 meeting note, we remove limitation and observe
 }
 
-const ELLIPSIS = '⋯⋯';
-
 /**
  * @param {string} text
  * @param {number} limit
  * @return {string} if the text length is lower than limit, return text; else, return
  *                  text with ellipsis.
  */
-export function ellipsis(text, limit) {
+export function ellipsis(text, limit, ellipsis = '⋯⋯') {
   if (splitter.countGraphemes(text) < limit) return text;
 
   return (
     splitter
       .splitGraphemes(text)
-      .slice(0, limit - ELLIPSIS.length)
-      .join('') + ELLIPSIS
+      .slice(0, limit - ellipsis.length)
+      .join('') + ellipsis
   );
 }
 

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -1,3 +1,6 @@
+import GraphemeSplitter from 'grapheme-splitter';
+const splitter = new GraphemeSplitter();
+
 export function createPostbackAction(label, input, issuedAt) {
   return {
     type: 'postback',
@@ -176,9 +179,14 @@ const ELLIPSIS = '⋯⋯';
  *                  text with ellipsis.
  */
 export function ellipsis(text, limit) {
-  if (text.length < limit) return text;
+  if (splitter.countGraphemes(text) < limit) return text;
 
-  return text.slice(0, limit - ELLIPSIS.length) + ELLIPSIS;
+  return (
+    splitter
+      .splitGraphemes(text)
+      .slice(0, limit - ELLIPSIS.length)
+      .join('') + ELLIPSIS
+  );
 }
 
 const SITE_URL = process.env.SITE_URL || 'https://cofacts.g0v.tw';

--- a/src/handlers/utils.js
+++ b/src/handlers/utils.js
@@ -77,7 +77,7 @@ export const DOWNVOTE_PREFIX = '💡 我覺得回應沒有幫助，可以這樣�
  */
 export function getLIFFURL(state, text, prefix, issuedAt) {
   return `${process.env.LIFF_URL}?state=${state}&text=${encodeURIComponent(
-    text
+    ellipsis(text, 10)
   )}&prefix=${encodeURIComponent(prefix)}&issuedAt=${issuedAt}`;
 }
 


### PR DESCRIPTION
Fixes #129 .

- This PR uses a specific string splitting library that takes unicode surrogate pairs into account.
- Also, we reviewed all use of `string.slice(constantNumber)` and replaces them with `ellipsis()` or anything appropriate.
- Some usage of `ellipsis()` is moved into `getLIFFURL` to avoid code duplication.

## Before (production)
<img width="625" alt="螢幕快照 2019-03-25 上午2 34 58" src="https://user-images.githubusercontent.com/108608/54884014-b6356100-4ea6-11e9-8a0c-c538629aac03.png">

## After (staging)
<img width="616" alt="螢幕快照 2019-03-25 上午2 35 03" src="https://user-images.githubusercontent.com/108608/54884013-b6356100-4ea6-11e9-9cdb-a1aeb128dc3c.png">
