### PR TITLE
Remove babel.config.js dotenv and set env in Dockerfile instead

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/release') && 'latest' || 'dev' }}
+      LOCALE: zh_TW
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -59,6 +60,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: cofacts/rumors-line-bot:${{ env.RELEASE_TAG }}-tw
+          build-args:
+            - LOCALE=${{ env.LOCALE }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -60,8 +60,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: cofacts/rumors-line-bot:${{ env.RELEASE_TAG }}-tw
-          build-args:
-            - LOCALE=${{ env.LOCALE }}
+          build-args: |
+            "LOCALE=${{ env.LOCALE }}"
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN npm install
 #
 COPY . .
 
+ARG LOCALE=en_US
 RUN NODE_ENV=production npm run build
 RUN npm prune --production
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,4 @@
-require('dotenv').config();
-
 const locale = process.env.LOCALE || 'en_US';
-console.log('[babel.config.js] building locale: ', locale);
 
 // Project-wide config
 //


### PR DESCRIPTION
## Problem
dotenv in babel.config.js it will load .env on unit tests, thus contents in `.env` file can affect `npm test` results and snapshots.

## Expected
Unit test should always use `.env.sample`, as set in `setup-jest.js`.
Changing any env in `.env` file should have no affect on test snapshots and test results.

## Solution
Remove dotenv in `babel.config.js`, which was newly added during [dockerization](https://github.com/cofacts/rumors-line-bot/pull/253)

- babel.config.js only requires LOCALE and is only relevent on docker build, thus set LOCALE in Dockerfile instead.
- LOCALE in `.env` file is overridden by Dockerfile args.
- also enables matrix build of diffrerent languages in the future.