### PR TITLE
Simplify state, return state only when we need it

### DIFF
--- a/src/webhook/handleInput.js
+++ b/src/webhook/handleInput.js
@@ -64,6 +64,8 @@ export default async function handleInput(
       event.input.startsWith(DOWNVOTE_PREFIX)
     ) {
       state = 'ASKING_REPLY_FEEDBACK';
+    } else if (event.input.startsWith(REASON_PREFIX)) {
+      state = 'ASKING_REPLY_REQUEST_REASON';
     } else if (event.input.startsWith(SOURCE_PREFIX)) {
       // state should be given from input, ASKING_ARTICLE_SUBMISSION_CONSENT or ASKING_REPLY_REQUEST_REASON
     } else {

--- a/src/webhook/handleInput.js
+++ b/src/webhook/handleInput.js
@@ -41,43 +41,45 @@ export default async function handleInput(
   if (event.type === 'postback') {
     // Jump to the correct state to handle the postback input
     state = event.postbackHandlerState;
-  } else if (
-    event.type === 'message' &&
-    event.input.startsWith(VIEW_ARTICLE_PREFIX)
-  ) {
-    const articleId = event.input
-      .replace(VIEW_ARTICLE_PREFIX, '')
-      .replace(getArticleURL(''), '');
+  } else if (event.type === 'message') {
+    if (event.input.startsWith(VIEW_ARTICLE_PREFIX)) {
+      const articleId = event.input
+        .replace(VIEW_ARTICLE_PREFIX, '')
+        .replace(getArticleURL(''), '');
 
-    // Start new session, reroute to CHOOSING_ARTILCE and simulate "choose article" postback event
-    //
-    state = 'CHOOSING_ARTICLE';
-    data = {
-      // Start a new session
-      sessionId: Date.now(),
-      searchedText: '',
-    };
-    event = {
-      type: 'postback',
-      input: articleId,
-    };
-  } else if (
-    event.type === 'message' &&
-    !event.input.startsWith(REASON_PREFIX) &&
-    !event.input.startsWith(UPVOTE_PREFIX) &&
-    !event.input.startsWith(DOWNVOTE_PREFIX) &&
-    !event.input.startsWith(SOURCE_PREFIX)
-  ) {
-    // The user forwarded us an new message.
-    // Create a new "search session" and reset state to `__INIT__`.
-    //
-    data = {
-      // Used to determine button postbacks and GraphQL requests are from
-      // previous sessions
+      // Start new session, reroute to CHOOSING_ARTILCE and simulate "choose article" postback event
       //
-      sessionId: Date.now(),
-    };
-    state = '__INIT__';
+      state = 'CHOOSING_ARTICLE';
+      data = {
+        // Start a new session
+        sessionId: Date.now(),
+        searchedText: '',
+      };
+      event = {
+        type: 'postback',
+        input: articleId,
+      };
+    } else if (
+      event.input.startsWith(UPVOTE_PREFIX) ||
+      event.input.startsWith(DOWNVOTE_PREFIX)
+    ) {
+      state = 'ASKING_REPLY_FEEDBACK';
+    } else if (event.input.startsWith(SOURCE_PREFIX)) {
+      // state should be given from input, ASKING_ARTICLE_SUBMISSION_CONSENT or ASKING_REPLY_REQUEST_REASON
+    } else {
+      // The user forwarded us an new message.
+      // Create a new "search session" and reset state to `__INIT__`.
+      //
+      data = {
+        // Used to determine button postbacks and GraphQL requests are from
+        // previous sessions
+        //
+        sessionId: Date.now(),
+      };
+      state = '__INIT__';
+    }
+  } else {
+    state = 'Error';
   }
 
   let params = {
@@ -99,6 +101,8 @@ export default async function handleInput(
           params = await initState(params);
           break;
         }
+
+        // from postback
         case 'CHOOSING_ARTICLE': {
           params = await choosingArticle(params);
           break;
@@ -107,18 +111,24 @@ export default async function handleInput(
           params = await choosingReply(params);
           break;
         }
+
+        // from liff, message contains prefix
+        // UPVOTE_PREFIX, DOWNVOTE_PREFIX
         case 'ASKING_REPLY_FEEDBACK': {
           params = await askingReplyFeedback(params);
           break;
         }
+        // SOURCE_PREFIX and state = ASKING_ARTICLE_SUBMISSION_CONSENT
         case 'ASKING_ARTICLE_SUBMISSION_CONSENT': {
           params = await askingArticleSubmissionConsent(params);
           break;
         }
+        // SOURCE_PREFIX and state = ASKING_REPLY_REQUEST_REASON
         case 'ASKING_REPLY_REQUEST_REASON': {
           params = await askingReplyRequestReason(params);
           break;
         }
+
         default: {
           params = defaultState(params);
           break;

--- a/src/webhook/handlers/askingArticleSubmissionConsent.js
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.js
@@ -41,7 +41,6 @@ export default async function askingArticleSubmissionConsent(params) {
       },
       createSuggestOtherFactCheckerReply(),
     ];
-    state = '__INIT__';
   } else {
     visitor.event({ ec: 'Article', ea: 'Create', el: 'Yes' });
 
@@ -104,9 +103,8 @@ export default async function askingArticleSubmissionConsent(params) {
 
     // Record article ID in context for reason LIFF
     data.selectedArticleId = CreateArticle.id;
-    state = '__INIT__';
   }
 
   visitor.send();
-  return { data, state, event, userId, replies, isSkipUser };
+  return { data, event, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/askingReplyFeedback.js
+++ b/src/webhook/handlers/askingReplyFeedback.js
@@ -177,5 +177,5 @@ export default async function askingReplyFeedback(params) {
 
   visitor.send();
 
-  return { data, state, event, issuedAt, userId, replies, isSkipUser };
+  return { data, event, issuedAt, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/askingReplyRequestReason.js
+++ b/src/webhook/handlers/askingReplyRequestReason.js
@@ -1,74 +1,169 @@
-import { t } from 'ttag';
+import { t, msgid, ngettext } from 'ttag';
 import ga from 'src/lib/ga';
-import { getArticleURL, SOURCE_PREFIX } from 'src/lib/sharedUtils';
+import {
+  getArticleURL,
+  SOURCE_PREFIX,
+  REASON_PREFIX,
+} from 'src/lib/sharedUtils';
 import {
   ManipulationError,
   createArticleShareBubble,
   getArticleSourceOptionFromLabel,
   createReasonButtonFooter,
 } from './utils';
+import gql from 'src/lib/gql';
 
 export default async function askingReplyRequestSubmission(params) {
   let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
 
-  if (!event.input.startsWith(SOURCE_PREFIX)) {
+  if (event.input.startsWith(SOURCE_PREFIX)) {
+    const sourceOption = getArticleSourceOptionFromLabel(
+      event.input.slice(SOURCE_PREFIX.length)
+    );
+
+    const visitor = ga(userId, state, data.selectedArticleText);
+
+    visitor.event({
+      ec: 'UserInput',
+      ea: 'ProvidingSource',
+      el: sourceOption.value,
+    });
+
+    visitor.event({
+      ec: 'Article',
+      ea: 'ProvidingSource',
+      el: `${data.selectedArticleId}/${sourceOption.value}`,
+    });
+
+    const articleUrl = getArticleURL(data.selectedArticleId);
+    const sourceRecordedMsg = t`Thanks for the info.`;
+
+    replies = [
+      {
+        type: 'flex',
+        altText: sourceRecordedMsg,
+        contents: {
+          type: 'carousel',
+          contents: [
+            {
+              type: 'bubble',
+              body: {
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'text',
+                    wrap: true,
+                    text: sourceRecordedMsg,
+                  },
+                ],
+              },
+              footer: createReasonButtonFooter(
+                articleUrl,
+                userId,
+                data.sessionId
+              ),
+            },
+            createArticleShareBubble(articleUrl),
+          ],
+        },
+      },
+    ];
+    visitor.send();
+    return { data, event, issuedAt, userId, replies, isSkipUser };
+  } else if (event.input.startsWith(REASON_PREFIX)) {
+    // Check required data to update reply request
+    if (!data.selectedArticleId) {
+      throw new ManipulationError(
+        t`Please press the latest button to submit message to database.`
+      );
+    }
+
+    // Update the reply request
+    const { data: mutationData, errors } = await gql`
+      mutation UpdateReplyRequest($id: String!, $reason: String) {
+        CreateOrUpdateReplyRequest(articleId: $id, reason: $reason) {
+          text
+          replyRequestCount
+        }
+      }
+    `(
+      {
+        id: data.selectedArticleId,
+        reason: event.input.slice(REASON_PREFIX.length),
+      },
+      { userId }
+    );
+
+    if (errors) {
+      throw new ManipulationError(
+        t`Something went wrong when recording your reason, please try again later.`
+      );
+    }
+
+    const visitor = ga(
+      userId,
+      state,
+      mutationData.CreateOrUpdateReplyRequest.text
+    );
+    visitor.event({
+      ec: 'Article',
+      ea: 'ProvidingReason',
+      el: data.selectedArticleId,
+    });
+
+    const articleUrl = getArticleURL(data.selectedArticleId);
+    const otherReplyRequestCount =
+      mutationData.CreateOrUpdateReplyRequest.replyRequestCount - 1;
+    const replyRequestUpdatedMsg = t`Thanks for the info you provided.`;
+
+    replies = [
+      {
+        type: 'flex',
+        altText: replyRequestUpdatedMsg,
+        contents: {
+          type: 'carousel',
+          contents: [
+            createArticleShareBubble(articleUrl),
+            {
+              type: 'bubble',
+              body: {
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'text',
+                    wrap: true,
+                    text: replyRequestUpdatedMsg,
+                  },
+                  otherReplyRequestCount > 0 && {
+                    type: 'text',
+                    wrap: true,
+                    text: ngettext(
+                      msgid`There is ${otherReplyRequestCount} user also waiting for clarification.`,
+                      `There are ${otherReplyRequestCount} users also waiting for clarification.`,
+                      otherReplyRequestCount
+                    ),
+                  },
+                ].filter(m => m),
+              },
+              footer: createReasonButtonFooter(
+                articleUrl,
+                userId,
+                data.sessionId,
+                true
+              ),
+            },
+          ],
+        },
+      },
+    ];
+    visitor.send();
+
+    return { data, event, userId, replies, isSkipUser };
+  } else {
     throw new ManipulationError(
       t`Please press the latest button to submit message to database.`
     );
   }
-
-  const sourceOption = getArticleSourceOptionFromLabel(
-    event.input.slice(SOURCE_PREFIX.length)
-  );
-
-  const visitor = ga(userId, state, data.selectedArticleText);
-
-  visitor.event({
-    ec: 'UserInput',
-    ea: 'ProvidingSource',
-    el: sourceOption.value,
-  });
-
-  visitor.event({
-    ec: 'Article',
-    ea: 'ProvidingSource',
-    el: `${data.selectedArticleId}/${sourceOption.value}`,
-  });
-
-  const articleUrl = getArticleURL(data.selectedArticleId);
-  const sourceRecordedMsg = t`Thanks for the info.`;
-
-  replies = [
-    {
-      type: 'flex',
-      altText: sourceRecordedMsg,
-      contents: {
-        type: 'carousel',
-        contents: [
-          {
-            type: 'bubble',
-            body: {
-              type: 'box',
-              layout: 'vertical',
-              contents: [
-                {
-                  type: 'text',
-                  wrap: true,
-                  text: sourceRecordedMsg,
-                },
-              ],
-            },
-            footer: createReasonButtonFooter(
-              articleUrl,
-              userId,
-              data.sessionId
-            ),
-          },
-          createArticleShareBubble(articleUrl),
-        ],
-      },
-    },
-  ];
-  visitor.send();
-  return { data, event, issuedAt, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/askingReplyRequestReason.js
+++ b/src/webhook/handlers/askingReplyRequestReason.js
@@ -69,7 +69,6 @@ export default async function askingReplyRequestSubmission(params) {
       },
     },
   ];
-  state = '__INIT__';
   visitor.send();
-  return { data, state, event, issuedAt, userId, replies, isSkipUser };
+  return { data, event, issuedAt, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/choosingReply.js
+++ b/src/webhook/handlers/choosingReply.js
@@ -125,7 +125,5 @@ export default async function choosingReply(params) {
   visitor.event({ ec: 'Reply', ea: 'Type', el: GetReply.type, ni: true });
   visitor.send();
 
-  state = 'ASKING_REPLY_FEEDBACK';
-
-  return { data, state, event, issuedAt, userId, replies, isSkipUser };
+  return { data, event, issuedAt, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/initState.js
+++ b/src/webhook/handlers/initState.js
@@ -18,7 +18,8 @@ import ga from 'src/lib/ga';
 const SIMILARITY_THRESHOLD = 0.95;
 
 export default async function initState(params) {
-  let { data, state, event, userId, replies, isSkipUser } = params;
+  let { data, event, userId, replies, isSkipUser } = params;
+  let state = '__INIT__';
 
   if (event.input.startsWith(REASON_PREFIX)) {
     // Check required data to update reply request
@@ -109,7 +110,7 @@ export default async function initState(params) {
     ];
     visitor.send();
 
-    return { data, state, event, userId, replies, isSkipUser };
+    return { data, event, userId, replies, isSkipUser };
   }
 
   // Track text message type send by user
@@ -385,7 +386,6 @@ export default async function initState(params) {
         },
         createSuggestOtherFactCheckerReply(),
       ];
-      state = '__INIT__';
     } else {
       replies = [
         {

--- a/src/webhook/handlers/initState.js
+++ b/src/webhook/handlers/initState.js
@@ -1,16 +1,12 @@
 import stringSimilarity from 'string-similarity';
-import { t, msgid, ngettext } from 'ttag';
+import { t } from 'ttag';
 import gql from 'src/lib/gql';
-import { REASON_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
 import {
-  ManipulationError,
   createPostbackAction,
   ellipsis,
   createAskArticleSubmissionConsentReply,
   createSuggestOtherFactCheckerReply,
   POSTBACK_NO_ARTICLE_FOUND,
-  createReasonButtonFooter,
-  createArticleShareBubble,
   createHighlightContents,
 } from './utils';
 import ga from 'src/lib/ga';
@@ -20,98 +16,6 @@ const SIMILARITY_THRESHOLD = 0.95;
 export default async function initState(params) {
   let { data, event, userId, replies, isSkipUser } = params;
   let state = '__INIT__';
-
-  if (event.input.startsWith(REASON_PREFIX)) {
-    // Check required data to update reply request
-    if (!data.selectedArticleId) {
-      throw new ManipulationError(
-        t`Please press the latest button to submit message to database.`
-      );
-    }
-
-    // Update the reply request
-    const { data: mutationData, errors } = await gql`
-      mutation UpdateReplyRequest($id: String!, $reason: String) {
-        CreateOrUpdateReplyRequest(articleId: $id, reason: $reason) {
-          text
-          replyRequestCount
-        }
-      }
-    `(
-      {
-        id: data.selectedArticleId,
-        reason: event.input.slice(REASON_PREFIX.length),
-      },
-      { userId }
-    );
-
-    if (errors) {
-      throw new ManipulationError(
-        t`Something went wrong when recording your reason, please try again later.`
-      );
-    }
-
-    const visitor = ga(
-      userId,
-      state,
-      mutationData.CreateOrUpdateReplyRequest.text
-    );
-    visitor.event({
-      ec: 'Article',
-      ea: 'ProvidingReason',
-      el: data.selectedArticleId,
-    });
-
-    const articleUrl = getArticleURL(data.selectedArticleId);
-    const otherReplyRequestCount =
-      mutationData.CreateOrUpdateReplyRequest.replyRequestCount - 1;
-    const replyRequestUpdatedMsg = t`Thanks for the info you provided.`;
-
-    replies = [
-      {
-        type: 'flex',
-        altText: replyRequestUpdatedMsg,
-        contents: {
-          type: 'carousel',
-          contents: [
-            createArticleShareBubble(articleUrl),
-            {
-              type: 'bubble',
-              body: {
-                type: 'box',
-                layout: 'vertical',
-                contents: [
-                  {
-                    type: 'text',
-                    wrap: true,
-                    text: replyRequestUpdatedMsg,
-                  },
-                  otherReplyRequestCount > 0 && {
-                    type: 'text',
-                    wrap: true,
-                    text: ngettext(
-                      msgid`There is ${otherReplyRequestCount} user also waiting for clarification.`,
-                      `There are ${otherReplyRequestCount} users also waiting for clarification.`,
-                      otherReplyRequestCount
-                    ),
-                  },
-                ].filter(m => m),
-              },
-              footer: createReasonButtonFooter(
-                articleUrl,
-                userId,
-                data.sessionId,
-                true
-              ),
-            },
-          ],
-        },
-      },
-    ];
-    visitor.send();
-
-    return { data, event, userId, replies, isSkipUser };
-  }
 
   // Track text message type send by user
   const visitor = ga(userId, state, event.input);

--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -74,7 +74,7 @@ const singleUserHandler = async (
   // Set default result
   //
   let result = {
-    context: { state: '__INIT__', data: {} },
+    context: { data: {} },
     replies: [
       {
         type: 'text',
@@ -247,7 +247,7 @@ async function processText(context, type, input, otherFields, userId, req) {
     console.error(e);
     rollbar.error(e, req);
     result = {
-      context: { state: '__INIT__', data: {} },
+      context: { data: {} },
       replies: [
         {
           type: 'text',


### PR DESCRIPTION
Fixes #177 

1. Remove useless state assignment and return state only when we need it
   - `ASKING_REPLY_FEEDBACK` state is replaced by `input.startsWith(UPVOTE_PREFIX or DOWNVOTE_PREFIX)`.
   - In [handleInput], `context.state` is mainly used for postback message. But now it's also used to distinguish state `ASKING_ARTICLE_SUBMISSION_CONSENT` and `ASKING_REPLY_REQUEST_REASON` from `input.startsWith(SOURCE_PREFIX)`. Maybe we can use different prefixes for them in the future.

2. Move reason message handler from [initState] to [askingReplyRequestReason]
   - Merge reason message(original in `initState`) to `ASKING_REPLY_REQUEST_REASON`.

3. I don't update test in this PR, so we can see if there's fatal test fail after this refactoring.
Will fix test in another PR.
   - In [initState.test], all `handles reason LIFF` should test in [askingReplyRequestReason.test].
   - In [handleInput.test], the test `processes first article reason submission` is wrong, `REASON_PREFIX` was processed in [initState] not [askingArticleSubmissionConsent].
   - In [askingReplyRequestReason.test], because we merged reason message handler into [askingReplyRequestReason],  the test `should block incorrect prefix` shouldn't input `REASON_PREFIX` now.