### PR TITLE
Aritcle LIFF scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ We use dimemsion `Message Source` (Custom Dimemsion1) to classify different even
 
 11. Other LIFF operations
   - `LIFF` / `page_redirect` / `App` is sent on LIFF redirect, with value being redirect count.
+  - `LIFF` / `ViewArticle` / `<articleId>` when article page with `articleId` is opened
+  - `LIFF` / `ViewReply` / `<replyId>` for each displayed reply in article page
 
 12. Tutorial
   - If it's triggered by follow event (a.k.a add-friend event)

--- a/src/graphql/__tests__/setViewed.js
+++ b/src/graphql/__tests__/setViewed.js
@@ -1,0 +1,63 @@
+jest.mock("../lineClient");
+
+import Client from "src/database/mongoClient";
+import UserArticleLink from "src/database/models/userArticleLink";
+import MockDate from "mockdate";
+import { gql } from "../testUtils";
+
+it("context rejects anonymous users", async () => {
+  const result = await gql`
+    mutation($articleId: String!) {
+      setViewed(articleId: $articleId) {
+        articleId
+      }
+    }
+  `({
+    articleId: "foo"
+  });
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "setViewed": null,
+      },
+      "errors": Array [
+        [GraphQLError: Invalid authentication header],
+      ],
+    }
+  `);
+});
+
+describe("finds", () => {
+  beforeAll(async () => {
+    MockDate.set(612921600000);
+    if (await UserArticleLink.collectionExists()) {
+      await (await UserArticleLink.client).drop();
+    }
+  });
+
+  afterAll(async () => {
+    MockDate.reset();
+    await (await Client.getInstance()).close();
+  });
+
+  it("creates user article link with current date", () =>
+    expect(
+      gql`
+        mutation($articleId: String!) {
+          setViewed(articleId: $articleId) {
+            articleId
+            lastViewedAt
+          }
+        }
+      `({ articleId: "foo" }, { userId: "user1" })
+    ).resolves.toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "setViewed": Object {
+            "articleId": "foo",
+            "lastViewedAt": 1989-06-04T00:00:00.000Z,
+          },
+        },
+      }
+    `));
+});

--- a/src/graphql/__tests__/setViewed.js
+++ b/src/graphql/__tests__/setViewed.js
@@ -1,11 +1,11 @@
-jest.mock("../lineClient");
+jest.mock('../lineClient');
 
-import Client from "src/database/mongoClient";
-import UserArticleLink from "src/database/models/userArticleLink";
-import MockDate from "mockdate";
-import { gql } from "../testUtils";
+import Client from 'src/database/mongoClient';
+import UserArticleLink from 'src/database/models/userArticleLink';
+import MockDate from 'mockdate';
+import { gql } from '../testUtils';
 
-it("context rejects anonymous users", async () => {
+it('context rejects anonymous users', async () => {
   const result = await gql`
     mutation($articleId: String!) {
       setViewed(articleId: $articleId) {
@@ -13,7 +13,7 @@ it("context rejects anonymous users", async () => {
       }
     }
   `({
-    articleId: "foo"
+    articleId: 'foo',
   });
   expect(result).toMatchInlineSnapshot(`
     Object {
@@ -27,7 +27,7 @@ it("context rejects anonymous users", async () => {
   `);
 });
 
-describe("finds", () => {
+describe('finds', () => {
   beforeAll(async () => {
     MockDate.set(612921600000);
     if (await UserArticleLink.collectionExists()) {
@@ -40,7 +40,7 @@ describe("finds", () => {
     await (await Client.getInstance()).close();
   });
 
-  it("creates user article link with current date", () =>
+  it('creates user article link with current date', () =>
     expect(
       gql`
         mutation($articleId: String!) {
@@ -49,7 +49,7 @@ describe("finds", () => {
             lastViewedAt
           }
         }
-      `({ articleId: "foo" }, { userId: "user1" })
+      `({ articleId: 'foo' }, { userId: 'user1' })
     ).resolves.toMatchInlineSnapshot(`
       Object {
         "data": Object {

--- a/src/graphql/resolvers/Mutation.js
+++ b/src/graphql/resolvers/Mutation.js
@@ -1,5 +1,6 @@
 import gql from 'src/lib/gql';
 import UserSettings from 'src/database/models/userSettings';
+import UserArticleLink from 'src/database/models/userArticleLink';
 import { revokeNotifyToken } from '../lineClient';
 
 export default {
@@ -54,5 +55,18 @@ export default {
       result = await UserSettings.setNewReplyNotifyToken(userId, null);
     }
     return result;
+  },
+
+  setViewed(root, args, context) {
+    const { articleId } = args;
+    const { userId } = context;
+
+    return UserArticleLink.createOrUpdateByUserIdAndArticleId(
+      userId,
+      articleId,
+      {
+        lastViewedAt: new Date(),
+      }
+    );
   },
 };

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -23,10 +23,12 @@ type Mutation {
   Add feedback to article-reply in context.
   Returns feedback count after vote.
   """
-  voteReply(vote: FeedbackVote!): Int @auth
+  voteReply(vote: FeedbackVote!): Int @auth @deprecated(reason: "Use CreateOrUpdateArticleReplyFeedback instead")
 
-  # TODO: Implement after database is established
-  setViewed(articleId: String!): Boolean @auth
+  """
+  Establish article-user link between the current user and the specified article.
+  """
+  setViewed(articleId: String!): UserArticleLink @auth(check: ["userId"])
 
   """
   Add feedback to article-reply in context.

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { page } from './lib';
+  import Article from './pages/Article.svelte';
   import Articles from './pages/Articles.svelte';
   import Source from './pages/Source.svelte';
   import Reason from './pages/Reason.svelte';
@@ -9,6 +10,7 @@
   import NegativeFeedback from './pages/NegativeFeedback.svelte';
 
   const routes = {
+    article: Article,
     articles: Articles,
     source: Source,
     reason: Reason,

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -1,0 +1,57 @@
+<script>
+  import { onMount } from 'svelte';
+  import { gql } from '../lib';
+
+  const params = new URLSearchParams(location.search);
+  const articleId = params.get('articleId');
+  const replyId = params.get('replyId');
+
+  let articleData;
+  let articleReplies = [];
+
+  const loadData = async () => {
+    const {
+      data: { GetArticle },
+    } = await gql`
+      query GetArticleInLIFF($id: String) {
+        GetArticle(id: $id) {
+          text
+          articleReplies {
+            reply {
+              id
+              text
+            }
+          }
+        }
+      }
+    `({id: articleId});
+
+    articleData = GetArticle;
+
+    articleReplies = GetArticle.articleReplies.filter(({reply}) => replyId ? reply.id === replyId : true);
+  }
+
+  onMount(async () => {
+    await loadData();
+  })
+</script>
+
+<svelte:head>
+  <title>Cofacts 網友協作回應</title>
+</svelte:head>
+
+{#if !articleData }
+  <p>載入中...</p>
+{:else}
+  <details>
+    {articleData.text}
+  </details>
+
+  <ul>
+    {#each articleReplies as articleReply (articleReply.reply.id)}
+      <li>
+        {articleReply.reply.text}
+      </li>
+    {/each}
+  </ul>
+{/if}

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -35,10 +35,31 @@
 
     articleData = GetArticle;
     articleReplies = GetArticle.articleReplies.filter(({reply}) => replyId ? reply.id === replyId : true);
+
+    // Send event to Google Analytics
+    gtag('event', 'ViewArticle', {
+      event_category: 'LIFF',
+      event_label: articleId,
+    });
+    articleReplies.forEach(({reply}) => {
+      gtag('event', 'ViewReply', {
+        event_category: 'LIFF',
+        event_label: reply.id,
+      });
+    })
   }
 
-  onMount(async () => {
-    await loadData();
+  const setViewed = async () => {
+    await gql`
+      mutation SetViewedInLIFF($id: String!) {
+        setViewed(articleId: $id) { lastViewedAt }
+      }
+    `({id: articleId});
+  }
+
+  onMount(() => {
+    loadData();
+    setViewed();
   });
 
   const handleVote = async (replyId, vote) => {


### PR DESCRIPTION
This PR implements an article & reply LIFF ([Previous proposal](https://g0v.hackmd.io/0RX4MsjRRJmBqJSKVilWMA#article-amp-reply-LIFF)) that functionally supports:
- Show the article by `articleId` in URL param
- If no replies yet, show button for user to submit reply request
- Lists all replies or show only the reply specified by `replyId` in URL param
- Upvote & downvote article replies
- setup userArticleLink so that users can be notified via Cofacts chatbot when new replies are available
    - implements `setViewed` mutation in LINE bot GraphQL to support this
- sends GA events

## Screenshots
### Article without replies
<img width="1023" alt="圖片" src="https://user-images.githubusercontent.com/108608/115754714-11f8ae00-a3cf-11eb-82fb-32de51c4742f.png">

### Submitting reply requests
![submit-reply-request](https://user-images.githubusercontent.com/108608/115754924-4cfae180-a3cf-11eb-9e05-0a86983faf6f.gif)

### Article & specified reply
<img width="1042" alt="圖片" src="https://user-images.githubusercontent.com/108608/115755052-7d428000-a3cf-11eb-90fd-8bd3e8fb4d03.png">

### Article & all replies
<img width="1050" alt="圖片" src="https://user-images.githubusercontent.com/108608/115755091-8895ab80-a3cf-11eb-95b6-bd0885cd7c93.png">

### Upvote & downvote
![Downvote and upvote](https://user-images.githubusercontent.com/108608/115755191-abc05b00-a3cf-11eb-9782-09d02fd217ab.gif)
