### PR TITLE
Tell the user the postback button no longer works if their user session is expired

### DIFF
--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -126,6 +126,21 @@ const singleUserHandler = async (
     if (type === 'postback') {
       const data = JSON.parse(otherFields.postback.data);
 
+      // Handle the case when user context in redis is expired
+      if (!context.data) {
+        lineClient.post('/message/reply', {
+          replyToken,
+          messages: [
+            {
+              type: 'text',
+              text: '🚧 ' + t`Sorry, the button is expired.`,
+            },
+          ],
+        });
+        clearTimeout(timerId);
+        return;
+      }
+
       // When the postback is expired,
       // i.e. If other new messages have been sent before pressing buttons,
       // Don't do anything, just ignore silently.


### PR DESCRIPTION
This PR handles the case when postback actions are called after the search session is removed from Redis.

This should fix https://rollbar.com/mrorz/rumors-line-bot/items/220/ .

