### PR TITLE
Implement AppVariable for persistent app-wide variable

### DIFF
--- a/src/database/models/__tests__/__snapshots__/appVariable.js.snap
+++ b/src/database/models/__tests__/__snapshots__/appVariable.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`appVariable [model] sets valid value to DB 1`] = `
+Object {
+  "_id": "foo",
+  "value": "123456",
+}
+`;

--- a/src/database/models/__tests__/appVariable.js
+++ b/src/database/models/__tests__/appVariable.js
@@ -1,0 +1,52 @@
+import Client from '../../mongoClient';
+import AppVariable from '../appVariable';
+
+describe('appVariable', () => {
+  beforeAll(async () => {
+    if (await AppVariable.collectionExists()) {
+      await (await AppVariable.client).drop();
+    }
+  });
+
+  afterAll(async () => {
+    await (await Client.getInstance()).close();
+  });
+
+  it('[schema] should pass', async () => {
+    const data = {
+      _id: 'foo',
+      value: 'some string',
+    };
+    const { valid } = AppVariable.validator(data);
+    expect(valid).toBe(true);
+  });
+
+  it('[model] sets valid value to DB', async () => {
+    await AppVariable.set('foo', 123456);
+
+    const data = (await AppVariable.find({ _id: 'foo' }))[0];
+    expect(data).toMatchSnapshot();
+
+    const { valid } = AppVariable.validator(data);
+    expect(valid).toBe(true);
+  });
+
+  it('[model] gets undefined for variables not set yet', async () => {
+    const value = await AppVariable.get('notExist');
+    expect(value).toBe(undefined);
+  });
+
+  it('[model] gets setted primitive and objects', async () => {
+    await AppVariable.set('num', 123456);
+    expect(await AppVariable.get('num')).toBe(123456);
+
+    await AppVariable.set('null', null);
+    expect(await AppVariable.get('null')).toBe(null);
+
+    await AppVariable.set('str', '123');
+    expect(await AppVariable.get('str')).toBe('123');
+
+    await AppVariable.set('obj', { foo: 123 });
+    expect(await AppVariable.get('obj')).toEqual({ foo: 123 });
+  });
+});

--- a/src/database/models/appVariable.js
+++ b/src/database/models/appVariable.js
@@ -10,12 +10,13 @@ class AppVariable extends Base {
    * @returns {Promise<any>} - variable value
    */
   static async get(varName) {
-    try {
-      return JSON.parse((await this.find({ _id: varName }))[0].value);
-    } catch (e) {
-      // Resolves to undefined if not set at all
+    const result = await this.find({ _id: varName });
+    if (result.length === 0) {
+      // Resolves to undefined if varName is not set previously
       return;
     }
+
+    return JSON.parse(result[0].value);
   }
 
   /**

--- a/src/database/models/appVariable.js
+++ b/src/database/models/appVariable.js
@@ -1,0 +1,34 @@
+import Base from './base';
+
+class AppVariable extends Base {
+  static get collection() {
+    return 'appVariable';
+  }
+
+  /**
+   * @param {string} varName - the name of app variable to read
+   * @returns {Promise<any>} - variable value
+   */
+  static async get(varName) {
+    try {
+      return JSON.parse((await this.find({ _id: varName }))[0].value);
+    } catch (e) {
+      // Resolves to undefined if not set at all
+      return;
+    }
+  }
+
+  /**
+   *
+   * @param {string} varName - the name of app variable to write
+   * @param {any} value
+   * @returns {Promise<AppVariable>}
+   */
+  static async set(varName, value) {
+    const valueStr = JSON.stringify(value);
+
+    return this.findOneAndUpdate({ _id: varName }, { value: valueStr });
+  }
+}
+
+export default AppVariable;

--- a/src/database/models/appVariable.json
+++ b/src/database/models/appVariable.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "cofacts/schemas/appVariable",
+  "$comment": "design document https://g0v.hackmd.io/eIeU2g86Tfu5VnLazNfUvQ",
+  "description": "A representation of an AppVariable",
+  "title": "AppVariable",
+  "type": "object",
+
+  "properties": {
+    "_id": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "required": [ "value" ]
+}

--- a/src/database/models/schemaValidator.js
+++ b/src/database/models/schemaValidator.js
@@ -5,6 +5,7 @@ const ajv = new Ajv();
 const SCHEMAS = {
   userArticleLink: require('./userArticleLink.json'),
   userSettings: require('./userSettings.json'),
+  appVariable: require('./appVariable.json'),
 };
 
 const ClassTable = {
@@ -31,4 +32,5 @@ export function compile(schemaName) {
 export const validators = {
   userArticleLink: compile('userArticleLink'),
   userSettings: compile('userSettings'),
+  appVariable: compile('appVariable'),
 };

--- a/src/scripts/scanRepliesAndNotify.js
+++ b/src/scripts/scanRepliesAndNotify.js
@@ -20,6 +20,7 @@ export default async function scanRepliesAndNotify() {
   await AppVariable.set('lastScannedAt', nowWithOffset);
 }
 
+/* istanbul ignore if */
 if (require.main === module) {
   scanRepliesAndNotify()
     .catch(e => {


### PR DESCRIPTION
In order to fix [missing `lastScannedAt` issue](https://g0v.hackmd.io/giYWfM8yRkKghtPOG1EBig#Notification-count-issue) which causes notifications to send in bulk, we move `lastScannedAt` from Redis to MongoDB instead.

This PR:
- Introduces new model `AppVariable` with `set()` and `get()`
- The value is persisted in MongoDB
- Uses `AppVariable` to replace `redis` in notification scanning code