### PR TITLE
Defer isInClient() call

### DIFF
--- a/src/liff/index.js
+++ b/src/liff/index.js
@@ -5,23 +5,23 @@ import { t } from 'ttag';
 import { isDuringLiffRedirect } from './lib';
 import App from './App.svelte';
 
-// Commenting this secion out during LIFF development to enable debugging on desktop
-// (Can do everything except liff.sendMessage)
-//
-if (!liff.isInClient()) {
-  alert(
-    t`Sorry, the function is not applicable on desktop.` +
-      '\n' +
-      t`Please proceed on your mobile phone.` +
-      ' 📲 '
-  );
-  liff.closeWindow();
-}
-
 liff.init({ liffId: LIFF_ID }).then(() => {
   // liff.init should have corrected the path now, don't initialize app and just wait...
   // Ref: https://www.facebook.com/groups/linebot/permalink/2380490388948200/?comment_id=2380868955577010
   if (isDuringLiffRedirect) return;
+
+  // Commenting this secion out during LIFF development to enable debugging on desktop
+  // (Can do everything except liff.sendMessage)
+  //
+  if (!liff.isInClient()) {
+    alert(
+      t`Sorry, the function is not applicable on desktop.` +
+        '\n' +
+        t`Please proceed on your mobile phone.` +
+        ' 📲 '
+    );
+    liff.closeWindow();
+  }
 
   // Cleanup loading
   document.getElementById('loading').remove();


### PR DESCRIPTION
Currently, iOS will show this when opening LIFF
![image](https://user-images.githubusercontent.com/108608/82446442-3cfcc280-9ad9-11ea-9b97-a217cdcddca6.png)

Related discussion:
https://g0v-tw.slack.com/archives/C2PPMRQGP/p1583323511054400

This PR avoids this condition by moving `isInClient` API call to after `liff.init()`.

Note: the ["open links in Safari"](https://today.line.me/tw/article/%E6%96%B0%E5%A2%9E%EF%BC%8F+iOS%E7%89%88LINE+%E6%8F%90%E4%BE%9B%E7%94%A8Safari%E9%96%8B%E5%95%9F%E9%80%A3%E7%B5%90%E7%9A%84%E5%AF%A6%E9%A9%97%E5%8A%9F%E8%83%BD-nm9m0D) toggle in iOS LINE does not matter. It seems that LIFFs are always opened in built-in browsers regardless of the toggle.