### PR TITLE
Improve README to document MongoDB and Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ Other customizable env vars are:
 * `IMAGE_MESSAGE_ENABLED`: Default disabled. To enable, please see "Process image message" section below.
 * `DEBUG_LIFF`: Disables external browser check in LIFF. Useful when debugging LIFF in external browser. Don't enable this on production.
 
-### Redis server
-
-We use Redis to store conversation context / intents. Please run a Redis server on your machine, or use the Heroku Redis's `REDIS_URL` directly if you happen to deploy the bot to Heroku.
-
 ### Node Dependencies
 
 You will need `Node.JS` 12+  to proceed.
@@ -55,11 +51,20 @@ $ npm i
 
 ### Get the bot server running on your local machine
 
+Spin up peripherals like Redis and MongoDB using:
+
+```
+$ docker-compose up -d
+```
+
+Then spin up the application, including chatbot server and webpack-dev-server for LIFF, using:
 ```
 $ npm run dev
 ```
 
-and the server will be started on `localhost:5001`. (Or the `PORT` you specified in your `.env` file.)
+The server will be started on `localhost:5001` (or the `PORT` you specified in your `.env` file.)
+
+If you wish to stop the peripherals, run `docker-compose stop`.
 
 ### Get LINE messages to your local machine
 
@@ -211,6 +216,20 @@ $ node build/scripts/scanRepliesAndNotify.js
 ## Production Deployment
 
 If you would like to start your own LINE bot server in production environment, this section describes how you can deploy the line bot to your own Heroku account.
+
+### Storage
+
+#### Redis
+
+We use Redis to store conversation context.
+
+Use the env var `REDIS_URL` to specify how chatbot should link to the Redis server.
+
+#### MongoDB
+
+We use MongoDB to store users' visited posts. It's the data source for related GraphQL APIs.
+
+Use the env var `MONGODB_URI` to specify your MongoDB's connection string.
 
 ### Get the server running
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,14 @@ $ node build/scripts/scanRepliesAndNotify.js
 
 If you would like to start your own LINE bot server in production environment, this section describes how you can deploy the line bot to your own Heroku account.
 
-### Storage
+### Get the server running
+
+You can deploy the line bot server to your own Heroku account by [creating a Heroku app and push to it](https://devcenter.heroku.com/articles/git#creating-a-heroku-remote).
+
+Despite the fact that we don't use `Procfile`, Heroku still does detection and installs the correct environment for us.
+
+
+### Prepare storage services
 
 #### Redis
 
@@ -225,21 +232,16 @@ We use Redis to store conversation context.
 
 Use the env var `REDIS_URL` to specify how chatbot should link to the Redis server.
 
+On Heroku, you can [provision a Heroku Redis addon](https://elements.heroku.com/addons/heroku-redis) to get redis.
+It sets the env var `REDIS_URL` for you.
+
 #### MongoDB
 
 We use MongoDB to store users' visited posts. It's the data source for related GraphQL APIs.
 
 Use the env var `MONGODB_URI` to specify your MongoDB's connection string.
 
-### Get the server running
-
-You can deploy the line bot server to your own Heroku account by [creating a Heroku app and push to it](https://devcenter.heroku.com/articles/git#creating-a-heroku-remote).
-
-Despite the fact that we don't use `Procfile`, Heroku still does detection and installs the correct environment for us.
-
-### Provision add-on "Heroku Redis"
-
-[Provision a Heroku Redis addon](https://elements.heroku.com/addons/heroku-redis) to get redis. It sets the env var `REDIS_URL` for you.
+[MongoDB Atlas Free Tier cluster](https://docs.atlas.mongodb.com/tutorial/deploy-free-tier-cluster/) to start with.
 
 ### Tesseract-ocr on heroku
 
@@ -247,18 +249,20 @@ Despite the fact that we don't use `Procfile`, Heroku still does detection and i
 
 ### Configurations
 
-You will still have to set the following config vars manually:
+Besides previously mentioned `MONGODB_URI`, `REDIS_URL` and `IMAGE_MESSAGE_ENABLED`,
+you will still have to set the following config vars manually:
 
 ```
 $ heroku config:set API_URL=https://cofacts-api.g0v.tw/graphql
 $ heroku config:set SITE_URL=https://cofacts.g0v.tw
 $ heroku config:set LINE_CHANNEL_SECRET=<Your channel secret>
 $ heroku config:set LINE_CHANNEL_TOKEN=<Your channel token>
-$ heroku config:set GOOGLE_CREDENTIALS=<Your google credential (optional)>
 $ heroku config:set LIFF_URL=<LIFF URL>
-$ heroku config:set IMAGE_MESSAGE_ENABLED=true
-$ heroku config:set MONGODB_URI=<MONGODB URI>
+$ heroku config:set FACEBOOK_APP_ID=<Facebook App ID for share dialog>
+$ heroku config:set JWT_SECRET=<arbitary secret string>
 ```
+
+Consult `.env.sample` for other optional env vars.
 
 ## Google Analytics Events table
 


### PR DESCRIPTION
Current README did not mention that we need to spin up MongoDB to get chatbot server ready.

This PR
- Adds `docker-compose` command to dev instructions.
    - Although it's mainly used in unit tests, current docker-compose settings & its combination with `.env.sample` is pretty suitable for development as well.
- Moves env var setup to `Production Deployment` section.
