### PR TITLE
Fix env in docker

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Echo RELEASE_TAG
         run: 'echo $RELEASE_TAG'
 
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
       - name: Generate staging .env file
         run: 'curl $ENV_URL -o .env'
         env:
@@ -39,9 +42,6 @@ jobs:
         if: ${{ env.RELEASE_TAG == 'latest' }}
 
       - run: head -n 10 .env
-
-      - name: Checkout repo
-        uses: actions/checkout@v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -41,8 +41,6 @@ jobs:
           ENV_URL: ${{ secrets.PRODUCTION_ENV_URL }}
         if: ${{ env.RELEASE_TAG == 'latest' }}
 
-      - run: head -n 10 .env
-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,23 @@ RUN npm install
 #
 COPY . .
 
-RUN head -n 10 .env
+RUN NODE_ENV=production npm run build
+RUN npm prune --production
 
-RUN NODE_ENV=production npm run build:server
+#########################################
+
+FROM node:16-alpine
+
+WORKDIR /srv/www
+EXPOSE 5001
+ENTRYPOINT NODE_ENV=production npm start
+
+RUN apk --no-cache add tesseract-ocr tesseract-ocr-data-chi_tra
+
+COPY package.json package-lock.json ecosystem.config.js ./
+COPY i18n i18n
+COPY static static
+COPY --from=builder /srv/www/node_modules ./node_modules
+COPY --from=builder /srv/www/build ./build
+COPY --from=builder /srv/www/data ./data
+COPY --from=builder /srv/www/liff ./liff

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,23 +11,6 @@ RUN npm install
 #
 COPY . .
 
-RUN NODE_ENV=production npm run build
-RUN npm prune --production
+RUN head -n 10 .env
 
-#########################################
-
-FROM node:16-alpine
-
-WORKDIR /srv/www
-EXPOSE 5001
-ENTRYPOINT NODE_ENV=production npm start
-
-RUN apk --no-cache add tesseract-ocr tesseract-ocr-data-chi_tra
-
-COPY package.json package-lock.json ecosystem.config.js ./
-COPY i18n i18n
-COPY static static
-COPY --from=builder /srv/www/node_modules ./node_modules
-COPY --from=builder /srv/www/build ./build
-COPY --from=builder /srv/www/data ./data
-COPY --from=builder /srv/www/liff ./liff
+RUN NODE_ENV=production npm run build:server


### PR DESCRIPTION
Previously, docker images built by Github actions are always in English.
`console.log` in `babel.config.js` always detects `en_US` locale:
![圖片](https://user-images.githubusercontent.com/108608/120918743-8ae66780-c6e8-11eb-80a3-b51a29b8cdf6.png)

The root cause is that `actions/checkout@v2` action will remove `.env` file. This PR moves `.env` file download to after  `actions/checkout@v2` and the build process can correctly pick up the env file:
![圖片](https://user-images.githubusercontent.com/108608/120918792-cbde7c00-c6e8-11eb-992b-375cec4fe3ba.png)
