### PR TITLE
@auth directive and context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "googleapis": "^36.0.0",
     "grapheme-splitter": "^1.0.4",
     "graphql": "^15.0.0",
+    "graphql-tools": "^4.0.7",
     "koa": "^2.5.0",
     "koa-router": "^7.4.0",
     "koa-static": "^5.0.0",

--- a/src/graphql/__tests__/context.js
+++ b/src/graphql/__tests__/context.js
@@ -34,6 +34,7 @@ it('Returns user context', async () => {
   `(
     {},
     {
+      userId: 'U12345678',
       userContext: {
         state: 'CHOOSING_ARTICLE',
         issuedAt: 1586013070089,

--- a/src/graphql/__tests__/context.js
+++ b/src/graphql/__tests__/context.js
@@ -1,0 +1,59 @@
+import { gql } from "../testUtils";
+
+it("context rejects anonymous users", async () => {
+  const result = await gql`
+    {
+      context {
+        state
+      }
+    }
+  `();
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "context": null,
+      },
+      "errors": Array [
+        [GraphQLError: Invalid authentication header],
+      ],
+    }
+  `);
+});
+
+it("Returns user context", async () => {
+  const result = await gql`
+    {
+      context {
+        state
+        issuedAt
+        data {
+          searchedText
+        }
+      }
+    }
+  `(
+    {},
+    {
+      userContext: {
+        state: "CHOOSING_ARTICLE",
+        issuedAt: 1586013070089,
+        data: {
+          searchedText: "Foo"
+        }
+      }
+    }
+  );
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "context": Object {
+          "data": Object {
+            "searchedText": "Foo",
+          },
+          "issuedAt": 1586013070089,
+          "state": "CHOOSING_ARTICLE",
+        },
+      },
+    }
+  `);
+});

--- a/src/graphql/__tests__/context.js
+++ b/src/graphql/__tests__/context.js
@@ -1,6 +1,6 @@
-import { gql } from "../testUtils";
+import { gql } from '../testUtils';
 
-it("context rejects anonymous users", async () => {
+it('context rejects anonymous users', async () => {
   const result = await gql`
     {
       context {
@@ -20,7 +20,7 @@ it("context rejects anonymous users", async () => {
   `);
 });
 
-it("Returns user context", async () => {
+it('Returns user context', async () => {
   const result = await gql`
     {
       context {
@@ -35,12 +35,12 @@ it("Returns user context", async () => {
     {},
     {
       userContext: {
-        state: "CHOOSING_ARTICLE",
+        state: 'CHOOSING_ARTICLE',
         issuedAt: 1586013070089,
         data: {
-          searchedText: "Foo"
-        }
-      }
+          searchedText: 'Foo',
+        },
+      },
     }
   );
   expect(result).toMatchInlineSnapshot(`

--- a/src/graphql/__tests__/index.js
+++ b/src/graphql/__tests__/index.js
@@ -14,6 +14,7 @@ describe('getContext', () => {
     expect(context).toMatchInlineSnapshot(`
       Object {
         "userContext": null,
+        "userId": "",
       }
     `);
   });
@@ -38,6 +39,7 @@ describe('getContext', () => {
     expect(context).toMatchInlineSnapshot(`
       Object {
         "userContext": null,
+        "userId": "user1",
       }
     `);
   });
@@ -66,6 +68,7 @@ describe('getContext', () => {
           "foo": "bar",
           "nonce": "correctpass",
         },
+        "userId": "user1",
       }
     `);
   });

--- a/src/graphql/__tests__/index.js
+++ b/src/graphql/__tests__/index.js
@@ -1,0 +1,72 @@
+jest.mock('src/lib/redisClient');
+
+import { getContext } from '../';
+import redis from 'src/lib/redisClient';
+
+beforeEach(() => {
+  redis.get.mockClear();
+});
+
+describe('getContext', () => {
+  it('generates null context for anonymous requests', async () => {
+    const context = await getContext({ ctx: { req: { headers: {} } } });
+
+    expect(context).toMatchInlineSnapshot(`
+      Object {
+        "userContext": null,
+      }
+    `);
+  });
+
+  it('generates null context for wrong credentials', async () => {
+    redis.get.mockImplementationOnce(() => ({
+      nonce: 'correctpass',
+    }));
+
+    const context = await getContext({
+      ctx: {
+        req: {
+          headers: {
+            authorization: `basic ${Buffer.from('user1:wrongpass').toString(
+              'base64'
+            )}`,
+          },
+        },
+      },
+    });
+
+    expect(context).toMatchInlineSnapshot(`
+      Object {
+        "userContext": null,
+      }
+    `);
+  });
+
+  it('reads userContext for logged-in requests', async () => {
+    redis.get.mockImplementationOnce(() => ({
+      nonce: 'correctpass',
+      foo: 'bar',
+    }));
+
+    const context = await getContext({
+      ctx: {
+        req: {
+          headers: {
+            authorization: `basic ${Buffer.from('user1:correctpass').toString(
+              'base64'
+            )}`,
+          },
+        },
+      },
+    });
+
+    expect(context).toMatchInlineSnapshot(`
+      Object {
+        "userContext": Object {
+          "foo": "bar",
+          "nonce": "correctpass",
+        },
+      }
+    `);
+  });
+});

--- a/src/graphql/__tests__/insights.js
+++ b/src/graphql/__tests__/insights.js
@@ -1,4 +1,3 @@
-jest.mock('@line/bot-sdk');
 import {
   mockedGetNumberOfMessageDeliveries,
   mockedGetNumberOfFollowers,

--- a/src/graphql/directives/auth.js
+++ b/src/graphql/directives/auth.js
@@ -11,7 +11,7 @@ class AuthDirective extends SchemaDirectiveVisitor {
     field.resolve = (...args) => {
       const [, , context] = args;
 
-      if (!context.userContext) {
+      if (!context.userId || !context.userContext) {
         throw new AuthenticationError('Invalid authentication header');
       }
 

--- a/src/graphql/directives/auth.js
+++ b/src/graphql/directives/auth.js
@@ -1,0 +1,23 @@
+import { AuthenticationError } from 'apollo-server-koa';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+
+/**
+ * When field with @auth is accessed, make sure the user is logged in (i.e. `userContext` in context).
+ */
+class AuthDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field) {
+    const { resolve } = field;
+
+    field.resolve = (...args) => {
+      const [, , context] = args;
+
+      if (!context.userContext) {
+        throw new AuthenticationError('Invalid authentication header');
+      }
+
+      return resolve(...args);
+    };
+  }
+}
+
+export default AuthDirective;

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -46,6 +46,7 @@ export async function getContext({ ctx: { req } }) {
   }
 
   return {
+    userId,
     userContext,
   };
 }

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { ApolloServer, makeExecutableSchema } from 'apollo-server-koa';
+import redis from 'src/lib/redisClient';
 
 export const schema = makeExecutableSchema({
   typeDefs: fs.readFileSync(path.join(__dirname, `./typeDefs.graphql`), {
@@ -14,8 +15,44 @@ export const schema = makeExecutableSchema({
       ] = require(`./resolvers/${fileName}`).default;
       return resolvers;
     }, {}),
+  schemaDirectives: fs
+    .readdirSync(path.join(__dirname, 'directives'))
+    .reduce((directives, fileName) => {
+      directives[
+        fileName.replace(/\.js$/, '')
+      ] = require(`./directives/${fileName}`).default;
+      return directives;
+    }, {}),
 });
 
-const server = new ApolloServer({ schema });
+/**
+ * @param {{ctx: Koa.Context}}
+ * @returns {object}
+ */
+export async function getContext({ ctx: { req } }) {
+  const [userId, nonce] = Buffer.from(
+    (req.headers.authorization || '').replace(/^basic /, ''),
+    'base64'
+  )
+    .toString()
+    .split(':');
+
+  let userContext = null;
+  if (userId && nonce) {
+    const context = await redis.get(userId);
+    if (context && context.nonce === nonce) {
+      userContext = context;
+    }
+  }
+
+  return {
+    userContext,
+  };
+}
+
+const server = new ApolloServer({
+  schema,
+  context: getContext,
+});
 
 export default server.getMiddleware();

--- a/src/graphql/resolvers/Query.js
+++ b/src/graphql/resolvers/Query.js
@@ -3,4 +3,8 @@ export default {
     // Resolvers in next level
     return {};
   },
+
+  context(root, args, context) {
+    return context.userContext;
+  },
 };

--- a/src/graphql/testUtils.js
+++ b/src/graphql/testUtils.js
@@ -1,3 +1,6 @@
+// ./index.js contains imports to redisClient, which should be mocked in unit tests.
+jest.mock('src/lib/redisClient');
+
 import { graphql } from 'graphql';
 import { schema } from './';
 

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -1,5 +1,10 @@
+directive @auth on FIELD_DEFINITION
+
 type Query {
   insights: MessagingAPIInsight
+
+  # Current user's chatbot context
+  context: UserContext @auth
 }
 
 type MessagingAPIInsight {
@@ -122,4 +127,17 @@ enum MessagingAPIInsightStatus {
   READY
   UNREADY
   OUT_OF_SERVICE
+}
+
+type UserContext {
+  state: String
+  issuedAt: Float
+  data: StateData
+}
+
+type StateData {
+  searchedText: String
+  selectedArticleId: ID
+  selectedArticleText: String
+  selectedReplyId: ID
 }

--- a/src/lib/__mocks__/redisClient.js
+++ b/src/lib/__mocks__/redisClient.js
@@ -1,0 +1,2 @@
+// Automatically mocks all existence of redisClient in unit tests
+export default jest.genMockFromModule('../redisClient').default;

--- a/src/lib/__mocks__/redisClient.js
+++ b/src/lib/__mocks__/redisClient.js
@@ -1,2 +1,3 @@
-// Automatically mocks all existence of redisClient in unit tests
-export default jest.genMockFromModule('../redisClient').default;
+export default {
+  get: jest.fn(),
+};


### PR DESCRIPTION
This PR implements a GraphQL API, `Query.context`, that will replace the current `/context/:userId` API endpoint.


As designed in [design doc](https://g0v.hackmd.io/860RnxUGTi6z2Kca6ojAbg), we authenticate the user by `Authorization` header. When `userId` and `nonce` match the one in Redis, we populate GraphQL context with `{userContext: <the one in redis>}`.

The `Query.context` API is guarded using `@auth` directive, which checks `userContext` field in GraphQL context. When accessing fields with `@auth` directive, it throws `AuthenticationError` if `userContext` does not exist.

References
- Apollo-server: authentication using directive: https://www.apollographql.com/docs/apollo-server/security/authentication/#authorization-via-custom-directives
- Schema directive doc: https://www.apollographql.com/docs/graphql-tools/schema-directives/#what-about-directiveresolvers