### PR TITLE
Fix console to better track progress of notification sending process

### DIFF
--- a/src/lib/sendMessage.js
+++ b/src/lib/sendMessage.js
@@ -39,6 +39,11 @@ const multicast = async (userIds, messages) => {
     userIds,
     500 /* Multicast can send to 500 ppl in max each time */
   )) {
+    console.log(
+      '[sendMessage][multicast] Sending message to',
+      userIdBatch.length,
+      'people'
+    );
     await lineClient.post('/message/multicast', {
       to: userIdBatch,
       messages: messages,

--- a/src/scripts/lib.js
+++ b/src/scripts/lib.js
@@ -135,8 +135,12 @@ const getNotificationList = async (lastScannedAt, nowWithOffset) => {
         result[uid].push(data.articleId);
       });
     }
+    console.log(
+      '[notify] Scanning articles, notification list user count: ',
+      Object.keys(result).length
+    );
   }
-  console.log('[notify] notificationList :' + JSON.stringify(result));
+  // console.log('[notify] notificationList :' + JSON.stringify(result));
   return result;
 };
 


### PR DESCRIPTION
1. Comment out logging `JSON.stringify(result)` as it will crash the terminal when there are 10000 users to send
2. Send incremental `console.log`s so that we can track the processing status 