### PR TITLE
Flow for having reply

### DIFF
--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -11,6 +11,7 @@ const SITE_URL = process.env.SITE_URL || 'https://cofacts.g0v.tw';
  */
 export const REASON_PREFIX = `💁 ${t`My reason is`}:\n`;
 export const SOURCE_PREFIX = `ℹ️ ${t`I got the message from`}:\n`;
+export const UPVOTE_PREFIX = `👍 ${t`I think the reply is useful and I want to add`}:\n`;
 export const DOWNVOTE_PREFIX = `💡 ${t`I think the reply is not useful and I suggest`}:\n`;
 
 /**

--- a/src/webhook/handleInput.js
+++ b/src/webhook/handleInput.js
@@ -10,6 +10,7 @@ import { ManipulationError } from './handlers/utils';
 import {
   REASON_PREFIX,
   DOWNVOTE_PREFIX,
+  UPVOTE_PREFIX,
   SOURCE_PREFIX,
 } from 'src/lib/sharedUtils';
 
@@ -38,6 +39,7 @@ export default async function handleInput(
   if (
     event.type === 'message' &&
     !event.input.startsWith(REASON_PREFIX) &&
+    !event.input.startsWith(UPVOTE_PREFIX) &&
     !event.input.startsWith(DOWNVOTE_PREFIX) &&
     !event.input.startsWith(SOURCE_PREFIX)
   ) {

--- a/src/webhook/handlers/__fixtures__/askingReplyFeedback.js
+++ b/src/webhook/handlers/__fixtures__/askingReplyFeedback.js
@@ -1,36 +1,21 @@
 export const twoFeedbacks = {
   data: {
-    action: {
+    CreateOrUpdateArticleReplyFeedback: {
       feedbackCount: 2,
-    },
-    GetReply: {
-      type: 'NOT_ARTICLE',
-      text:
-        '這是商業活動廣告01 這是商業活動廣告02 這是商業活動廣告03 這是商業活動廣告04 這是商業活動廣告05 這是商業活動廣告06 這是商業活動廣告07 這是商業活動廣告08 這是商業活動廣告09 這是商業活動廣告10 這是商業活動廣告11 這是商業活動廣告12 這是商業活動廣告13 這是商業活動廣告14 這是商業活動廣告15 這是商業活動廣告16 這是商業活動廣告17 這是商業活動廣告18 這是商業活動廣告19 這是商業活動廣告20',
-      reference: '',
-    },
-    GetArticle: {
-      text:
-        '(0)(1)(/)(0)(9)(line)免費貼圖\n\n「[全螢幕貼圖]生活市集x生活小黑熊」\nhttps://line.me/S/sticker/10299\n\n「松果購物 x 狗與鹿(動態貼圖) 」\nhttps://line.me/S/sticker/10300\n\n「LINE TV X 我的男孩限免貼圖」\nhttps://line.me/S/sticker/10207',
+      reply: { type: 'NOT_ARTICLE' },
     },
   },
 };
 
 export const oneFeedback = {
   data: {
-    action: {
+    CreateOrUpdateArticleReplyFeedback: {
       feedbackCount: 1,
+      reply: { type: 'NOT_ARTICLE' },
     },
   },
 };
 
-export const articleData = {
-  data: {
-    GetReply: {
-      type: 'NOT_ARTICLE',
-      text:
-        '這是商業活動廣告01 這是商業活動廣告02 這是商業活動廣告03 這是商業活動廣告04 這是商業活動廣告05 這是商業活動廣告06 這是商業活動廣告07 這是商業活動廣告08 這是商業活動廣告09 這是商業活動廣告10 這是商業活動廣告11 這是商業活動廣告12 這是商業活動廣告13 這是商業活動廣告14 這是商業活動廣告15 這是商業活動廣告16 這是商業活動廣告17 這是商業活動廣告18 這是商業活動廣告19 這是商業活動廣告20',
-      reference: '',
-    },
-  },
+export const error = {
+  errors: [{ message: 'Some error' }],
 };

--- a/src/webhook/handlers/__fixtures__/choosingReply.js
+++ b/src/webhook/handlers/__fixtures__/choosingReply.js
@@ -7,5 +7,23 @@ export const oneReply = {
       reference: '',
       createdAt: '2018-01-09T05:52:12.658Z',
     },
+    GetArticle: {
+      replyCount: 1,
+    },
+  },
+};
+
+export const multipleReplies = {
+  data: {
+    GetReply: {
+      type: 'NOT_ARTICLE',
+      text:
+        '這是商業活動廣告01 這是商業活動廣告02 這是商業活動廣告03 這是商業活動廣告04 這是商業活動廣告05 這是商業活動廣告06 這是商業活動廣告07 這是商業活動廣告08 這是商業活動廣告09 這是商業活動廣告10 這是商業活動廣告11 這是商業活動廣告12 這是商業活動廣告13 這是商業活動廣告14 這是商業活動廣告15 這是商業活動廣告16 這是商業活動廣告17 這是商業活動廣告18 這是商業活動廣告19 這是商業活動廣告20',
+      reference: '',
+      createdAt: '2018-01-09T05:52:12.658Z',
+    },
+    GetArticle: {
+      replyCount: 4,
+    },
   },
 };

--- a/src/webhook/handlers/__tests__/__snapshots__/askingReplyFeedback.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingReplyFeedback.test.js.snap
@@ -1,17 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`handles "no" postback with other existing feedback comments 1`] = `
+exports[`handles "no" postback with no other existing feedbacks 1`] = `
 Object {
   "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
@@ -19,12 +10,6 @@ Object {
   "event": Object {
     "input": "💡 I think the reply is not useful and I suggest:
 我覺得不行",
-    "message": Object {
-      "id": 1519019734813,
-      "text": "💡 I think the reply is not useful and I suggest:
-我覺得不行",
-      "type": "text",
-    },
     "timestamp": 1519019734813,
     "type": "text",
   },
@@ -32,31 +17,22 @@ Object {
   "issuedAt": 1519019735467,
   "replies": Array [
     Object {
-      "text": "感謝您的回饋，您是第一個評論這個回應的人 :)",
+      "text": "Thanks. You're the first one who gave feedback on this reply!",
       "type": "text",
     },
     Object {
-      "text": "💁 若您認為自己能回應得更好，歡迎到 https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz 提交新的回應唷！",
+      "text": "💁 If you have a better reply, feel free to submit it to https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz .",
       "type": "text",
     },
   ],
-  "state": "__INIT__",
+  "state": "ASKING_REPLY_FEEDBACK",
   "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
 }
 `;
 
-exports[`handles "no" postback with other existing feedback comments 2`] = `
+exports[`handles "no" postback with other existing feedback comments 1`] = `
 Object {
   "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
@@ -64,12 +40,6 @@ Object {
   "event": Object {
     "input": "💡 I think the reply is not useful and I suggest:
 我覺得不行",
-    "message": Object {
-      "id": 1519019734813,
-      "text": "💡 I think the reply is not useful and I suggest:
-我覺得不行",
-      "type": "text",
-    },
     "timestamp": 1519019734813,
     "type": "text",
   },
@@ -77,15 +47,15 @@ Object {
   "issuedAt": 1519019735467,
   "replies": Array [
     Object {
-      "text": "感謝您與其他 1 人的回饋。",
+      "text": "We've received feedback from you and 1 other users!",
       "type": "text",
     },
     Object {
-      "text": "💁 若您認為自己能回應得更好，歡迎到 https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz 提交新的回應唷！",
+      "text": "💁 If you have a better reply, feel free to submit it to https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz .",
       "type": "text",
     },
   ],
-  "state": "__INIT__",
+  "state": "ASKING_REPLY_FEEDBACK",
   "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
 }
 `;
@@ -93,15 +63,6 @@ Object {
 exports[`handles "yes" postback with no other existing feedbacks 1`] = `
 Object {
   "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
     "selectedArticleText": "(0)(1)(/)(0)(9)(line)免費貼圖
@@ -117,140 +78,8 @@ https://line.me/S/sticker/10207",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
   },
   "event": Object {
-    "input": "y",
-    "postback": Object {
-      "data": "{\\"input\\":\\"y\\",\\"issuedAt\\":1519019701265}",
-    },
-    "timestamp": 1519019734813,
-    "type": "postback",
-  },
-  "isSkipUser": false,
-  "issuedAt": 1519019735467,
-  "replies": Array [
-    Object {
-      "text": "感謝您的回饋，您是第一個評論這個回應的人 :)",
-      "type": "text",
-    },
-    Object {
-      "altText": "📲 別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！
-💁 若您認為自己能回應得更好，歡迎到 https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz 提交新的回應唷！",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "label": "分享給朋友",
-            "type": "uri",
-            "uri": "line://msg/text/?%E7%B6%B2%E8%B7%AF%E4%B8%8A%E6%9C%89%E4%BA%BA%E8%AA%AA%E3%80%8C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E3%80%8D%20Invalid%20request%E5%96%94%EF%BC%81%0A%0A%E8%AB%8B%E8%87%B3%20https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz%20%E7%9C%8B%E7%9C%8B%E9%84%89%E8%A6%AA%E5%80%91%E9%87%9D%E5%B0%8D%E9%80%99%E5%89%87%E8%A8%8A%E6%81%AF%E7%9A%84%E5%9B%9E%E6%87%89%E3%80%81%E7%90%86%E7%94%B1%EF%BC%8C%E8%88%87%E7%9B%B8%E9%97%9C%E7%9A%84%E5%87%BA%E8%99%95%E5%94%B7%EF%BC%81",
-          },
-          Object {
-            "label": "提交新回應",
-            "type": "uri",
-            "uri": "https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
-          },
-        ],
-        "text": "📲 別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！
-💁 若您認為自己能回應得更好，歡迎提交新的回應唷！",
-        "type": "confirm",
-      },
-      "type": "template",
-    },
-  ],
-  "state": "__INIT__",
-  "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
-}
-`;
-
-exports[`handles "yes" postback with other existing feedbacks 1`] = `
-Object {
-  "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
-    "searchedText": "貼圖",
-    "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
-    "selectedArticleText": "(0)(1)(/)(0)(9)(line)免費貼圖
-
-「[全螢幕貼圖]生活市集x生活小黑熊」
-https://line.me/S/sticker/10299
-
-「松果購物 x 狗與鹿(動態貼圖) 」
-https://line.me/S/sticker/10300
-
-「LINE TV X 我的男孩限免貼圖」
-https://line.me/S/sticker/10207",
-    "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
-  },
-  "event": Object {
-    "input": "y",
-    "postback": Object {
-      "data": "{\\"input\\":\\"y\\",\\"issuedAt\\":1519019701265}",
-    },
-    "timestamp": 1519019734813,
-    "type": "postback",
-  },
-  "isSkipUser": false,
-  "issuedAt": 1519019735467,
-  "replies": Array [
-    Object {
-      "text": "感謝您與其他 1 人的回饋。",
-      "type": "text",
-    },
-    Object {
-      "altText": "📲 別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！
-💁 若您認為自己能回應得更好，歡迎到 https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz 提交新的回應唷！",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "label": "分享給朋友",
-            "type": "uri",
-            "uri": "line://msg/text/?%E7%B6%B2%E8%B7%AF%E4%B8%8A%E6%9C%89%E4%BA%BA%E8%AA%AA%E3%80%8C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E3%80%8D%20Invalid%20request%E5%96%94%EF%BC%81%0A%0A%E8%AB%8B%E8%87%B3%20https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz%20%E7%9C%8B%E7%9C%8B%E9%84%89%E8%A6%AA%E5%80%91%E9%87%9D%E5%B0%8D%E9%80%99%E5%89%87%E8%A8%8A%E6%81%AF%E7%9A%84%E5%9B%9E%E6%87%89%E3%80%81%E7%90%86%E7%94%B1%EF%BC%8C%E8%88%87%E7%9B%B8%E9%97%9C%E7%9A%84%E5%87%BA%E8%99%95%E5%94%B7%EF%BC%81",
-          },
-          Object {
-            "label": "提交新回應",
-            "type": "uri",
-            "uri": "https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
-          },
-        ],
-        "text": "📲 別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！
-💁 若您認為自己能回應得更好，歡迎提交新的回應唷！",
-        "type": "confirm",
-      },
-      "type": "template",
-    },
-  ],
-  "state": "__INIT__",
-  "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
-}
-`;
-
-exports[`handles unexpected feedbacks 1`] = `
-Object {
-  "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
-    "searchedText": "貼圖",
-    "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
-    "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
-  },
-  "event": Object {
-    "input": "asdasdasd",
-    "message": Object {
-      "id": 1519019734813,
-      "text": "asdasdasd",
-      "type": "text",
-    },
+    "input": "👍 I think the reply is useful and I want to add:
+Reply is good!",
     "timestamp": 1519019734813,
     "type": "text",
   },
@@ -258,8 +87,140 @@ Object {
   "issuedAt": 1519019735467,
   "replies": Array [
     Object {
-      "text": "請點擊上面的「是」、「否」對回應表達意見，或改轉傳其他訊息給我查詢。",
+      "text": "Thanks. You're the first one who gave feedback on this reply!",
       "type": "text",
+    },
+    Object {
+      "altText": "Don't forget to forward the messages above to others and share with them!
+📱 Please proceed on your mobile phone.",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Don't forget to forward the messages above to others and share with them!",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "paddingAll": "lg",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "label": "Share to friends",
+                "type": "uri",
+                "uri": "https://line.me/R/msg/text/?Someone%20says%20the%20message%20%E2%80%9C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E2%80%9D%20invalid%20request.%0A%0APlease%20refer%20to%20https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz%20for%20more%20information,%20replies%20and%20references.",
+              },
+              "color": "#ffb600",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "See reported message",
+                "type": "uri",
+                "uri": "https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
+              },
+              "color": "#ffb600",
+              "style": "link",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "type": "flex",
+    },
+  ],
+  "state": "ASKING_REPLY_FEEDBACK",
+  "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
+}
+`;
+
+exports[`handles "yes" postback with other existing feedbacks 1`] = `
+Object {
+  "data": Object {
+    "searchedText": "貼圖",
+    "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
+    "selectedArticleText": "(0)(1)(/)(0)(9)(line)免費貼圖
+
+「[全螢幕貼圖]生活市集x生活小黑熊」
+https://line.me/S/sticker/10299
+
+「松果購物 x 狗與鹿(動態貼圖) 」
+https://line.me/S/sticker/10300
+
+「LINE TV X 我的男孩限免貼圖」
+https://line.me/S/sticker/10207",
+    "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
+  },
+  "event": Object {
+    "input": "👍 I think the reply is useful and I want to add:
+Reply is good!",
+    "timestamp": 1519019734813,
+    "type": "text",
+  },
+  "isSkipUser": false,
+  "issuedAt": 1519019735467,
+  "replies": Array [
+    Object {
+      "text": "We've received feedback from you and 1 other users!",
+      "type": "text",
+    },
+    Object {
+      "altText": "Don't forget to forward the messages above to others and share with them!
+📱 Please proceed on your mobile phone.",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Don't forget to forward the messages above to others and share with them!",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "paddingAll": "lg",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "label": "Share to friends",
+                "type": "uri",
+                "uri": "https://line.me/R/msg/text/?Someone%20says%20the%20message%20%E2%80%9C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E2%80%9D%20invalid%20request.%0A%0APlease%20refer%20to%20https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz%20for%20more%20information,%20replies%20and%20references.",
+              },
+              "color": "#ffb600",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "See reported message",
+                "type": "uri",
+                "uri": "https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
+              },
+              "color": "#ffb600",
+              "style": "link",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "type": "flex",
     },
   ],
   "state": "ASKING_REPLY_FEEDBACK",

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
@@ -1,58 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should handle invalid reply ids 1`] = `
-Object {
-  "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
-    "searchedText": "貼圖",
-    "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
-  },
-  "event": Object {
-    "input": "123",
-    "timestamp": 1518964687709,
-    "type": "text",
-  },
-  "isSkipUser": false,
-  "issuedAt": 1518964688672,
-  "replies": Array [
-    Object {
-      "text": "請輸入 1～1 的數字，來選擇回應。",
-      "type": "text",
-    },
-  ],
-  "state": "CHOOSING_REPLY",
-  "userId": "Uaddc74df8a3a176b901d9d648b0fc4fe",
-}
-`;
-
 exports[`should select reply by replyId should handle the case with just one reply 1`] = `
 Object {
   "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-    ],
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
   },
   "event": Object {
-    "input": 1,
+    "input": "AWDZeeV0yCdS-nWhuml8",
     "postback": Object {
-      "data": "{\\"input\\":1,\\"issuedAt\\":1518964675191}",
+      "data": "{\\"input\\":\\"AWDZeeV0yCdS-nWhuml8\\",\\"state\\":\\"CHOOSING_REPLY\\"}",
     },
     "timestamp": 1518964687709,
     "type": "postback",
@@ -82,25 +40,52 @@ https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
       "type": "text",
     },
     Object {
-      "altText": "請問上面回應是否有幫助？
-「是」請輸入「y」，「否」請至手機上回應",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "data": "{\\"input\\":\\"y\\",\\"sessionId\\":1518964688672}",
-            "label": "Yes",
-            "type": "postback",
-          },
-          Object {
-            "label": "No",
-            "type": "uri",
-            "uri": "line://app/1631030389-xb5mnDdN?p=ASKING_REPLY_FEEDBACK&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOiLwn5KhIEkgdGhpbmsgdGhlIHJlcGx5IGlzIG5vdCB1c2VmdWwgYW5kIEkgc3VnZ2VzdDpcbiIsImV4cCI6MTU3NzkyMzIwMH0._hEe14XF6DQvMOmgv_G1yPkVGExgNPtGaaTaBK_BuuQ",
-          },
-        ],
-        "text": "Is the reply helpful?",
-        "type": "confirm",
+      "altText": "Is the reply helpful?
+📱 Please proceed on your mobile phone.",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Is the reply helpful?",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "paddingAll": "lg",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "label": "Yes",
+                "type": "uri",
+                "uri": "line://app/1631030389-xb5mnDdN?p=feedback/yes&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
+              },
+              "color": "#ffb600",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "No",
+                "type": "uri",
+                "uri": "line://app/1631030389-xb5mnDdN?p=feedback/no&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
+              },
+              "color": "#ffb600",
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "horizontal",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "type": "bubble",
       },
-      "type": "template",
+      "type": "flex",
     },
   ],
   "state": "ASKING_REPLY_FEEDBACK",
@@ -108,27 +93,17 @@ https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
 }
 `;
 
-exports[`should select reply by replyId should handle the case with multiple replues 1`] = `
+exports[`should select reply by replyId should handle the case with multiple replies 1`] = `
 Object {
   "data": Object {
-    "foundArticleIds": Array [
-      "AWDZYXxAyCdS-nWhumlz",
-      "5483323992880-rumor",
-      "AV-Urc0jyCdS-nWhuity",
-      "AVsh8u7StKp96s659Dgq",
-    ],
-    "foundReplyIds": Array [
-      "AWDZeeV0yCdS-nWhuml8",
-      "BVDZeeV0yCdS-nWhuml8",
-    ],
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
   },
   "event": Object {
-    "input": 1,
+    "input": "AWDZeeV0yCdS-nWhuml8",
     "postback": Object {
-      "data": "{\\"input\\":1,\\"issuedAt\\":1518964675191}",
+      "data": "{\\"input\\":\\"AWDZeeV0yCdS-nWhuml8\\",\\"state\\":\\"CHOOSING_REPLY\\"}",
     },
     "timestamp": 1518964687709,
     "type": "postback",
@@ -160,25 +135,52 @@ https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz",
       "type": "text",
     },
     Object {
-      "altText": "請問上面回應是否有幫助？
-「是」請輸入「y」，「否」請至手機上回應",
-      "template": Object {
-        "actions": Array [
-          Object {
-            "data": "{\\"input\\":\\"y\\",\\"sessionId\\":1518964688672}",
-            "label": "Yes",
-            "type": "postback",
-          },
-          Object {
-            "label": "No",
-            "type": "uri",
-            "uri": "line://app/1631030389-xb5mnDdN?p=ASKING_REPLY_FEEDBACK&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOiLwn5KhIEkgdGhpbmsgdGhlIHJlcGx5IGlzIG5vdCB1c2VmdWwgYW5kIEkgc3VnZ2VzdDpcbiIsImV4cCI6MTU3NzkyMzIwMH0._hEe14XF6DQvMOmgv_G1yPkVGExgNPtGaaTaBK_BuuQ",
-          },
-        ],
-        "text": "Is the reply helpful?",
-        "type": "confirm",
+      "altText": "Is the reply helpful?
+📱 Please proceed on your mobile phone.",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Is the reply helpful?",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "paddingAll": "lg",
+          "spacing": "md",
+          "type": "box",
+        },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "label": "Yes",
+                "type": "uri",
+                "uri": "line://app/1631030389-xb5mnDdN?p=feedback/yes&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
+              },
+              "color": "#ffb600",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "label": "No",
+                "type": "uri",
+                "uri": "line://app/1631030389-xb5mnDdN?p=feedback/no&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
+              },
+              "color": "#ffb600",
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "horizontal",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "type": "bubble",
       },
-      "type": "template",
+      "type": "flex",
     },
   ],
   "state": "ASKING_REPLY_FEEDBACK",

--- a/src/webhook/handlers/__tests__/askingReplyFeedback.test.js
+++ b/src/webhook/handlers/__tests__/askingReplyFeedback.test.js
@@ -1,35 +1,30 @@
 jest.mock('src/lib/gql');
+jest.mock('src/lib/ga');
 
 import askingReplyFeedback from '../askingReplyFeedback';
 import * as apiResult from '../__fixtures__/askingReplyFeedback';
 import gql from 'src/lib/gql';
-import { DOWNVOTE_PREFIX } from 'src/lib/sharedUtils';
+import ga from 'src/lib/ga';
+import { UPVOTE_PREFIX, DOWNVOTE_PREFIX } from 'src/lib/sharedUtils';
 
 beforeEach(() => {
   gql.__reset();
+  ga.clearAllMocks();
 });
 
 const commonParamsYes = {
   data: {
     searchedText: '貼圖',
-    foundArticleIds: [
-      'AWDZYXxAyCdS-nWhumlz',
-      '5483323992880-rumor',
-      'AV-Urc0jyCdS-nWhuity',
-      'AVsh8u7StKp96s659Dgq',
-    ],
     selectedArticleId: 'AWDZYXxAyCdS-nWhumlz',
     selectedArticleText:
       '(0)(1)(/)(0)(9)(line)免費貼圖\n\n「[全螢幕貼圖]生活市集x生活小黑熊」\nhttps://line.me/S/sticker/10299\n\n「松果購物 x 狗與鹿(動態貼圖) 」\nhttps://line.me/S/sticker/10300\n\n「LINE TV X 我的男孩限免貼圖」\nhttps://line.me/S/sticker/10207',
-    foundReplyIds: ['AWDZeeV0yCdS-nWhuml8'],
     selectedReplyId: 'AWDZeeV0yCdS-nWhuml8',
   },
   state: 'ASKING_REPLY_FEEDBACK',
   event: {
-    type: 'postback',
-    input: 'y',
+    type: 'text',
+    input: `${UPVOTE_PREFIX}Reply is good!`,
     timestamp: 1519019734813,
-    postback: { data: '{"input":"y","issuedAt":1519019701265}' },
   },
   issuedAt: 1519019735467,
   userId: 'Uaddc74df8a3a176b901d9d648b0fc4fe',
@@ -39,27 +34,33 @@ const commonParamsYes = {
 
 it('handles "yes" postback with no other existing feedbacks', async () => {
   gql.__push(apiResult.oneFeedback);
-  gql.__push(apiResult.articleData);
   expect(await askingReplyFeedback(commonParamsYes)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
+
+  expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "ea": "Feedback-Vote",
+          "ec": "UserInput",
+          "el": "AWDZYXxAyCdS-nWhumlz/AWDZeeV0yCdS-nWhuml8",
+        },
+      ],
+    ]
+  `);
+  expect(ga.sendMock).toHaveBeenCalledTimes(1);
 });
 
 it('handles "yes" postback with other existing feedbacks', async () => {
   gql.__push(apiResult.twoFeedbacks);
-  gql.__push(apiResult.articleData);
   expect(await askingReplyFeedback(commonParamsYes)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 const commonParamsNo = {
   data: {
     searchedText: '貼圖',
-    foundArticleIds: [
-      'AWDZYXxAyCdS-nWhumlz',
-      '5483323992880-rumor',
-      'AV-Urc0jyCdS-nWhuity',
-      'AVsh8u7StKp96s659Dgq',
-    ],
     selectedArticleId: 'AWDZYXxAyCdS-nWhumlz',
-    foundReplyIds: ['AWDZeeV0yCdS-nWhuml8'],
     selectedReplyId: 'AWDZeeV0yCdS-nWhuml8',
   },
   state: 'ASKING_REPLY_FEEDBACK',
@@ -67,11 +68,6 @@ const commonParamsNo = {
     type: 'text',
     input: `${DOWNVOTE_PREFIX}我覺得不行`,
     timestamp: 1519019734813,
-    message: {
-      id: 1519019734813,
-      type: 'text',
-      text: `${DOWNVOTE_PREFIX}我覺得不行`,
-    },
   },
   issuedAt: 1519019735467,
   userId: 'Uaddc74df8a3a176b901d9d648b0fc4fe',
@@ -79,37 +75,29 @@ const commonParamsNo = {
   isSkipUser: false,
 };
 
-it('handles "no" postback with other existing feedback comments', async () => {
+it('handles "no" postback with no other existing feedbacks', async () => {
   gql.__push(apiResult.oneFeedback);
   expect(await askingReplyFeedback(commonParamsNo)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
+});
 
+it('handles "no" postback with other existing feedback comments', async () => {
   gql.__push(apiResult.twoFeedbacks);
   expect(await askingReplyFeedback(commonParamsNo)).toMatchSnapshot();
+  expect(gql.__finished()).toBe(true);
 });
 
 const commonParamsOthers = {
   data: {
     searchedText: '貼圖',
-    foundArticleIds: [
-      'AWDZYXxAyCdS-nWhumlz',
-      '5483323992880-rumor',
-      'AV-Urc0jyCdS-nWhuity',
-      'AVsh8u7StKp96s659Dgq',
-    ],
     selectedArticleId: 'AWDZYXxAyCdS-nWhumlz',
-    foundReplyIds: ['AWDZeeV0yCdS-nWhuml8'],
     selectedReplyId: 'AWDZeeV0yCdS-nWhuml8',
   },
   state: 'ASKING_REPLY_FEEDBACK',
   event: {
     type: 'text',
-    input: 'asdasdasd',
+    input: 'Unexpected text here!',
     timestamp: 1519019734813,
-    message: {
-      id: 1519019734813,
-      type: 'text',
-      text: 'asdasdasd',
-    },
   },
   issuedAt: 1519019735467,
   userId: 'Uaddc74df8a3a176b901d9d648b0fc4fe',
@@ -118,33 +106,25 @@ const commonParamsOthers = {
 };
 
 it('handles unexpected feedbacks', async () => {
-  gql.__push(apiResult.oneFeedback);
-
-  expect(await askingReplyFeedback(commonParamsOthers)).toMatchSnapshot();
+  await expect(
+    askingReplyFeedback(commonParamsOthers)
+  ).rejects.toMatchInlineSnapshot(
+    `[Error: Please press the latest button to provide feedback to reply.]`
+  );
+  expect(ga.sendMock).toHaveBeenCalledTimes(0);
 });
 
 const commonParamsInvalid = {
   data: {
     searchedText: '貼圖',
-    foundArticleIds: [
-      'AWDZYXxAyCdS-nWhumlz',
-      '5483323992880-rumor',
-      'AV-Urc0jyCdS-nWhuity',
-      'AVsh8u7StKp96s659Dgq',
-    ],
     selectedArticleId: 'AWDZYXxAyCdS-nWhumlz',
-    foundReplyIds: ['AWDZeeV0yCdS-nWhuml8'],
+    // No selectedReplyId
   },
   state: 'ASKING_REPLY_FEEDBACK',
   event: {
     type: 'text',
     input: 'asdasdasd',
     timestamp: 1519019734813,
-    message: {
-      id: 1519019734813,
-      type: 'text',
-      text: 'asdasdasd',
-    },
   },
   issuedAt: 1519019735467,
   userId: 'Uaddc74df8a3a176b901d9d648b0fc4fe',
@@ -153,7 +133,19 @@ const commonParamsInvalid = {
 };
 
 it('handles invalid params', async () => {
-  gql.__push(apiResult.oneFeedback);
+  await expect(
+    askingReplyFeedback(commonParamsInvalid)
+  ).rejects.toMatchInlineSnapshot(`[Error: selectedReply not set in data]`);
+  expect(ga.sendMock).toHaveBeenCalledTimes(0);
+});
 
-  await expect(askingReplyFeedback(commonParamsInvalid)).rejects.toThrow(Error);
+it('gracefully handle graphql error', async () => {
+  gql.__push(apiResult.error);
+  await expect(
+    askingReplyFeedback(commonParamsYes)
+  ).rejects.toMatchInlineSnapshot(
+    `[Error: Cannot record your feedback. Try again later?]`
+  );
+  expect(gql.__finished()).toBe(true);
+  expect(ga.sendMock).toHaveBeenCalledTimes(0);
 });

--- a/src/webhook/handlers/askingReplyFeedback.js
+++ b/src/webhook/handlers/askingReplyFeedback.js
@@ -1,13 +1,169 @@
 import gql from 'src/lib/gql';
 import ga from 'src/lib/ga';
-import { getArticleURL, DOWNVOTE_PREFIX } from 'src/lib/sharedUtils';
-import { createTypeWords, ellipsis } from './utils';
+import { t } from 'ttag';
+import {
+  getArticleURL,
+  UPVOTE_PREFIX,
+  DOWNVOTE_PREFIX,
+} from 'src/lib/sharedUtils';
+import {
+  createTypeWords,
+  ellipsis,
+  ManipulationError,
+  FLEX_MESSAGE_ALT_TEXT,
+} from './utils';
+
+/**
+ * @param {{vote: FeedbackVote, articleId: String, replyId: String, comment: String}} variables
+ * @param {object} search
+ * @returns {Promise}
+ */
+const updateFeedback = gql`
+  mutation UpdateFeedback(
+    $vote: FeedbackVote!
+    $articleId: String!
+    $replyId: String!
+    $comment: String
+  ) {
+    CreateOrUpdateArticleReplyFeedback(
+      vote: $vote
+      articleId: $articleId
+      replyId: $replyId
+      comment: $comment
+    ) {
+      reply {
+        type
+      }
+      feedbackCount
+    }
+  }
+`;
 
 export default async function askingReplyFeedback(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
 
   if (!data.selectedReplyId) {
     throw new Error('selectedReply not set in data');
+  }
+
+  if (event.input.startsWith(UPVOTE_PREFIX)) {
+    const { data: updateData, errors } = await updateFeedback(
+      {
+        articleId: data.selectedArticleId,
+        replyId: data.selectedReplyId,
+        vote: 'UPVOTE',
+        comment: event.input.slice(UPVOTE_PREFIX.length),
+      },
+      { userId }
+    );
+
+    if (errors) {
+      throw ManipulationError(t`Cannot record your feedback. Try again later?`);
+    }
+
+    const articleText = ellipsis(data.selectedArticleText, 15);
+    const replyType = createTypeWords(
+      updateData.CreateOrUpdateArticleReplyFeedback.reply.type
+    ).toLowerCase();
+    const articleUrl = getArticleURL(data.selectedArticleId);
+    const sharedText = t`Someone says the message “${articleText}” ${replyType}.\n\nPlease refer to ${articleUrl} for more information, replies and references.`;
+
+    const otherFeedbackCount =
+      updateData.CreateOrUpdateArticleReplyFeedback.feedbackCount - 1;
+    const callToAction = t`Don't forget to forward the messages above to others and share with them!`;
+
+    replies = [
+      {
+        type: 'text',
+        text:
+          otherFeedbackCount > 0
+            ? t`We've received feedback from you and ${otherFeedbackCount} other users!`
+            : t`Thanks. You're the first one who gave feedback on this reply!`,
+      },
+      {
+        type: 'flex',
+        altText: callToAction + '\n' + FLEX_MESSAGE_ALT_TEXT,
+        contents: {
+          type: 'bubble',
+          body: {
+            type: 'box',
+            layout: 'vertical',
+            spacing: 'md',
+            paddingAll: 'lg',
+            contents: [
+              {
+                type: 'text',
+                wrap: true,
+                text: callToAction,
+              },
+            ],
+          },
+          footer: {
+            type: 'box',
+            layout: 'vertical',
+            spacing: 'sm',
+            contents: [
+              {
+                type: 'button',
+                style: 'primary',
+                color: '#ffb600',
+                action: {
+                  type: 'uri',
+                  label: t`Share to friends`,
+                  uri: `https://line.me/R/msg/text/?${encodeURI(sharedText)}`,
+                },
+              },
+              {
+                type: 'button',
+                style: 'link',
+                color: '#ffb600',
+                action: {
+                  type: 'uri',
+                  label: t`Submit new reply`,
+                  uri: getArticleURL(data.selectedArticleId),
+                },
+              },
+            ],
+          },
+        },
+      },
+    ];
+  } else if (event.input.startsWith(DOWNVOTE_PREFIX)) {
+    const { data: updateData, errors } = await updateFeedback(
+      {
+        articleId: data.selectedArticleId,
+        replyId: data.selectedReplyId,
+        vote: 'DOWNVOTE',
+        comment: event.input.slice(DOWNVOTE_PREFIX.length),
+      },
+      { userId }
+    );
+
+    if (errors) {
+      throw ManipulationError(t`Cannot record your feedback. Try again later?`);
+    }
+
+    const articleUrl = getArticleURL(data.selectedArticleId);
+    const otherFeedbackCount =
+      updateData.CreateOrUpdateArticleReplyFeedback.feedbackCount - 1;
+
+    replies = [
+      {
+        type: 'text',
+        text:
+          otherFeedbackCount > 0
+            ? t`We've received feedback from you and ${otherFeedbackCount} other users!`
+            : t`Thanks. You're the first one who gave feedback on this reply!`,
+      },
+      {
+        type: 'text',
+        text: `💁 ${t`If you have a better reply, feel free to submit it to ${articleUrl} .`}`,
+      },
+    ];
+  } else {
+    throw new ManipulationError(
+      t`Please press the latest button to provide feedback to reply.`
+    );
   }
 
   const visitor = ga(userId, state, data.selectedArticleText);
@@ -19,144 +175,7 @@ export default async function askingReplyFeedback(params) {
     el: `${data.selectedArticleId}/${data.selectedReplyId}`,
   });
 
-  if (event.input === 'y') {
-    const {
-      data: {
-        action: { feedbackCount },
-      },
-    } = await gql`
-      mutation($vote: FeedbackVote!, $articleId: String!, $replyId: String!) {
-        action: CreateOrUpdateArticleReplyFeedback(
-          vote: $vote
-          articleId: $articleId
-          replyId: $replyId
-        ) {
-          feedbackCount
-        }
-      }
-    `(
-      {
-        articleId: data.selectedArticleId,
-        replyId: data.selectedReplyId,
-        vote: 'UPVOTE',
-      },
-      { userId }
-    );
-    const {
-      data: { GetReply },
-    } = await gql`
-      query($replyId: String!) {
-        GetReply(id: $replyId) {
-          type
-          text
-          reference
-        }
-      }
-    `({
-      replyId: data.selectedReplyId,
-    });
-
-    const articleUrl = getArticleURL(data.selectedArticleId);
-    let sharedText = `網路上有人說「${ellipsis(
-      data.selectedArticleText,
-      15
-    )}」 ${createTypeWords(
-      GetReply.type
-    )}喔！\n\n請至 ${articleUrl} 看看鄉親們針對這則訊息的回應、理由，與相關的出處唷！`;
-
-    replies = [
-      {
-        type: 'text',
-        text:
-          feedbackCount > 1
-            ? `感謝您與其他 ${feedbackCount - 1} 人的回饋。`
-            : '感謝您的回饋，您是第一個評論這個回應的人 :)',
-      },
-      {
-        type: 'template',
-        altText: `📲 別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！\n💁 若您認為自己能回應得更好，歡迎到 ${articleUrl} 提交新的回應唷！`,
-        template: {
-          type: 'confirm',
-          text: `📲 別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！\n💁 若您認為自己能回應得更好，歡迎提交新的回應唷！`,
-          actions: [
-            {
-              type: 'uri',
-              label: '分享給朋友',
-              uri: `line://msg/text/?${encodeURI(sharedText)}`,
-            },
-            {
-              type: 'uri',
-              label: '提交新回應',
-              uri: getArticleURL(data.selectedArticleId),
-            },
-          ],
-        },
-      },
-    ];
-
-    visitor.send();
-    state = '__INIT__';
-  } else if (event.input.startsWith(DOWNVOTE_PREFIX)) {
-    const comment = event.input.slice(DOWNVOTE_PREFIX.length);
-    const {
-      data: {
-        action: { feedbackCount },
-      },
-    } = await gql`
-      mutation(
-        $comment: String!
-        $vote: FeedbackVote!
-        $articleId: String!
-        $replyId: String!
-      ) {
-        action: CreateOrUpdateArticleReplyFeedback(
-          comment: $comment
-          articleId: $articleId
-          replyId: $replyId
-          vote: $vote
-        ) {
-          feedbackCount
-        }
-      }
-    `(
-      {
-        articleId: data.selectedArticleId,
-        replyId: data.selectedReplyId,
-        comment,
-        vote: 'DOWNVOTE',
-      },
-      { userId }
-    );
-
-    replies = [
-      {
-        type: 'text',
-        text:
-          feedbackCount > 1
-            ? `感謝您與其他 ${feedbackCount - 1} 人的回饋。`
-            : '感謝您的回饋，您是第一個評論這個回應的人 :)',
-      },
-      {
-        type: 'text',
-        text: `💁 若您認為自己能回應得更好，歡迎到 ${getArticleURL(
-          data.selectedArticleId
-        )} 提交新的回應唷！`,
-      },
-    ];
-
-    visitor.send();
-    state = '__INIT__';
-  } else {
-    replies = [
-      {
-        type: 'text',
-        text:
-          '請點擊上面的「是」、「否」對回應表達意見，或改轉傳其他訊息給我查詢。',
-      },
-    ];
-
-    // Don't do visitor.send() nor change state here because user did not respond yet
-  }
+  visitor.send();
 
   return { data, state, event, issuedAt, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/askingReplyFeedback.js
+++ b/src/webhook/handlers/askingReplyFeedback.js
@@ -41,7 +41,9 @@ async function updateFeedback(variables, search) {
   `(variables, search);
 
   if (errors) {
-    throw ManipulationError(t`Cannot record your feedback. Try again later?`);
+    throw new ManipulationError(
+      t`Cannot record your feedback. Try again later?`
+    );
   }
 
   return data.CreateOrUpdateArticleReplyFeedback;

--- a/src/webhook/handlers/askingReplyFeedback.js
+++ b/src/webhook/handlers/askingReplyFeedback.js
@@ -122,7 +122,7 @@ export default async function askingReplyFeedback(params) {
                 color: '#ffb600',
                 action: {
                   type: 'uri',
-                  label: t`Submit new reply`,
+                  label: t`See reported message`,
                   uri: getArticleURL(data.selectedArticleId),
                 },
               },

--- a/src/webhook/handlers/choosingReply.js
+++ b/src/webhook/handlers/choosingReply.js
@@ -20,9 +20,7 @@ export default async function choosingReply(params) {
 
   const selectedReplyId = (data.selectedReplyId = event.input);
 
-  const {
-    data: { GetReply, GetArticle },
-  } = await gql`
+  const { data: getReplyData, errors } = await gql`
     query GetReplyRelatedData($id: String!, $articleId: String!) {
       GetReply(id: $id) {
         type
@@ -35,6 +33,14 @@ export default async function choosingReply(params) {
       }
     }
   `({ id: selectedReplyId, articleId: data.selectedArticleId });
+
+  if (errors) {
+    throw new ManipulationError(
+      t`We have problem retrieving message and reply data, please forward the message again`
+    );
+  }
+
+  const { GetReply, GetArticle } = getReplyData;
 
   const articleUrl = getArticleURL(data.selectedArticleId);
   const typeStr = createTypeWords(GetReply.type).toLocaleLowerCase();

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -111,7 +111,9 @@ export function getLIFFURL(page, userId, sessionId) {
   return `${process.env.LIFF_URL}?p=${page}&token=${jwt}`;
 }
 
-export const FLEX_MESSAGE_ALT_TEXT = `📱 ${t`Please proceed on your mobile phone.`}`;
+export const FLEX_MESSAGE_ALT_TEXT = `📱 ${
+  /* t: Flex message alt-text */ t`Please proceed on your mobile phone.`
+}`;
 
 /**
  * @param {string} userId - LINE user ID

--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -99,6 +99,17 @@ const singleUserHandler = async (
       //
       if (data.sessionId !== context.data.sessionId) {
         console.log('Previous button pressed.');
+        lineClient('/message/reply', {
+          replyToken,
+          messages: [
+            {
+              type: 'text',
+              text:
+                '🚧 ' +
+                t`You are currently searching for another message, buttons from previous search sessions do not work now.`,
+            },
+          ],
+        });
         clearTimeout(timerId);
         return;
       }
@@ -237,7 +248,7 @@ async function processText(context, type, input, otherFields, userId, req) {
       replies: [
         {
           type: 'text',
-          text: t`Oops, something is not working. Would you please send that again?`,
+          text: t`Oops, something is not working. We have cleared your search data, hopefully the error will go away. Would you please send us the message from the start?`,
         },
       ],
     };


### PR DESCRIPTION
This PR displays a single reply and collects feedback from user.

# What's covered
![skAdT290hqMGZQAHIK3QRvQ](https://user-images.githubusercontent.com/108608/80211453-5cced100-8668-11ea-9ccf-7543ab62bfe2.png)

- implements `choosingReply` and `askingReplyFeedback` handler
- `askingReplyFeedback` no longer returns to `__INIT__`. This allows users to edit their feedback by entering LIFF and submit new feedback again and again.
- Refactor: Make exceptions like "previous buttons" and "error occurred (exception)" more readable.

# What's not covered
LIFF implementation. The flow is tested by manually inputting `prefix` + `option` on LINE, mimicking user interaction in LIFF.

# Screenshot

![image](https://user-images.githubusercontent.com/108608/80212174-97853900-8669-11ea-8f7c-f7efe1e972ad.png)
![image](https://user-images.githubusercontent.com/108608/80212222-aff55380-8669-11ea-8175-c8180ac4e311.png)


## Previous button error

Previously the chatbot will not do anything in this case. Since we are setting `displayText` for postback buttons, I think we should reply something instead:
![image](https://user-images.githubusercontent.com/108608/80211969-3e1d0a00-8669-11ea-8e81-4a18d012d5b9.png)

## Error occurred / exception message

We added a message here to hint the user that we cleared search context.
![image](https://user-images.githubusercontent.com/108608/80211937-3198b180-8669-11ea-8766-87a441572a2c.png)

