### PR TITLE
Put reason response & share response in parallel

### DIFF
--- a/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
@@ -92,90 +92,91 @@ A LINE group",
     Object {
       "altText": "Your submission is now recorded at https://cofacts.hacktabl.org/article/new-article-id",
       "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Your submission is now recorded at https://cofacts.hacktabl.org/article/new-article-id",
-              "type": "text",
-              "wrap": true,
+        "contents": Array [
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Your submission is now recorded at https://cofacts.hacktabl.org/article/new-article-id",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "See reported message",
-                "type": "uri",
-                "uri": "https://cofacts.hacktabl.org/article/new-article-id",
-              },
-              "color": "#333333",
-              "style": "primary",
-              "type": "button",
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "See reported message",
+                    "type": "uri",
+                    "uri": "https://cofacts.hacktabl.org/article/new-article-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Provide more info",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-            Object {
-              "action": Object {
-                "label": "Provide more info",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
-      },
-      "type": "flex",
-    },
-    Object {
-      "altText": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-      "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-              "type": "text",
-              "wrap": true,
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share on LINE",
+                    "type": "uri",
+                    "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fnew-article-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Share on Facebook",
+                    "type": "uri",
+                    "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fnew-article-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "Share on LINE",
-                "type": "uri",
-                "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fnew-article-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-            Object {
-              "action": Object {
-                "label": "Share on Facebook",
-                "type": "uri",
-                "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fnew-article-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
+            "type": "bubble",
+          },
+        ],
+        "type": "carousel",
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/__snapshots__/askingReplyRequestReason.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingReplyRequestReason.test.js.snap
@@ -15,90 +15,91 @@ A LINE group",
     Object {
       "altText": "Thanks for the info.",
       "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Thanks for the info.",
-              "type": "text",
-              "wrap": true,
+        "contents": Array [
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Thanks for the info.",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "See reported message",
-                "type": "uri",
-                "uri": "https://cofacts.hacktabl.org/article/selected-article-id",
-              },
-              "color": "#333333",
-              "style": "primary",
-              "type": "button",
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "See reported message",
+                    "type": "uri",
+                    "uri": "https://cofacts.hacktabl.org/article/selected-article-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Provide more info",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-            Object {
-              "action": Object {
-                "label": "Provide more info",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Nzc5MjMyMDB9.zfrE2uvmsu7mPH23-TZ5L_mfjiNEeiX-x5Md4Lvsk7I",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
-      },
-      "type": "flex",
-    },
-    Object {
-      "altText": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-      "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-              "type": "text",
-              "wrap": true,
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share on LINE",
+                    "type": "uri",
+                    "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fselected-article-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Share on Facebook",
+                    "type": "uri",
+                    "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fselected-article-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "Share on LINE",
-                "type": "uri",
-                "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fselected-article-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-            Object {
-              "action": Object {
-                "label": "Share on Facebook",
-                "type": "uri",
-                "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Fselected-article-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
+            "type": "bubble",
+          },
+        ],
+        "type": "carousel",
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -333,95 +333,96 @@ My reason",
     Object {
       "altText": "Thanks for the info you provided.",
       "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Thanks for the info you provided.",
-              "type": "text",
-              "wrap": true,
+        "contents": Array [
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-            Object {
-              "text": "There is 1 user also waiting for clarification.",
-              "type": "text",
-              "wrap": true,
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share on LINE",
+                    "type": "uri",
+                    "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Share on Facebook",
+                    "type": "uri",
+                    "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "See reported message",
-                "type": "uri",
-                "uri": "https://cofacts.hacktabl.org/article/article-id",
-              },
-              "color": "#333333",
-              "style": "primary",
-              "type": "button",
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Thanks for the info you provided.",
+                  "type": "text",
+                  "wrap": true,
+                },
+                Object {
+                  "text": "There is 1 user also waiting for clarification.",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-            Object {
-              "action": Object {
-                "label": "Provide more info",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE0OTc5OTQwMTc0NDcsInN1YiI6IlVjNzZkOGFlOWNjZDFhZGE0ZjA2YzRlMTUxNWQ0NjQ2NiIsImV4cCI6MTU3NzkyMzIwMH0.V4OTSDA0wDDrlc665JRyjkC0Ux3RFqUM-RN_VNKNCcs",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "See reported message",
+                    "type": "uri",
+                    "uri": "https://cofacts.hacktabl.org/article/article-id",
+                  },
+                  "color": "#333333",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Rewrite my reason",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE0OTc5OTQwMTc0NDcsInN1YiI6IlVjNzZkOGFlOWNjZDFhZGE0ZjA2YzRlMTUxNWQ0NjQ2NiIsImV4cCI6MTU3NzkyMzIwMH0.V4OTSDA0wDDrlc665JRyjkC0Ux3RFqUM-RN_VNKNCcs",
+                  },
+                  "color": "#333333",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
-      },
-      "type": "flex",
-    },
-    Object {
-      "altText": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-      "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-              "type": "text",
-              "wrap": true,
-            },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "Share on LINE",
-                "type": "uri",
-                "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-            Object {
-              "action": Object {
-                "label": "Share on Facebook",
-                "type": "uri",
-                "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
+            "type": "bubble",
+          },
+        ],
+        "type": "carousel",
       },
       "type": "flex",
     },
@@ -448,90 +449,91 @@ My reason",
     Object {
       "altText": "Thanks for the info you provided.",
       "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Thanks for the info you provided.",
-              "type": "text",
-              "wrap": true,
+        "contents": Array [
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "See reported message",
-                "type": "uri",
-                "uri": "https://cofacts.hacktabl.org/article/article-id",
-              },
-              "color": "#333333",
-              "style": "primary",
-              "type": "button",
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share on LINE",
+                    "type": "uri",
+                    "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Share on Facebook",
+                    "type": "uri",
+                    "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-            Object {
-              "action": Object {
-                "label": "Provide more info",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE0OTc5OTQwMTc0NDcsInN1YiI6IlVjNzZkOGFlOWNjZDFhZGE0ZjA2YzRlMTUxNWQ0NjQ2NiIsImV4cCI6MTU3NzkyMzIwMH0.V4OTSDA0wDDrlc665JRyjkC0Ux3RFqUM-RN_VNKNCcs",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Thanks for the info you provided.",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
-      },
-      "type": "flex",
-    },
-    Object {
-      "altText": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-      "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
-              "type": "text",
-              "wrap": true,
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "See reported message",
+                    "type": "uri",
+                    "uri": "https://cofacts.hacktabl.org/article/article-id",
+                  },
+                  "color": "#333333",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Rewrite my reason",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW/liff/index.html?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE0OTc5OTQwMTc0NDcsInN1YiI6IlVjNzZkOGFlOWNjZDFhZGE0ZjA2YzRlMTUxNWQ0NjQ2NiIsImV4cCI6MTU3NzkyMzIwMH0.V4OTSDA0wDDrlc665JRyjkC0Ux3RFqUM-RN_VNKNCcs",
+                  },
+                  "color": "#333333",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
             },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "Share on LINE",
-                "type": "uri",
-                "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-            Object {
-              "action": Object {
-                "label": "Share on Facebook",
-                "type": "uri",
-                "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2Farticle-id",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "type": "bubble",
+            "type": "bubble",
+          },
+        ],
+        "type": "carousel",
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/utils.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createArticleShareReply() should uri size less then 1000 1`] = `"line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2FAWDZYXxAyCdS-nWhumlz"`;
+exports[`createArticleShareBubble() should uri size less then 1000 1`] = `"line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2FAWDZYXxAyCdS-nWhumlz"`;
 
-exports[`createArticleShareReply() should uri size less then 1000 2`] = `"https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2FAWDZYXxAyCdS-nWhumlz"`;
+exports[`createArticleShareBubble() should uri size less then 1000 2`] = `"https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fcofacts.hacktabl.org%2Farticle%2FAWDZYXxAyCdS-nWhumlz"`;
 
 exports[`createFeedbackWords() should create both feedback words 1`] = `
 "👍 1 user considers this helpful

--- a/src/webhook/handlers/__tests__/utils.test.js
+++ b/src/webhook/handlers/__tests__/utils.test.js
@@ -3,18 +3,18 @@ import {
   createFeedbackWords,
   createReferenceWords,
   ellipsis,
-  createArticleShareReply,
+  createArticleShareBubble,
   createFlexMessageText,
   createTypeWords,
 } from '../utils';
 
-describe('createArticleShareReply()', () => {
+describe('createArticleShareBubble()', () => {
   it('should uri size less then 1000', () => {
     const articleUrl =
       'https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz';
 
-    const result = createArticleShareReply(articleUrl);
-    result.contents.footer.contents.forEach(({ action }) => {
+    const result = createArticleShareBubble(articleUrl);
+    result.footer.contents.forEach(({ action }) => {
       expect(action.uri.length).toBeLessThan(1000);
       expect(action.uri).toMatchSnapshot();
     });

--- a/src/webhook/handlers/askingArticleSubmissionConsent.js
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.js
@@ -4,7 +4,7 @@ import gql from 'src/lib/gql';
 import { SOURCE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
 import {
   ManipulationError,
-  createArticleShareReply,
+  createArticleShareBubble,
   createSuggestOtherFactCheckerReply,
   getArticleSourceOptionFromLabel,
   createReasonButtonFooter,
@@ -68,22 +68,31 @@ export default async function askingArticleSubmissionConsent(params) {
         type: 'flex',
         altText: articleCreatedMsg,
         contents: {
-          type: 'bubble',
-          body: {
-            type: 'box',
-            layout: 'vertical',
-            contents: [
-              {
-                type: 'text',
-                wrap: true,
-                text: articleCreatedMsg,
+          type: 'carousel',
+          contents: [
+            {
+              type: 'bubble',
+              body: {
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'text',
+                    wrap: true,
+                    text: articleCreatedMsg,
+                  },
+                ],
               },
-            ],
-          },
-          footer: createReasonButtonFooter(articleUrl, userId, data.sessionId),
+              footer: createReasonButtonFooter(
+                articleUrl,
+                userId,
+                data.sessionId
+              ),
+            },
+            createArticleShareBubble(articleUrl),
+          ],
         },
       },
-      createArticleShareReply(articleUrl),
     ];
 
     // Record article ID in context for reason LIFF

--- a/src/webhook/handlers/askingReplyRequestReason.js
+++ b/src/webhook/handlers/askingReplyRequestReason.js
@@ -3,7 +3,7 @@ import ga from 'src/lib/ga';
 import { getArticleURL, SOURCE_PREFIX } from 'src/lib/sharedUtils';
 import {
   ManipulationError,
-  createArticleShareReply,
+  createArticleShareBubble,
   getArticleSourceOptionFromLabel,
   createReasonButtonFooter,
 } from './utils';
@@ -43,22 +43,31 @@ export default async function askingReplyRequestSubmission(params) {
       type: 'flex',
       altText: sourceRecordedMsg,
       contents: {
-        type: 'bubble',
-        body: {
-          type: 'box',
-          layout: 'vertical',
-          contents: [
-            {
-              type: 'text',
-              wrap: true,
-              text: sourceRecordedMsg,
+        type: 'carousel',
+        contents: [
+          {
+            type: 'bubble',
+            body: {
+              type: 'box',
+              layout: 'vertical',
+              contents: [
+                {
+                  type: 'text',
+                  wrap: true,
+                  text: sourceRecordedMsg,
+                },
+              ],
             },
-          ],
-        },
-        footer: createReasonButtonFooter(articleUrl, userId, data.sessionId),
+            footer: createReasonButtonFooter(
+              articleUrl,
+              userId,
+              data.sessionId
+            ),
+          },
+          createArticleShareBubble(articleUrl),
+        ],
       },
     },
-    createArticleShareReply(articleUrl),
   ];
   state = '__INIT__';
   visitor.send();

--- a/src/webhook/handlers/initState.js
+++ b/src/webhook/handlers/initState.js
@@ -10,7 +10,7 @@ import {
   createSuggestOtherFactCheckerReply,
   POSTBACK_NO_ARTICLE_FOUND,
   createReasonButtonFooter,
-  createArticleShareReply,
+  createArticleShareBubble,
 } from './utils';
 import ga from 'src/lib/ga';
 
@@ -70,31 +70,41 @@ export default async function initState(params) {
         type: 'flex',
         altText: replyRequestUpdatedMsg,
         contents: {
-          type: 'bubble',
-          body: {
-            type: 'box',
-            layout: 'vertical',
-            contents: [
-              {
-                type: 'text',
-                wrap: true,
-                text: replyRequestUpdatedMsg,
+          type: 'carousel',
+          contents: [
+            createArticleShareBubble(articleUrl),
+            {
+              type: 'bubble',
+              body: {
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'text',
+                    wrap: true,
+                    text: replyRequestUpdatedMsg,
+                  },
+                  otherReplyRequestCount > 0 && {
+                    type: 'text',
+                    wrap: true,
+                    text: ngettext(
+                      msgid`There is ${otherReplyRequestCount} user also waiting for clarification.`,
+                      `There are ${otherReplyRequestCount} users also waiting for clarification.`,
+                      otherReplyRequestCount
+                    ),
+                  },
+                ].filter(m => m),
               },
-              otherReplyRequestCount > 0 && {
-                type: 'text',
-                wrap: true,
-                text: ngettext(
-                  msgid`There is ${otherReplyRequestCount} user also waiting for clarification.`,
-                  `There are ${otherReplyRequestCount} users also waiting for clarification.`,
-                  otherReplyRequestCount
-                ),
-              },
-            ].filter(m => m),
-          },
-          footer: createReasonButtonFooter(articleUrl, userId, data.sessionId),
+              footer: createReasonButtonFooter(
+                articleUrl,
+                userId,
+                data.sessionId,
+                true
+              ),
+            },
+          ],
         },
       },
-      createArticleShareReply(articleUrl),
     ];
     visitor.send();
 

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -233,58 +233,52 @@ export function ellipsis(text, limit, ellipsis = '⋯⋯') {
  * @param {string} reason
  * @returns {object} Reply object with sharing buttings
  */
-export function createArticleShareReply(articleUrl) {
-  const text = t`Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!`;
-
+export function createArticleShareBubble(articleUrl) {
   return {
-    type: 'flex',
-    altText: text,
-    contents: {
-      type: 'bubble',
-      body: {
-        type: 'box',
-        layout: 'vertical',
-        contents: [
-          {
-            type: 'text',
-            wrap: true,
-            text,
+    type: 'bubble',
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      contents: [
+        {
+          type: 'text',
+          wrap: true,
+          text: t`Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!`,
+        },
+      ],
+    },
+    footer: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'sm',
+      contents: [
+        {
+          type: 'button',
+          action: {
+            type: 'uri',
+            label: t`Share on LINE`,
+            uri: `line://msg/text/?${encodeURIComponent(
+              t`Please help me verify if this is true: ${articleUrl}`
+            )}`,
           },
-        ],
-      },
-      footer: {
-        type: 'box',
-        layout: 'vertical',
-        spacing: 'sm',
-        contents: [
-          {
-            type: 'button',
-            action: {
-              type: 'uri',
-              label: t`Share on LINE`,
-              uri: `line://msg/text/?${encodeURIComponent(
-                t`Please help me verify if this is true: ${articleUrl}`
-              )}`,
-            },
-            style: 'primary',
-            color: '#ffb600',
+          style: 'primary',
+          color: '#ffb600',
+        },
+        {
+          type: 'button',
+          action: {
+            type: 'uri',
+            label: t`Share on Facebook`,
+            uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=${
+              process.env.FACEBOOK_APP_ID
+            }&display=popup&hashtag=${encodeURIComponent(
+              `#${/* t: Facebook hash tag */ t`ReportedToCofacts`}`
+            )}&href=${encodeURIComponent(articleUrl)}`,
           },
-          {
-            type: 'button',
-            action: {
-              type: 'uri',
-              label: t`Share on Facebook`,
-              uri: `https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=${
-                process.env.FACEBOOK_APP_ID
-              }&display=popup&hashtag=${encodeURIComponent(
-                `#${/* t: Facebook hash tag */ t`ReportedToCofacts`}`
-              )}&href=${encodeURIComponent(articleUrl)}`,
-            },
-            style: 'primary',
-            color: '#ffb600',
-          },
-        ],
-      },
+          style: 'primary',
+          color: '#ffb600',
+        },
+      ],
     },
   };
 }
@@ -382,9 +376,18 @@ export function createSuggestOtherFactCheckerReply() {
  * @param {string} articleUrl
  * @param {string} userId
  * @param {string} sessionId
+ * @param {boolean} isUpdating
  * @returns {object} Flex bubble message's footer object
  */
-export function createReasonButtonFooter(articleUrl, userId, sessionId) {
+export function createReasonButtonFooter(
+  articleUrl,
+  userId,
+  sessionId,
+  isUpdating = false
+) {
+  // Updating is not call-to-action, use normal gray
+  const color = isUpdating ? '#333333' : '#ffb600';
+
   return {
     type: 'box',
     layout: 'vertical',
@@ -398,17 +401,17 @@ export function createReasonButtonFooter(articleUrl, userId, sessionId) {
           uri: articleUrl,
         },
         style: 'primary',
-        color: '#333333',
+        color,
       },
       {
         type: 'button',
         action: {
           type: 'uri',
-          label: t`Provide more info`,
+          label: isUpdating ? t`Rewrite my reason` : t`Provide more info`,
           uri: getLIFFURL('reason', userId, sessionId),
         },
         style: 'primary',
-        color: '#ffb600',
+        color,
       },
     ],
   };


### PR DESCRIPTION
As discussed in https://g0v.hackmd.io/@mrorz/BksBf58KI#%E9%80%81%E5%87%BA-source-%E8%88%87-reason-%E5%BE%8C%E7%9A%84%E8%A8%8A%E6%81%AF%E9%87%8D%E8%A4%87%E5%95%8F%E9%A1%8C

And slack:
![](https://s3-ap-northeast-1.amazonaws.com/g0v-hackmd-images/uploads/upload_44bbc4718c130674369e6d9c88a456f8.png)


This PR turns the 2 bubbles after LIFF response into carousel to make it more compact, hopefully the message will not overwhelm the user.

![image](https://user-images.githubusercontent.com/108608/81098815-790e2000-8f3c-11ea-8c1d-d2917421ab65.png)

Note that
- In response to source (first carousel), both bubble are all call-to-actions (we want user to both provide more info and share)
- In response to reason (2nd carousel), not many people updates their own reason, thus use gray color instead; also, the update bubble is moved to the right (2nd bubble).