### PR TITLE
Add google analytics to LIFF

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,8 @@
 LINE_CHANNEL_SECRET=
 LINE_CHANNEL_TOKEN=
 
-# From LINE LOGIN developer console, use for external browser liff login
+# From LINE LOGIN developer console, used to identify ID token from LIFF.
+# This LINE Login channel should be under the same provider as LIFF (LIFF_URL)
 LINE_LOGIN_CHANNEL_ID=
 
 # Redis stores chatbot's conversation context among HTTP requests

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This state diagram describes how the LINE bot talks to users:
 
 Developing rumors-line-bot requires you to finish the following settings.
 
-### LINE@ account & Developer accounts
+### LINE channels & Developer accounts
 
 Please follow all the steps in [LINE official tutorial](https://developers.line.me/messaging-api/getting-started).
 
@@ -25,8 +25,9 @@ Please follow all the steps in [LINE official tutorial](https://developers.line.
 Create `.env` file from `.env.sample` template, at least fill in:
 ```
 API_URL=https://cofacts-api.g0v.tw/graphql
-LINE_CHANNEL_SECRET=<paste LINE@'s channel secret here>
-LINE_CHANNEL_TOKEN=<paste LINE@'s channel token here>
+LINE_CHANNEL_SECRET=<paste Messaging API's channel secret here>
+LINE_CHANNEL_TOKEN=<paste Messaging API's channel access token here>
+LINE_LOGIN_CHANNEL_ID=<paste LINE Login channel ID here>
 LIFF_URL=<paste LIFF app's LiFF URL>
 ```
 
@@ -279,7 +280,6 @@ Sent event format: `Event category` / `Event action` / `Event label`
   - Page view for page `/articles` is sent
   - If opened via rich menu: `utm_source=rumors-line-bot&utm_medium=richmenu`
   - If opened via push message: `utm_source=rumors-line-bot&utm_medium=push`
-  - If opened via LINE notify: `utm_source=line-notify&utm_medium=push`
 
 9. When user clicks viewed article item in article list
   - `LIFF` / `ChooseArticle` / `<articleId>`

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ On Heroku, please set `LOCALE` to one of `en_US`, `zh_TW` or any other language 
 If you want to build using docker instead, you may need to modify Dockerfile to include the desired `LOCALE`.
 
 #### Notification setup
-- Prerequisites : 
+- Prerequisites :
   1. [LIFF setup](https://github.com/cofacts/rumors-line-bot#liff-setup)
   2. Connect MongoDB
 
@@ -241,6 +241,7 @@ Sent event format: `Event category` / `Event action` / `Event label`
   - If we found a articles in database that matches the message:
     - `UserInput` / `ArticleSearch` / `ArticleFound`
     - `Article` / `Search` / `<article id>` for each article found
+  - When user opens LIFF providing source, page view for page `/source` is sent.
   - If nothing found in database:
     - `UserInput` / `ArticleSearch` / `ArticleNotFound`
   - If articles found in database but is not what user want:
@@ -261,6 +262,7 @@ Sent event format: `Event category` / `Event action` / `Event label`
 
 4. User votes a reply
   - `UserInput` / `Feedback-Vote` / `<articleId>/<replyId>`
+  - When the LIFF opens, page view for page `/feedback/yes` or `/feedback/no` is also sent.
 
 5. User want to submit a new article
   - `Article` / `Create` / `Yes`
@@ -271,3 +273,20 @@ Sent event format: `Event category` / `Event action` / `Event label`
 
 7. User updates their reason of reply request
   - `Article` / `ProvidingReason` / `<articleId>`
+  - When the LIFF opens, page view for page `/reason` is also sent.
+
+8. User opens article list
+  - Page view for page `/articles` is sent
+  - If opened via rich menu: `utm_source=rumors-line-bot&utm_medium=richmenu`
+  - If opened via push message: `utm_source=rumors-line-bot&utm_medium=push`
+  - If opened via LINE notify: `utm_source=line-notify&utm_medium=push`
+
+9. When user clicks viewed article item in article list
+  - `LIFF` / `ChooseArticle` / `<articleId>`
+  - Note: this event is dispatched in LIFF, thus URL params like `utm_source`, `utm_medium` also applies.
+
+10. User opens settings list
+  - Page view for page `/setting` is sent
+
+11. Other LIFF operations
+  - `LIFF` / `page_redirect` / `App` is sent on LIFF redirect, with value being redirect count.

--- a/src/liff/.eslintrc.js
+++ b/src/liff/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     // global scripts include in index.html
     rollbar: 'readonly',
     liff: 'readonly',
+    gtag: 'readonly',
 
     // Define plugin
     APP_ID: 'readonly',

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -1,6 +1,5 @@
 <script>
   import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
   import { page } from './lib';
   import Articles from './pages/Articles.svelte';
   import Source from './pages/Source.svelte';

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import { page } from './lib';
   import Articles from './pages/Articles.svelte';
   import Source from './pages/Source.svelte';
@@ -15,6 +17,27 @@
     'feedback/no': NegativeFeedback,
     setting: UserSetting,
   };
+
+  onMount(() => {
+    gtag('event', 'page_view', {
+      page_path: get(path)
+    });
+    if(window.performance) {
+      gtag('event', 'timing_complete', {
+        name: 'App mounted',
+        value: performance.now(),
+        event_category: 'LIFF',
+        event_label: 'App',
+      });
+      if(performance.navigation) {
+        gtag('event', 'page_redirect', {
+          event_category: 'LIFF',
+          event_label: 'App',
+          value: performance.navigation.redirectCount,
+        });
+      }
+    }
+  })
 </script>
 
 <svelte:component this={routes[$page]} />

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -17,9 +17,12 @@
     setting: UserSetting,
   };
 
-  // Send pageview with correct path on each page change
+  // Send pageview with correct path on each page change.
+  // delay a bit for page components to change page title
   page.subscribe(p => {
-    gtag('event', 'page_view', { page_path: p });
+    setTimeout(() => {
+      gtag('event', 'page_view', { page_path: p });
+    }, 10)
   });
 
   onMount(() => {

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -18,10 +18,12 @@
     setting: UserSetting,
   };
 
-  onMount(() => {
-    // Send pageview with correct path
-    gtag('event', 'page_view', { page_path: get(page) });
+  // Send pageview with correct path on each page change
+  page.subscribe(p => {
+    gtag('event', 'page_view', { page_path: p });
+  });
 
+  onMount(() => {
     if(window.performance) {
       gtag('event', 'timing_complete', {
         name: 'App mounted',

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -19,9 +19,9 @@
   };
 
   onMount(() => {
-    gtag('event', 'page_view', {
-      page_path: get(path)
-    });
+    // Send pageview with correct path
+    gtag('event', 'page_view', { page_path: get(page) });
+
     if(window.performance) {
       gtag('event', 'timing_complete', {
         name: 'App mounted',

--- a/src/liff/components/ViewedArticle.svelte
+++ b/src/liff/components/ViewedArticle.svelte
@@ -15,9 +15,9 @@
 
   $: replyCount = article ? article.articleReplies.length : 0;
   $: viewedAt = userArticleLink.lastViewedAt ?
-    userArticleLink.lastViewedAt :
-    userArticleLink.createdAt;
-  $: newArticleReplyCount = article ? article.articleReplies.map(ar => ar.createdAt > viewedAt ).length : 0;
+    new Date(userArticleLink.lastViewedAt) :
+    new Date(userArticleLink.createdAt);
+  $: newArticleReplyCount = article ? article.articleReplies.filter(ar => new Date(ar.createdAt) > viewedAt).length : 0;
 
   // String translation setup:
   // Svelte template will mess up with variable names, thus strings with variables
@@ -28,7 +28,7 @@
 
   let viewedAtStr = '';
   $: {
-    const fromNow = formatDistanceToNow(new Date(viewedAt));
+    const fromNow = formatDistanceToNow(viewedAt);
     viewedAtStr = t`Viewed ${fromNow} ago`;
   }
 

--- a/src/liff/index.html
+++ b/src/liff/index.html
@@ -16,6 +16,14 @@
       // End Rollbar Snippet
     </script>
     <script charset="utf-8" src="https://static.line-scdn.net/liff/edge/2.1/sdk.js"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= htmlWebpackPlugin.options.GA_ID %>"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '<%= htmlWebpackPlugin.options.GA_ID %>', { send_page_view: false });
+    </script>
   </head>
   <body>
     <div id="loading">

--- a/src/liff/pages/Articles.svelte
+++ b/src/liff/pages/Articles.svelte
@@ -11,10 +11,20 @@
   let articleMap = {};
 
   let selectArticle = async articleId => {
-    await sendMessages([{
-      type: 'text',
-      text: `${VIEW_ARTICLE_PREFIX}${getArticleURL(articleId)}`,
-    }]);
+    await Promise.all([
+      sendMessages([{
+        type: 'text',
+        text: `${VIEW_ARTICLE_PREFIX}${getArticleURL(articleId)}`,
+      }]),
+      new Promise(
+        resolve =>
+          gtag('event', 'ChooseArticle', {
+            event_category: 'LIFF',
+            event_label: articleId,
+            event_callback: () => resolve(),
+          })
+      )
+    ]);
     liff.closeWindow();
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,6 +122,7 @@ module.exports = {
       // custom constants passed to index.html via htmlWebpackPlugin.options
       ROLLBAR_ENV: process.env.ROLLBAR_ENV,
       ROLLBAR_CLIENT_TOKEN: process.env.ROLLBAR_CLIENT_TOKEN,
+      GA_ID: process.env.GA_ID,
     }),
     new CompressionPlugin(),
     new DefinePlugin({


### PR DESCRIPTION
## Feature
- Google analytics setup for LIFF; use the same Google analytics tracking ID as chatbot event handlers
- sends pageview on page change
- sends user timing on LIFF load
- record redirect count as redirect event

## Bugfix
Fix the bug that article list LIFF showing all replies as unread replies.
After fix: 
![image](https://user-images.githubusercontent.com/108608/88019443-66c77980-cb5c-11ea-97d0-4e073668df2b.png)


## Pageview
![image](https://user-images.githubusercontent.com/108608/87122580-c2ba1480-c2b7-11ea-90e6-b0f05317c071.png)

## Event
![image](https://user-images.githubusercontent.com/108608/87122559-b635bc00-c2b7-11ea-895d-5c22da2e87e3.png)

## `utm_source` & `utm_medium` in LIFF URL also works
![image](https://user-images.githubusercontent.com/108608/87122519-a28a5580-c2b7-11ea-9c77-e3eeef271f8f.png)
