### PR TITLE
Issue/220 highlight null

### DIFF
--- a/src/webhook/handlers/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/utils.test.js.snap
@@ -19,6 +19,15 @@ exports[`createFlexMessageText should create a text for flex message 1`] = `"計
 
 exports[`createFlexMessageText should handle the situation without input 1`] = `""`;
 
+exports[`createHighlightContents should handle line-bot#220 issue 1`] = `
+Array [
+  Object {
+    "text": "Original text",
+    "type": "span",
+  },
+]
+`;
+
 exports[`createHighlightContents should create a highlight flex message 1`] = `
 Array [
   Object {

--- a/src/webhook/handlers/__tests__/utils.test.js
+++ b/src/webhook/handlers/__tests__/utils.test.js
@@ -239,6 +239,18 @@ describe('createHighlightContents', () => {
   it('should handle the situation without input', () => {
     expect(createHighlightContents()).toMatchSnapshot();
   });
+
+  it('should handle line-bot#220 issue', () => {
+    expect(
+      createHighlightContents(
+        {
+          text: null,
+          hyperlinks: [],
+        },
+        'Original text'
+      )
+    ).toMatchSnapshot();
+  });
 });
 
 describe('createReplyMessages()', () => {

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -520,6 +520,17 @@ export function createHighlightContents(
     (summaries.length ? summaries.join('\n') : undefined) ||
     (titles.length ? titles.join('\n') : undefined);
 
+  // fix issue 220 (api bug)
+  // return original text if highlight isn't null but text and hyperlinks are null
+  if (!text) {
+    return [
+      {
+        type: 'span',
+        text: ellipsis(oriText, lettersLimit),
+      },
+    ];
+  }
+
   for (let highlightPair of text.split('</HIGHLIGHT>')) {
     const highlightContent = createHighlightContent(
       highlightPair.split('<HIGHLIGHT>')


### PR DESCRIPTION
Changes
1. Fixes #220, return original text if highlight text and hyperlinks are null
We still need to fix this issue in rumors-api

~~2. Update `package-lock.json`, `lockfileVersion`: 1 -> 2~~

Snapshot
![截圖 2021-06-21 上午11 22 10](https://user-images.githubusercontent.com/6376572/122703219-a7a3a300-d283-11eb-821e-2571c5f6b73f.png)

