### PR TITLE
Enable URL token related check only in search session related pages

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -57,3 +57,6 @@ JWT_SECRET=secret
 
 # MONGODB
 MONGODB_URI=mongodb://root:root-test-password@localhost:27017
+
+# Uncomment this to bypass in-client check in LIFF, enable debugging on extenral browsers
+# DEBUG_LIFF=1

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Other customizable env vars are:
 * `GOOGLE_CREDENTIALS`: will be populated by `authGoogleDrive.js`. See "Upload image/video" section below.
 * `GA_ID`: Google analytics universal analytics tracking ID, for tracking events
 * `IMAGE_MESSAGE_ENABLED`: Default disabled. To enable, please see "Process image message" section below.
+* `DEBUG_LIFF`: Disables external browser check in LIFF. Useful when debugging LIFF in external browser. Don't enable this on production.
 
 ### Redis server
 

--- a/src/liff/.eslintrc.js
+++ b/src/liff/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
 
     // Define plugin
     LIFF_ID: 'readonly',
+    DEBUG_LIFF: 'readonly',
   }
 };

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -1,7 +1,5 @@
 <script>
-  import { onMount } from 'svelte';
-  import { t } from 'ttag';
-  import { page, parsedToken, gql } from './lib';
+  import { page } from './lib';
   import Source from './pages/Source.svelte';
   import Reason from './pages/Reason.svelte';
   import PositiveFeedback from './pages/PositiveFeedback.svelte';
@@ -13,47 +11,6 @@
     'feedback/yes': PositiveFeedback,
     'feedback/no': NegativeFeedback,
   };
-
-  const expired = parsedToken && (
-    (parsedToken.exp || -Infinity) < Date.now() / 1000
-  );
-
-  // Chatbot context of current user
-  let context = null;
-
-  onMount(async () => {
-    if(expired) return;
-
-    const {data, errors} = await gql`
-      query GetContextForLIFF {
-        context {
-          state
-          data {
-            sessionId
-            searchedText
-            selectedArticleText
-          }
-        }
-      }
-    `();
-
-    if(errors && errors[0].message === 'Invalid authentication header') {
-      alert(t`This button was for previous search and is now expired.`);
-      liff.closeWindow();
-      return;
-    }
-
-    if(!data || !data.context) {
-      alert(/* t: In LIFF, should not happen */ t`Unexpected error, no search data is retrieved.`);
-      returnl;
-    }
-
-    context = data.context;
-  })
 </script>
 
-{#if expired}
-  <p>{t`Sorry, the button is expired.`}</p>
-{:else}
-  <svelte:component this={routes[$page]} {context} />
-{/if}
+<svelte:component this={routes[$page]} />

--- a/src/liff/index.js
+++ b/src/liff/index.js
@@ -9,14 +9,16 @@ liff.init({ liffId: LIFF_ID }).then(() => {
   // Ref: https://www.facebook.com/groups/linebot/permalink/2380490388948200/?comment_id=2380868955577010
   if (isDuringLiffRedirect) return;
 
+  document.getElementById('loading').remove(); // Cleanup loading
+
+  // Kickstart app loading; fire assertions
+  new App({ target: document.body });
+
+  // For devs (and users on LINE desktop, which is rare)
   if (!liff.isLoggedIn()) {
     liff.login({
       // https://github.com/line/line-liff-v2-starter/issues/4
-      redirectUri: `${location.href}${location.search}`,
+      redirectUri: location.href,
     });
   }
-
-  // Cleanup loading
-  document.getElementById('loading').remove();
-  new App({ target: document.body });
 });

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -81,6 +81,9 @@ export const gql = (query, ...substitutions) => variables => {
  * such as invoking `liff.sendMessage()`.
  */
 export const assertInClient = () => {
+  // To develop on browser, you may want to skip the logic by uncommenting the line below:
+  // return;
+
   if (!liff.isInClient()) {
     alert(
       t`Sorry, the function is not applicable on desktop.` +

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -81,8 +81,9 @@ export const gql = (query, ...substitutions) => variables => {
  * such as invoking `liff.sendMessage()`.
  */
 export const assertInClient = () => {
-  // To develop on browser, you may want to skip the logic by uncommenting the line below:
-  // return;
+  if (DEBUG_LIFF) {
+    return;
+  }
 
   if (!liff.isInClient()) {
     alert(

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -17,17 +17,7 @@ export const page = writable(params.get('p'));
 /**
  * Original JWT token from URL param.
  */
-export const urlToken = params.get('token');
-
-/**
- * Data parsed from JWT token (Javascript object).
- *
- * Note: the JWT token is taken from URL and is not validated, thus its data cannot be considered as
- * safe from XSS.
- */
-export const parsedToken = urlToken
-  ? JSON.parse(atob(urlToken.split('.')[1]))
-  : null;
+const urlToken = params.get('token');
 
 /**
  * Usage: gql`query {...}`(variables)
@@ -99,5 +89,58 @@ export const assertInClient = () => {
         ' 📲 '
     );
     liff.closeWindow();
+  }
+};
+
+/**
+ * Checks if still in the same search session.
+ * This checks URL token for expiracy and try retrieving sessionId from GraphQL server.
+ *
+ * Closes LIFF when GraphQL server rejects.
+ */
+export const assertSameSearchSession = async () => {
+  if (!urlToken) {
+    alert(t`Cannot get token from URL`);
+    liff.closeWindow();
+    return;
+  }
+
+  const parsedToken = urlToken
+    ? JSON.parse(atob(urlToken.split('.')[1]))
+    : null;
+
+  if ((parsedToken.exp || -Infinity) < Date.now() / 1000) {
+    alert(t`Sorry, the button is expired.`);
+    liff.closeWindow();
+    return;
+  }
+
+  const { data, errors } = await gql`
+    query CheckSessionId {
+      context {
+        data {
+          sessionId
+        }
+      }
+    }
+  `();
+
+  if (errors && errors[0].message === 'Invalid authentication header') {
+    alert(t`This button was for previous search and is now expired.`);
+    liff.closeWindow();
+    return;
+  }
+
+  if (
+    !data ||
+    !data.context ||
+    !data.context.data ||
+    !data.context.data.sessionId
+  ) {
+    alert(
+      /* t: In LIFF, should not happen */ t`Unexpected error, no search session data is retrieved.`
+    );
+    liff.closeWindow();
+    return;
   }
 };

--- a/src/liff/pages/NegativeFeedback.svelte
+++ b/src/liff/pages/NegativeFeedback.svelte
@@ -4,19 +4,20 @@
   import Button, { Label } from '@smui/button';
   import Textfield, { Input, Textarea } from '@smui/textfield';
   import { DOWNVOTE_PREFIX } from 'src/lib/sharedUtils';
-  import { gql, assertInClient } from '../lib';
+  import { gql, assertInClient, assertSameSearchSession } from '../lib';
 
   let processing = false;
   let comment = '';
 
   // Submitting feedback without comment first
-  onMount(() => {
+  onMount(async () => {
     assertInClient();
+    await assertSameSearchSession();
     gql`
-    mutation VoteDown {
-      voteReply(vote: DOWNVOTE)
-    }
-  `()
+      mutation VoteDown {
+        voteReply(vote: DOWNVOTE)
+      }
+    `();
   });
 
   const handleSubmit = async () => {

--- a/src/liff/pages/PositiveFeedback.svelte
+++ b/src/liff/pages/PositiveFeedback.svelte
@@ -4,19 +4,20 @@
   import Button, { Label } from '@smui/button';
   import Textfield, { Input, Textarea } from '@smui/textfield';
   import { UPVOTE_PREFIX } from 'src/lib/sharedUtils';
-  import { gql, assertInClient } from '../lib';
+  import { gql, assertInClient, assertSameSearchSession } from '../lib';
 
   let processing = false;
   let comment = '';
 
   // Submitting feedback without comment first
-  onMount(() => {
+  onMount(async () => {
     assertInClient();
+    await assertSameSearchSession();
     gql`
-    mutation VoteUp {
-      voteReply(vote: UPVOTE)
-    }
-  `()
+      mutation VoteUp {
+        voteReply(vote: UPVOTE)
+      }
+    `();
   });
 
   const handleSubmit = async () => {

--- a/src/liff/pages/Reason.svelte
+++ b/src/liff/pages/Reason.svelte
@@ -5,7 +5,7 @@
   import Textfield, { Input, Textarea } from '@smui/textfield';
   import HelperText from '@smui/textfield/helper-text/index';
   import { REASON_PREFIX } from 'src/lib/sharedUtils';
-  import { assertInClient, assertSameSearchSession } from '../lib';
+  import { gql, assertInClient, assertSameSearchSession } from '../lib';
 
   const SUFFICIENT_REASON_LENGTH = 40;
   const LENGHEN_HINT = /* t: Guidance in LIFF */ t`
@@ -49,11 +49,11 @@ ${LENGHEN_HINT}`
       return;
     }
 
-    searchedText = data.context.data.searchedText;
+    searchedText = data.context.data.searchedText.trim();
   });
 
   const handleSubmit = async () => {
-    if(context && context.data.searchedText.trim() === reason.trim()) {
+    if(searchedText === reason.trim()) {
       alert(DUP_SUGGESTION);
       return;
     }

--- a/src/liff/pages/Source.svelte
+++ b/src/liff/pages/Source.svelte
@@ -8,9 +8,9 @@
   import { assertInClient, assertSameSearchSession } from '../lib';
 
   let processing = false;
-  onMount(() => {
+  onMount(async () => {
     assertInClient();
-    assertSameSearchSession();
+    await assertSameSearchSession();
   });
   const handleClick = async ({label, valid}) => {
     processing = true;

--- a/src/liff/pages/Source.svelte
+++ b/src/liff/pages/Source.svelte
@@ -5,11 +5,12 @@
 
   import { page } from '../lib';
   import { ARTICLE_SOURCE_OPTIONS, SOURCE_PREFIX } from 'src/lib/sharedUtils';
-  import { assertInClient } from '../lib';
+  import { assertInClient, assertSameSearchSession } from '../lib';
 
   let processing = false;
   onMount(() => {
     assertInClient();
+    assertSameSearchSession();
   });
   const handleClick = async ({label, valid}) => {
     processing = true;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,6 +128,7 @@ module.exports = {
       LIFF_ID: JSON.stringify(
         (process.env.LIFF_URL || '').replace('https://liff.line.me/', '')
       ),
+      DEBUG_LIFF: process.env.DEBUG_LIFF,
     }),
   ],
   devtool: prod ? false : 'source-map',


### PR DESCRIPTION
Previously, `App.svelte` performs URL token expire check and tries getting context from API. However, this check does not make sense in "user setting" page and "previous searched article" page.

This PR moves the check `assertSameSearchSession` function and only invokes them in search related LIFF pages.

Note: It may seem tempting to merge `assertSameSession()` with `assertInClient()`. However, in "previous searched article" page that I am going to implement next, it requires `assertInClinet()` but not `assertSameSession()`. Thus I decided to separate the session check in a separate method.

## Refactor
- Moves URL token checking logic to `assertSameSession()`. 
- No need to expose token in `liff/lib` now.
- App.svelte now just serves as a simple router page.

Other fixes include:
- Move `new App` initialization to before `liff.login` so that LINE login don't interrupt assertion checks, which may close down the LIFF.
- Fix LINE login redirect URI: `location.href` already includes `location.search`. Repeating `location.search` will result in incorrect url token.