### PR TITLE
Enable cluster mode in NodeJS as Heroku suggested

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -13,6 +13,9 @@ module.exports = {
       autorestart: true,
       watch: false,
       max_memory_restart: `${process.env.WEB_MEMORY || 512}M`, // // Auto-restart if process takes more than XXmo
+
+      // https://devcenter.heroku.com/articles/optimizing-dyno-usage#node-js
+      exec_mode: 'cluster',
     },
   ],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -282,3 +282,15 @@ async function processText(
   console.log('\n||LOG||---------->');
   return result;
 }
+
+// Graceful shutdown
+// https://pm2.keymetrics.io/docs/usage/cluster-mode/#graceful-shutdown
+process.on('SIGINT', async () => {
+  try {
+    await redis.quit();
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+});

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -55,8 +55,21 @@ function del(key) {
   });
 }
 
+function quit() {
+  return new Promise((resolve, reject) => {
+    client.quit(err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 export default {
   set,
   get,
   del,
+  quit,
 };


### PR DESCRIPTION
Heroku suggests using cluster mode in its [dyno usage optimization guide](https://devcenter.heroku.com/articles/optimizing-dyno-usage#node-js) when NodeJS applications are deployed.

After this PR, it seems that cluster mode & graceful stopping mechanism is in place. This is how CLI reads after this PR:
```
~/workspace/rumors-line-bot ➠ heroku local
 ›   Warning: heroku update available from 7.35.0 to 7.37.0.
[WARN] ENOENT: no such file or directory, open 'Procfile'
[OKAY] package.json file found - trying 'npm start'
[OKAY] Loaded ENV .env File as KEY=VALUE Format
[WARN] ENOENT: no such file or directory, open 'Procfile'
[OKAY] package.json file found - trying 'npm start'
1:05:34 PM web.1 |  > rumors-line-bot@0.0.1 start /Users/johnsonliang/workspace/rumors-line-bot
1:05:34 PM web.1 |  > pm2-runtime start ecosystem.config.js --env production
1:05:35 PM web.1 |  2020-02-03T13:05:35: PM2 log: Launching in no daemon mode
1:05:36 PM web.1 |  2020-02-03T13:05:36: PM2 log: App [heroku-line-bot:0] starting in -cluster mode-
1:05:36 PM web.1 |  2020-02-03T13:05:36: PM2 log: App [heroku-line-bot:0] online
1:05:36 PM web.1 |  2020-02-03T13:05:36: PM2 log: App [heroku-line-bot:1] starting in -cluster mode-
1:05:36 PM web.1 |  2020-02-03T13:05:36: PM2 log: App [heroku-line-bot:1] online
1:05:36 PM web.1 |  2020-02-03T13:05:36: PM2 log: App [heroku-line-bot:2] starting in -cluster mode-
1:05:36 PM web.1 |  2020-02-03T13:05:36: PM2 log: App [heroku-line-bot:2] online
1:05:37 PM web.1 |  Google drive forder id not set, skip Gdrive initialization.
1:05:37 PM web.1 |  Listening port 5001
1:05:37 PM web.1 |  Google drive forder id not set, skip Gdrive initialization.
1:05:37 PM web.1 |  Listening port 5001
1:05:38 PM web.1 |  Google drive forder id not set, skip Gdrive initialization.
1:05:38 PM web.1 |  Listening port 5001

^C[WARN] Interrupted by User
[DONE] Killing all processes with signal  SIGINT

1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: App name:heroku-line-bot id:0 disconnected
1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: App name:heroku-line-bot id:1 disconnected
1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: App name:heroku-line-bot id:2 disconnected
1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: App [heroku-line-bot:0] exited with code [0] via signal [SIGINT]
1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: App [heroku-line-bot:1] exited with code [0] via signal [SIGINT]
1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: App [heroku-line-bot:2] exited with code [0] via signal [SIGINT]
1:05:43 PM web.1 |  2020-02-03T13:05:43: PM2 log: PM2 successfully stopped
1:05:43 PM web.1 Exited Successfully
```