### PR TITLE
Fix error cannot read property 'sessionId' of undefined

### DIFF
--- a/src/webhook/__mocks__/lineClient.js
+++ b/src/webhook/__mocks__/lineClient.js
@@ -1,0 +1,2 @@
+const lineClient = jest.fn();
+export default lineClient;

--- a/src/webhook/__tests__/__snapshots__/index.js.snap
+++ b/src/webhook/__tests__/__snapshots__/index.js.snap
@@ -43,3 +43,32 @@ Array [
   },
 ]
 `;
+
+exports[`Webhook router singleUserHandler() should reply default messages 1`] = `
+Array [
+  Array [
+    "/message/reply",
+    Object {
+      "messages": Array [
+        Object {
+          "text": "I cannot understand messages other than text.",
+          "type": "text",
+        },
+      ],
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+    },
+  ],
+]
+`;
+
+exports[`Webhook router singleUserHandler() should reply default messages 2`] = `
+Array [
+  Array [
+    "U4af4980630",
+    Object {
+      "data": Object {},
+      "state": "__INIT__",
+    },
+  ],
+]
+`;

--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -74,7 +74,7 @@ const singleUserHandler = async (
   // Set default result
   //
   let result = {
-    context: '__INIT__',
+    context: { state: '__INIT__', data: {} },
     replies: [
       {
         type: 'text',


### PR DESCRIPTION
Fixes #192 

It’s because default reply `context` object doesn’t have `data` property, when the next message comes in, getting `context.data.sessionId` will have such error.