### PR TITLE
Support more URL patterns when detecting article links

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,8 +29,9 @@ APP_ID=RUMORS_LINE_BOT
 API_URL=https://cofacts-api.hacktabl.org/graphql
 LICENSE_URL=https://github.com/cofacts/opendata#terms
 
-# Cofacts web page URL base
-SITE_URL=https://cofacts.hacktabl.org
+# Cofacts web page URL base, separate by comma.
+# First one will be used to generate article URLs, others will be used to detect article page.
+SITE_URLS=https://cofacts.hacktabl.org
 
 # Google drive
 GOOGLE_CREDENTIALS=

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ you will still have to set the following config vars manually:
 
 ```
 $ heroku config:set API_URL=https://cofacts-api.g0v.tw/graphql
-$ heroku config:set SITE_URL=https://cofacts.g0v.tw
+$ heroku config:set SITE_URLS=https://cofacts.g0v.tw
 $ heroku config:set LINE_CHANNEL_SECRET=<Your channel secret>
 $ heroku config:set LINE_CHANNEL_TOKEN=<Your channel token>
 $ heroku config:set LIFF_URL=<LIFF URL>

--- a/src/lib/__tests__/sharedUtils.js
+++ b/src/lib/__tests__/sharedUtils.js
@@ -1,10 +1,10 @@
-describe('Test SITE_URL', () => {
+describe('getArticleURL and extractArticleId', () => {
   const OLD_ENV = process.env;
 
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...OLD_ENV };
-    delete process.env.SITE_URL;
+    delete process.env.SITE_URLS;
   });
 
   afterEach(() => {
@@ -19,11 +19,38 @@ describe('Test SITE_URL', () => {
   });
 
   it('use SITE_URL from env variables', () => {
-    process.env.SITE_URL = 'https://cofacts.hacktabl.org';
+    process.env.SITE_URLS = 'https://cofacts.hacktabl.org';
     const utils = require('../sharedUtils');
     expect(utils.getArticleURL('AWDZYXxAyCdS-nWhumlz')).toMatchInlineSnapshot(
       `"https://cofacts.hacktabl.org/article/AWDZYXxAyCdS-nWhumlz"`
     );
+  });
+
+  it('returns empty string when no aritcle ID can be extracted', () => {
+    const utils = require('../sharedUtils');
+    const invalidMessages = [
+      'not valid',
+      utils.VIEW_ARTICLE_PREFIX + 'not valid',
+      'https://cofacts.g0v.tw/reply/not-article-url',
+    ];
+
+    for (const message of invalidMessages) {
+      expect(utils.extractArticleId(message)).toBe('');
+    }
+  });
+
+  it('extracts article successfully', () => {
+    process.env.SITE_URLS = 'http://host1,https://host2';
+    const utils = require('../sharedUtils');
+
+    const messagesWithArticleId = [
+      utils.VIEW_ARTICLE_PREFIX + 'http://host1/article/expected-id',
+      'https://host2/article/expected-id',
+    ];
+
+    for (const message of messagesWithArticleId) {
+      expect(utils.extractArticleId(message)).toBe('expected-id');
+    }
   });
 });
 

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -6,7 +6,9 @@ import { t } from 'ttag';
 import dateFnsFormat from 'date-fns/format';
 import dateFnsFormatDistanceToNow from 'date-fns/formatDistanceToNow';
 
-const SITE_URL = process.env.SITE_URL || 'https://cofacts.g0v.tw';
+const SITE_URLS = (process.env.SITE_URLS || 'https://cofacts.g0v.tw').split(
+  ','
+);
 
 /**
  * prefilled text for LIFF sendMessage()
@@ -23,7 +25,28 @@ export const VIEW_ARTICLE_PREFIX = `📃 ${t`See replies of`}:\n`;
  * @returns {string} The article's full URL
  */
 export function getArticleURL(articleId) {
-  return `${SITE_URL}/article/${articleId}`;
+  return `${SITE_URLS[0]}/article/${articleId}`;
+}
+
+/**
+ * Extracts Article ID from message with just article URL, or prefix + article URL.
+ *
+ * @param {string} message
+ * @returns {string} Extracts article ID from message, or empty string if the given string is not article URL.
+ */
+export function extractArticleId(message) {
+  if (message.startsWith(VIEW_ARTICLE_PREFIX)) {
+    message = message.replace(VIEW_ARTICLE_PREFIX, '');
+  }
+
+  for (const siteUrl of SITE_URLS) {
+    const articleUrlPrefix = `${siteUrl}/article/`;
+    if (message.startsWith(articleUrlPrefix)) {
+      return message.replace(articleUrlPrefix, '');
+    }
+  }
+
+  return '';
 }
 
 /**

--- a/src/webhook/handleInput.js
+++ b/src/webhook/handleInput.js
@@ -13,8 +13,7 @@ import {
   UPVOTE_PREFIX,
   SOURCE_PREFIX_NOT_YET_REPLIED,
   SOURCE_PREFIX_FRIST_SUBMISSION,
-  VIEW_ARTICLE_PREFIX,
-  getArticleURL,
+  extractArticleId,
 } from 'src/lib/sharedUtils';
 import tutorial, { TUTORIAL_STEPS } from './handlers/tutorial';
 
@@ -41,15 +40,8 @@ export default async function handleInput({ data = {} }, event, userId) {
     // Trim input because these may come from other chatbot
     //
     const trimmedInput = event.input.trim();
-    const articleUrlPrefix = getArticleURL('');
-    if (
-      trimmedInput.startsWith(VIEW_ARTICLE_PREFIX) ||
-      trimmedInput.startsWith(articleUrlPrefix)
-    ) {
-      const articleId = trimmedInput
-        .replace(VIEW_ARTICLE_PREFIX, '')
-        .replace(articleUrlPrefix, '');
-
+    const articleId = extractArticleId(trimmedInput);
+    if (articleId) {
       // Start new session, reroute to CHOOSING_ARTILCE and simulate "choose article" postback event
       //
       state = 'CHOOSING_ARTICLE';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,7 +132,7 @@ module.exports = {
       APP_ID: JSON.stringify(process.env.APP_ID),
       DEBUG_LIFF: process.env.DEBUG_LIFF,
       COFACTS_API_URL: JSON.stringify(process.env.API_URL),
-      'process.env.SITE_URL': JSON.stringify(process.env.SITE_URL),
+      'process.env.SITE_URLS': JSON.stringify(process.env.SITE_URLS),
       'process.env.LOCALE': JSON.stringify(process.env.LOCALE),
       NOTIFY_METHOD: JSON.stringify(process.env.NOTIFY_METHOD),
     }),


### PR DESCRIPTION
## Problem

Starting from 3/11, many messages with `http://cofacts.org/article/xxxxx` are submitted to Cofacts database:
- https://cofacts.g0v.tw/article/39ukl1k19aglm
- https://cofacts.g0v.tw/article/p8p1gml08ef3
- https://cofacts.g0v.tw/article/wys7nsvjwo9v
- https://cofacts.g0v.tw/article/17a78uaeoz4p
- https://cofacts.g0v.tw/article/2j4yh2nyojnzo 

On 3/13 @carolhsu reported that on iOS, https:// URLs are somehow converted to `http`. iOS users from Auntie Meiyu are submitting `http` URLs to Cofacts database.

## Solution

Cofacts chatbot should recognize http URLs as well.

## Implementation

1. replace `SITE_URL` env var with `SITE_URLS` env var. The latter takes a comma separated strings.
2. Rewrite article URL detection so that it supports host names in SITE_URLS.
3. On staging & production, we will put both http & https versions of Cofacts website URLs in `SITE_URLS`. We can support other URLs such as cofacts.tw, cofacts.g0v.tw as well, as `SITE_URLS` are very flexible.

## Screenshots

Existing behaviors are not affected.

###  Not found & URL only
![image](https://user-images.githubusercontent.com/108608/110971484-e6c57c80-8395-11eb-823e-f302c80c2e5f.png)

### LIFF URLs
![image](https://user-images.githubusercontent.com/108608/110971502-ed53f400-8395-11eb-825d-3dbfd3001bb5.png)
