### PR TITLE
Make most redis keys volatile

### DIFF
--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -5,12 +5,21 @@ const client = redis.createClient(
   process.env.REDIS_URL || 'redis://127.0.0.1:6379'
 );
 
-function set(key, value) {
+const DEFAULT_EXPIRE = 86400;
+/**
+ *
+ * @param {string} key
+ * @param {*} value
+ * @param {number} expire - Default to 1 day. Set to 0 to persist.
+ */
+function set(key, value, expire = DEFAULT_EXPIRE) {
   if (typeof key !== 'string') {
     throw new Error('key of `set(key, value)` must be a string.');
   }
   return new Promise((resolve, reject) => {
-    client.set(key, JSON.stringify(value), (err, reply) => {
+    const expArgs = expire ? ['EX', expire] : [];
+
+    client.set([key, JSON.stringify(value), ...expArgs], (err, reply) => {
       if (err) {
         reject(err);
       } else {

--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -5,7 +5,7 @@ const client = redis.createClient(
   process.env.REDIS_URL || 'redis://127.0.0.1:6379'
 );
 
-const DEFAULT_EXPIRE = 86400;
+const DEFAULT_EXPIRE = 86400 * 30; /* 30 days by default */
 /**
  *
  * @param {string} key

--- a/src/scripts/scanRepliesAndNotify.js
+++ b/src/scripts/scanRepliesAndNotify.js
@@ -17,7 +17,7 @@ export default async function scanRepliesAndNotify() {
     nowWithOffset
   );
   await lib.sendNotification(notificationList);
-  await redis.set('lastScannedAt', nowWithOffset);
+  await redis.set('lastScannedAt', nowWithOffset, 0); // Make lastScannedAt persistent
 
   // disconnect redis and mongodb
   await redis.quit();

--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -126,6 +126,20 @@ const singleUserHandler = async (
     if (type === 'postback') {
       const data = JSON.parse(otherFields.postback.data);
 
+      if (!context.data) {
+        lineClient.post('/message/reply', {
+          replyToken,
+          messages: [
+            {
+              type: 'text',
+              text: '🚧 ' + t`Sorry, the button is expired.`,
+            },
+          ],
+        });
+        clearTimeout(timerId);
+        return;
+      }
+
       // When the postback is expired,
       // i.e. If other new messages have been sent before pressing buttons,
       // Don't do anything, just ignore silently.


### PR DESCRIPTION
In this PR, we make most keys volatile and to `lastScannedAt` key is persistent.

After deploy, we can change Redis `maxmemory-policy` from `allkeys-lru` to `volatile-lru` to ensure that `lastScannedAt` is never evicted.

This PR also handles the case when postback actions are called after the search session is removed from Redis. This should fix https://rollbar.com/mrorz/rumors-line-bot/items/220/ .