### PR TITLE
Submit ReplyRequest w/o reason input when article exists in DB

### DIFF
--- a/src/__mocks__/gql.js
+++ b/src/__mocks__/gql.js
@@ -29,4 +29,11 @@ gqlMock.__reset = function() {
   mockResultQueue.length = 0;
 };
 
+/**
+ * @returns {Boolean} if the mock response has been depleted
+ */
+gqlMock.__finished = function() {
+  return mockResultQueue.length === 0;
+};
+
 export default gqlMock;

--- a/src/handlers/__fixtures__/askingReplyRequestReason.js
+++ b/src/handlers/__fixtures__/askingReplyRequestReason.js
@@ -1,0 +1,7 @@
+export const createReplyRequestSuccess = {
+  data: {
+    CreateOrUpdateReplyRequest: {
+      replyRequestCount: 1,
+    },
+  },
+};

--- a/src/handlers/__fixtures__/choosingArticle.js
+++ b/src/handlers/__fixtures__/choosingArticle.js
@@ -223,6 +223,6 @@ export const noReplies = {
   },
 };
 
-export const createReplyRequest = {
-  data: { CreateReplyRequest: { replyRequestCount: 2 } },
+export const createOrUpdateReplyRequest = {
+  data: { CreateOrUpdateReplyRequest: { replyRequestCount: 1 } },
 };

--- a/src/handlers/__tests__/__snapshots__/askingReplyRequestReason.test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/askingReplyRequestReason.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`extracts reason and submits replyrequest 1`] = `
+Object {
+  "data": Object {
+    "selectedArticleId": "selected-article-id",
+  },
+  "event": Object {
+    "input": "💁 我的理由是：
+Reason goes here",
+  },
+  "isSkipUser": undefined,
+  "issuedAt": undefined,
+  "replies": Array [
+    Object {
+      "text": "已經將您的需求記錄下來了，共有 1 人跟您一樣渴望看到針對這篇訊息的回應。若有最新回應，會寫在這個地方：https://cofacts.hacktabl.org/article/selected-article-id",
+      "type": "text",
+    },
+    Object {
+      "altText": "遠親不如近鄰🌟問問親友總沒錯。把訊息分享給朋友們，說不定有人能幫你解惑！",
+      "template": Object {
+        "actions": Array [
+          Object {
+            "label": "LINE 群組",
+            "type": "uri",
+            "uri": "line://msg/text/?%E6%88%91%E6%94%B6%E5%88%B0%E9%80%99%E5%89%87%E8%A8%8A%E6%81%AF%E7%9A%84%E6%83%B3%E6%B3%95%E6%98%AF%EF%BC%9A%0AReason%20goes%20here%0A%0A%E8%AB%8B%E5%B9%AB%E6%88%91%E7%9C%8B%E7%9C%8B%E9%80%99%E6%98%AF%E7%9C%9F%E7%9A%84%E9%82%84%E6%98%AF%E5%81%87%E7%9A%84%EF%BC%9Ahttps%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fselected-article-id",
+          },
+          Object {
+            "label": "臉書大神",
+            "type": "uri",
+            "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&quote=Reason%20goes%20here&hashtag=%23Cofacts%E6%B1%82%E8%A7%A3%E6%83%91&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fselected-article-id",
+          },
+        ],
+        "text": "說不定你的朋友裡，就有能替你解惑的人唷！
+你想要 Call-out 誰呢？",
+        "title": "遠親不如近鄰🌟問問親友總沒錯",
+        "type": "buttons",
+      },
+      "type": "template",
+    },
+  ],
+  "state": "__INIT__",
+  "userId": undefined,
+}
+`;
+
+exports[`handles the case when prefix does not match 1`] = `
+Object {
+  "data": Object {
+    "selectedArticleId": "selected-article-id",
+  },
+  "event": Object {
+    "input": "FOO",
+  },
+  "isSkipUser": undefined,
+  "issuedAt": undefined,
+  "replies": Array [
+    Object {
+      "text": "請點擊上面的「我也想知道」，或放棄這則，改轉傳其他訊息。",
+      "type": "text",
+    },
+  ],
+  "state": "ASKING_REPLY_REQUEST_REASON",
+  "userId": undefined,
+}
+`;

--- a/src/handlers/__tests__/askingReplyRequestReason.test.js
+++ b/src/handlers/__tests__/askingReplyRequestReason.test.js
@@ -1,0 +1,34 @@
+jest.mock('../../gql');
+
+import askingReplyRequestReason from '../askingReplyRequestReason';
+import * as apiResult from '../__fixtures__/askingReplyRequestReason';
+import gql from '../../gql';
+import { REASON_PREFIX } from '../utils';
+
+it('handles the case when prefix does not match', async () => {
+  const params = {
+    data: {
+      selectedArticleId: 'selected-article-id',
+    },
+    state: 'ASKING_REPLY_REQUEST_REASON',
+    event: {
+      input: 'FOO', // Wrong format
+    },
+  };
+  expect(await askingReplyRequestReason(params)).toMatchSnapshot();
+});
+
+it('extracts reason and submits replyrequest', async () => {
+  gql.__push(apiResult.createReplyRequestSuccess);
+  const params = {
+    data: {
+      selectedArticleId: 'selected-article-id',
+    },
+    state: 'ASKING_REPLY_REQUEST_REASON',
+    event: {
+      input: `${REASON_PREFIX}Reason goes here`, // From LIFF
+    },
+  };
+  expect(await askingReplyRequestReason(params)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
+});

--- a/src/handlers/__tests__/choosingArticle.test.js
+++ b/src/handlers/__tests__/choosingArticle.test.js
@@ -34,6 +34,7 @@ it('should select article by articleId', async () => {
   };
 
   expect(await choosingArticle(params)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 it('should select article and have OPINIONATED and NOT_ARTICLE replies', async () => {
@@ -59,11 +60,12 @@ it('should select article and have OPINIONATED and NOT_ARTICLE replies', async (
   };
 
   expect(await choosingArticle(params)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 it('should select article with no replies', async () => {
   gql.__push(apiResult.noReplies);
-  gql.__push(apiResult.createReplyRequest);
+  gql.__push(apiResult.createOrUpdateReplyRequest);
 
   const params = {
     data: {
@@ -84,11 +86,11 @@ it('should select article with no replies', async () => {
   };
 
   expect(await choosingArticle(params)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 it('should select article with just one reply', async () => {
   gql.__push(apiResult.oneReply);
-  gql.__push(apiResult.createReplyRequest);
 
   const params = {
     data: {
@@ -110,12 +112,10 @@ it('should select article with just one reply', async () => {
   };
 
   expect(await choosingArticle(params)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 it('should ask users to re-enter a valid number if an invalid number is received', async () => {
-  gql.__push(apiResult.oneReply);
-  gql.__push(apiResult.createReplyRequest);
-
   const params = {
     data: {
       searchedText:
@@ -161,6 +161,7 @@ it('should select article and slice replies when over 10', async () => {
   };
 
   expect(await choosingArticle(params)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 it('should ask users if they want to submit article when user say not found', async () => {

--- a/src/handlers/askingReplyRequestReason.js
+++ b/src/handlers/askingReplyRequestReason.js
@@ -16,10 +16,10 @@ export default async function askingArticleSubmission(params) {
     const reason = event.input.slice(REASON_PREFIX.length);
 
     const {
-      data: { CreateReplyRequest },
+      data: { CreateOrUpdateReplyRequest },
     } = await gql`
       mutation($id: String!, $reason: String) {
-        CreateReplyRequest(articleId: $id, reason: $reason) {
+        CreateOrUpdateReplyRequest(articleId: $id, reason: $reason) {
           replyRequestCount
         }
       }
@@ -31,7 +31,7 @@ export default async function askingArticleSubmission(params) {
       {
         type: 'text',
         text: `已經將您的需求記錄下來了，共有 ${
-          CreateReplyRequest.replyRequestCount
+          CreateOrUpdateReplyRequest.replyRequestCount
         } 人跟您一樣渴望看到針對這篇訊息的回應。若有最新回應，會寫在這個地方：${articleUrl}`,
       },
       createArticleShareReply(articleUrl, reason),

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -263,7 +263,7 @@ export default async function choosingArticle(params) {
       gql`
         mutation SubmitReplyRequestWithoutReason($id: String!) {
           CreateOrUpdateReplyRequest(articleId: $id) {
-            status
+            replyRequestCount
           }
         }
       `({ id: selectedArticleId }, { userId });

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -259,6 +259,13 @@ export default async function choosingArticle(params) {
         },
       ];
 
+      // Submit article replies early, no need to wait for the request
+      gql`
+        mutation SubmitReplyRequestWithoutReason($id: String!) {
+          CreateOrUpdateReplyRequest(articleId: $id)
+        }
+      `({ id: selectedArticleId }, { userId });
+
       state = 'ASKING_ARTICLE_SOURCE';
     }
     visitor.send();

--- a/src/handlers/choosingArticle.js
+++ b/src/handlers/choosingArticle.js
@@ -262,7 +262,9 @@ export default async function choosingArticle(params) {
       // Submit article replies early, no need to wait for the request
       gql`
         mutation SubmitReplyRequestWithoutReason($id: String!) {
-          CreateOrUpdateReplyRequest(articleId: $id)
+          CreateOrUpdateReplyRequest(articleId: $id) {
+            status
+          }
         }
       `({ id: selectedArticleId }, { userId });
 


### PR DESCRIPTION
## Changes
This PR submits ReplyRequest with empty reason right after a article w/o reply is chosen, and updates the ReplyRequest after returned from LIFF.
 
![螢幕快照 2019-09-15 下午4 30 33](https://user-images.githubusercontent.com/108608/64918848-6e005700-d7d6-11e9-9a7a-974422f34c07.png)

The timing when ReplyRequest is **inserted** (means "N人回報 in website will be incremented"):
![Screenshot_20190915-160904](https://user-images.githubusercontent.com/108608/64919025-99844100-d7d8-11e9-89f2-1f4dea71a4c4.png)
![Screenshot_20190915-160917](https://user-images.githubusercontent.com/108608/64919029-af920180-d7d8-11e9-8339-8d3bee903770.png)

## Related discussion
https://g0v.hackmd.io/3sK-smdoQBW6Vhw3oQCW4w?both#LINE-bot

## Dependency
This PR depends on https://github.com/cofacts/rumors-api/pull/131 .