### PR TITLE
Send reply list when article URL is sent

### DIFF
--- a/src/webhook/__tests__/handleInput.test.js
+++ b/src/webhook/__tests__/handleInput.test.js
@@ -94,7 +94,7 @@ it('invokes state handler specified by event.postbackHandlerState', async () => 
   expect(choosingReply).toHaveBeenCalledTimes(1);
 });
 
-it('shows article list when VIEW_ARTICLE_PREFIX is sent', async () => {
+it('shows reply list when VIEW_ARTICLE_PREFIX is sent', async () => {
   const context = {
     data: { sessionId: FIXED_DATE },
   };
@@ -128,6 +128,62 @@ it('shows article list when VIEW_ARTICLE_PREFIX is sent', async () => {
 
   expect(choosingReply).not.toHaveBeenCalled();
   expect(choosingArticle).toHaveBeenCalledTimes(1);
+});
+
+it('shows reply list when article URL is sent', async () => {
+  const context = {
+    data: { sessionId: FIXED_DATE },
+  };
+  const event = {
+    type: 'message',
+    input: getArticleURL('article-id') + '  \n  ' /* simulate manual input */,
+  };
+
+  choosingArticle.mockImplementationOnce(params => {
+    // it doesn't return `state`, discard it
+    // eslint-disable-next-line no-unused-vars
+    const { state, ...restParams } = params;
+    return Promise.resolve({
+      ...restParams,
+      isSkipUser: false,
+      replies: 'Foo replies',
+    });
+  });
+
+  await expect(handleInput(context, event)).resolves.toMatchInlineSnapshot(`
+          Object {
+            "context": Object {
+              "data": Object {
+                "searchedText": "",
+                "sessionId": 1561982400000,
+              },
+            },
+            "replies": "Foo replies",
+          }
+        `);
+
+  expect(choosingReply).not.toHaveBeenCalled();
+  expect(choosingArticle).toHaveBeenCalledTimes(1);
+  expect(choosingArticle.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "data": Object {
+            "searchedText": "",
+            "sessionId": 1561982400000,
+          },
+          "event": Object {
+            "input": "article-id",
+            "type": "postback",
+          },
+          "isSkipUser": false,
+          "replies": undefined,
+          "state": "CHOOSING_ARTICLE",
+          "userId": undefined,
+        },
+      ],
+    ]
+  `);
 });
 
 it('Resets session on free-form input, triggers fast-forward', async () => {

--- a/src/webhook/handleInput.js
+++ b/src/webhook/handleInput.js
@@ -38,10 +38,17 @@ export default async function handleInput({ data = {} }, event, userId) {
     // Jump to the correct state to handle the postback input
     state = event.postbackHandlerState;
   } else if (event.type === 'message') {
-    if (event.input.startsWith(VIEW_ARTICLE_PREFIX)) {
-      const articleId = event.input
+    // Trim input because these may come from other chatbot
+    //
+    const trimmedInput = event.input.trim();
+    const articleUrlPrefix = getArticleURL('');
+    if (
+      trimmedInput.startsWith(VIEW_ARTICLE_PREFIX) ||
+      trimmedInput.startsWith(articleUrlPrefix)
+    ) {
+      const articleId = trimmedInput
         .replace(VIEW_ARTICLE_PREFIX, '')
-        .replace(getArticleURL(''), '');
+        .replace(articleUrlPrefix, '');
 
       // Start new session, reroute to CHOOSING_ARTILCE and simulate "choose article" postback event
       //


### PR DESCRIPTION
This PR will make chatbot return list of replies when a URL to article page is sent to Cofacts chatbot.

This should make 3rd party chatbot integration easier. cc/ @carolhsu

## Screenshots

(`SITE_URL` setting on my local machine is `https://cofacts.hacktabl.org`, thus it's triggered by that. On production it should be `https://cofacts.org`.)
![image](https://user-images.githubusercontent.com/108608/107848774-1e8de280-6e31-11eb-98a6-779134fdbf25.png)
