### PR TITLE
Handle the case when article id is not found

### DIFF
--- a/src/webhook/handlers/__tests__/choosingArticle.test.js
+++ b/src/webhook/handlers/__tests__/choosingArticle.test.js
@@ -80,6 +80,27 @@ it('should select article by articleId', async () => {
   expect(ga.sendMock).toHaveBeenCalledTimes(1);
 });
 
+it('throws ManipulationError when articleId is not valid', async () => {
+  gql.__push({ data: { GetArticle: null } });
+
+  // Simulate Article URL input
+  const params = {
+    data: {},
+    event: {
+      type: 'postback',
+      input: 'article-id',
+    },
+    issuedAt: 1505314295017,
+    userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
+    isSkipUser: false,
+  };
+
+  await expect(choosingArticle(params)).rejects.toMatchInlineSnapshot(
+    `[Error: Provided message is not found.]`
+  );
+  expect(gql.__finished()).toBe(true);
+});
+
 it('should select article and have OPINIONATED and NOT_ARTICLE replies', async () => {
   gql.__push(apiResult.multipleReplies);
 

--- a/src/webhook/handlers/choosingArticle.js
+++ b/src/webhook/handlers/choosingArticle.js
@@ -94,6 +94,10 @@ export default async function choosingArticle(params) {
     id: selectedArticleId,
   });
 
+  if (!GetArticle) {
+    throw new ManipulationError(t`Provided message is not found.`);
+  }
+
   // Store it so that other handlers can use
   data.selectedArticleText = GetArticle.text;
 


### PR DESCRIPTION
Since we support third-party chatbots sending URLs to trigger `choosingArticle`, we should better handle exceptions, especially for the case when article id is not correct (user typed in extra message before sending it to Cofacts)
![image](https://user-images.githubusercontent.com/108608/108032616-b841d380-706d-11eb-82a5-56b4c0ca686d.png)
