### PR TITLE
LIFF FeedbackForm and positive / negative feedback page

### DIFF
--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -79,33 +79,36 @@ msgstr ""
 "不實訊息常常會被人修改重發。\n"
 "請選擇比較接近的版本"
 
-#: src/webhook/handlers/utils.js:589
+#: src/webhook/handlers/utils.js:600
 msgid "Someone on the internet replies to the message:"
 msgstr "網路上有人這樣回應這則訊息："
 
-#: src/webhook/handlers/utils.js:633
+#: src/webhook/handlers/utils.js:644
 #, javascript-format
 msgid "Therefore, the author think the message ${ typeStr }."
 msgstr "綜合以上，回應者認為它${typeStr}。"
 
-#: src/webhook/handlers/utils.js:636
+#: src/webhook/handlers/utils.js:647
 msgid ""
 "There are different replies for the message. Read them all here before "
 "making judgements:"
 msgstr "這則訊息有很多不同回應，建議到這裡一次讀完再下判斷："
 
-#: src/webhook/handlers/utils.js:638
+#: src/webhook/handlers/utils.js:649
 msgid "If you have different thoughts, you may have your say here:"
 msgstr "如果你對這則訊息有不同看法，歡迎到下面這裡寫入新的回應："
 
+#: src/liff/components/FeedbackForm.svelte:23
 #: src/webhook/handlers/choosingReply.js:19
 msgid "Is the reply helpful?"
 msgstr "請問上面回應是否有幫助？"
 
+#: src/liff/components/FeedbackForm.svelte:27
 #: src/webhook/handlers/choosingReply.js:55
 msgid "Yes"
 msgstr "是"
 
+#: src/liff/components/FeedbackForm.svelte:30
 #: src/webhook/handlers/choosingReply.js:65
 msgid "No"
 msgstr "否"
@@ -153,13 +156,13 @@ msgstr "不好意思！系統可能在忙線中，無法及時處理您傳的訊
 msgid "Wrong usage"
 msgstr "這不是這樣用的"
 
-#: src/webhook/index.js:142
+#: src/webhook/index.js:157
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "您已經在搜尋新的訊息了，過去查過的訊息的按鈕已經失效囉。"
 
-#: src/webhook/index.js:279
+#: src/webhook/index.js:294
 msgid ""
 "Oops, something is not working. We have cleared your search data, hopefully "
 "the error will go away. Would you please send us the message from the start?"
@@ -254,7 +257,7 @@ msgstr "${ countOfType.NOT_ARTICLE } 人認為它 ⚠️️ 不在 Cofacts 的�
 msgid "I choose “${ displayTextWhenChosen }”"
 msgstr "我要選「${displayTextWhenChosen}」"
 
-#: src/liff/pages/Reason.svelte:80
+#: src/liff/pages/Reason.svelte:79
 #: src/liff/pages/Source.svelte:33
 #: src/webhook/handlers/choosingArticle.js:303
 #: src/webhook/handlers/utils.js:473
@@ -370,6 +373,7 @@ msgid "This button was for previous search and is now expired."
 msgstr "您已經傳了新訊息進來，這個舊按鈕已經失效囉。"
 
 #: src/liff/lib.js:119
+#: src/webhook/index.js:136
 msgid "Sorry, the button is expired."
 msgstr "不好意思，這是有點久以前的訊息，現在按鈕已經失效囉。"
 
@@ -377,39 +381,16 @@ msgstr "不好意思，這是有點久以前的訊息，現在按鈕已經失效
 msgid "Sorry, the function is not applicable on desktop."
 msgstr "不好意思，在桌面環境無法使用這個功能。"
 
-#: src/liff/pages/NegativeFeedback.svelte:36
-msgid "Report not useful"
-msgstr "表示回應沒幫助"
-
-#: src/liff/pages/NegativeFeedback.svelte:37
-msgid ""
-"Your feedback has been recorded. We are sorry that the reply is not useful "
-"to you."
-msgstr "已經記下您的評價。很遺憾這則回應對您沒有幫助。"
-
-#: src/liff/pages/NegativeFeedback.svelte:38
-msgid "How can we make it useful to you?"
-msgstr "請問您覺得怎麼改才會更有幫助呢？"
-
-#: src/liff/pages/NegativeFeedback.svelte:41
-#: src/liff/pages/PositiveFeedback.svelte:41
-#: src/liff/pages/Reason.svelte:87
+#: src/liff/components/FeedbackForm.svelte:38
+#: src/liff/pages/Reason.svelte:86
 msgid "Submit"
 msgstr "送出"
 
-#: src/liff/pages/PositiveFeedback.svelte:36
-msgid "Report reply useful"
-msgstr "表示回應有幫助"
-
-#: src/liff/pages/PositiveFeedback.svelte:37
-msgid "We have recorded your feedback. It's glad to see the reply is helpful."
-msgstr "已經記下您的評價。很開心這則回應有幫助到您。"
-
-#: src/liff/pages/PositiveFeedback.svelte:38
+#: src/liff/components/FeedbackForm.svelte:32
 msgid "Do you have anything to add about the reply?"
 msgstr "針對這則回應，有沒有想補充的呢？"
 
-#: src/liff/pages/Reason.svelte:11
+#: src/liff/pages/Reason.svelte:10
 #. t: Guidance in LIFF
 msgid ""
 "You may try:\n"
@@ -422,7 +403,7 @@ msgstr ""
 "2. 去 google 查查看\n"
 "3. 把全文複製貼上到 Facebook 搜尋框看看"
 
-#: src/liff/pages/Reason.svelte:17
+#: src/liff/pages/Reason.svelte:16
 #. t: Guidance in LIFF
 #, javascript-format
 msgid ""
@@ -440,7 +421,7 @@ msgstr ""
 "\n"
 "若要補充資訊，請按「取消」；覺得現在這樣送出就好，請按「確定」。"
 
-#: src/liff/pages/Reason.svelte:24
+#: src/liff/pages/Reason.svelte:23
 #. t: Guidance in LIFF
 msgid ""
 "The info you provide should not be identical to the message itself.\n"
@@ -451,15 +432,15 @@ msgstr ""
 "\n"
 "${ LENGHEN_HINT }"
 
-#: src/liff/pages/Reason.svelte:81
+#: src/liff/pages/Reason.svelte:80
 msgid "To help with fact-checking, please tell the editors:"
 msgstr "為了協助查證，請告訴闢謠編輯："
 
-#: src/liff/pages/Reason.svelte:82
+#: src/liff/pages/Reason.svelte:81
 msgid "Why do you think this is a hoax?"
 msgstr "為何您覺得這是謠言？"
 
-#: src/liff/pages/Reason.svelte:84
+#: src/liff/pages/Reason.svelte:83
 msgid ""
 "Ex: I googled using (some keyword) and found that... / I found different "
 "opinion on (some website) saying that..."
@@ -523,17 +504,17 @@ msgstr "查過的訊息"
 msgid "Fetching viewed messages"
 msgstr "載入查過的訊息"
 
-#: src/liff/components/ViewedArticle.svelte:37
-#: src/liff/components/ViewedArticle.svelte:42
-#: src/liff/pages/Reason.svelte:87
+#: src/liff/components/ViewedArticle.svelte:36
+#: src/liff/components/ViewedArticle.svelte:41
+#: src/liff/pages/Reason.svelte:86
 msgid "Loading"
 msgstr "載入中"
 
-#: src/liff/components/ViewedArticle.svelte:38
+#: src/liff/components/ViewedArticle.svelte:37
 msgid "No replies yet"
 msgstr "尚無回應"
 
-#: src/liff/components/ViewedArticle.svelte:27
+#: src/liff/components/ViewedArticle.svelte:26
 msgid "${ replyCount } reply"
 msgid_plural "${ replyCount } replies"
 msgstr[0] "${ replyCount } 則回應"
@@ -542,12 +523,12 @@ msgstr[0] "${ replyCount } 則回應"
 msgid "See replies of"
 msgstr "查看這篇的回應"
 
-#: src/liff/components/ViewedArticle.svelte:32
+#: src/liff/components/ViewedArticle.svelte:31
 #, javascript-format
 msgid "Viewed ${ fromNow } ago"
 msgstr "${fromNow}前看過"
 
-#: src/liff/components/ViewedArticle.svelte:26
+#: src/liff/components/ViewedArticle.svelte:25
 #, javascript-format
 msgid "${ newArticleReplyCount } new reply"
 msgid_plural "${ newArticleReplyCount } new replies"
@@ -567,7 +548,7 @@ msgstr "上一頁"
 msgid "Next"
 msgstr "下一頁"
 
-#: src/liff/pages/UserSetting.svelte:66
+#: src/liff/pages/UserSetting.svelte:64
 msgid "Settings"
 msgstr "設定"
 
@@ -582,7 +563,7 @@ msgid ""
 "can interact with chatbot while clicking the buttons."
 msgstr "請重試一次，並允許「傳訊息至聊天室」權限，您按下按鈕的時候才能和「Cofacts 真的假的」機器人互動。"
 
-#: src/scripts/lib.js:146
+#: src/scripts/lib.js:150
 #, javascript-format
 msgid ""
 "There are new replies for the articles you have searched. Please see 'View "
@@ -591,11 +572,11 @@ msgstr ""
 "您搜尋過的訊息有新的回應，請到 Cofacts 機器人 (${ process.env.LINE_FRIEND_URL }) "
 "選單，點選右下角的「看過的訊息」查看。"
 
-#: src/scripts/lib.js:179
+#: src/scripts/lib.js:183
 msgid "View new replies"
 msgstr "查看新回應"
 
-#: src/scripts/lib.js:180
+#: src/scripts/lib.js:184
 msgid ""
 "There are new replies for the articles you have searched. Click the button "
 "for more details."
@@ -605,7 +586,7 @@ msgstr "有人針對您之前曾看過的訊息，寫了新的查證回應唷！
 msgid "(Words found in the hyperlink)"
 msgstr "（網址裡找到的字）"
 
-#: src/liff/pages/UserSetting.svelte:67
+#: src/liff/pages/UserSetting.svelte:65
 msgid "Welcome to Cofacts!"
 msgstr "感謝您加 Cofacts 好友！"
 
@@ -615,15 +596,15 @@ msgid ""
 "before."
 msgstr "當您查過的訊息有新回應時，Cofacts 可以通知您。"
 
-#: src/liff/pages/UserSetting.svelte:71
+#: src/liff/pages/UserSetting.svelte:68
 msgid "Notify me of new responses"
 msgstr "有新回應時通知我"
 
-#: src/liff/pages/UserSetting.svelte:73
+#: src/liff/pages/UserSetting.svelte:71
 msgid "No setup option for now :)"
 msgstr "目前沒有設定選項 :)"
 
-#: src/liff/pages/UserSetting.svelte:68
+#: src/liff/pages/UserSetting.svelte:66
 msgid "You can configure Cofacts here to meet your need."
 msgstr "您可以在這裡設定 Cofacts 以符合需求。"
 
@@ -641,7 +622,7 @@ msgstr "前往設定"
 msgid "Receive updates"
 msgstr "開啟小鈴鐺"
 
-#: src/liff/pages/UserSetting.svelte:69
+#: src/liff/pages/UserSetting.svelte:67
 msgid "Fetching settings"
 msgstr "載入設定中"
 
@@ -768,7 +749,7 @@ msgid ""
 "database."
 msgstr "如果我找不到的話，會徵求你的同意，看看要不要把這個訊息送進資料庫唷。"
 
-#: src/webhook/handlers/utils.js:634
+#: src/webhook/handlers/utils.js:645
 msgid ""
 "This content is provided by Cofact message reporting chatbot and "
 "crowd-sourced fact-checking community under CC BY-SA 4.0 license. Please "
@@ -777,7 +758,7 @@ msgstr ""
 "此內容由「Cofacts 真的假的」訊息回報機器人與查核協作社群提供，以創用 CC 姓名標示-相同方式分享 4.0 國際 "
 "授權條款釋出。請斟酌出處與理由，自行思考判斷。"
 
-#: src/webhook/handlers/utils.js:614
+#: src/webhook/handlers/utils.js:625
 msgid "I found that there are some disagreement to the message:"
 msgstr "剛剛這則訊息，我查過似乎發現有點問題。有另外一種說法是："
 
@@ -785,7 +766,7 @@ msgstr "剛剛這則訊息，我查過似乎發現有點問題。有另外一種
 msgid "Hi i am cofacts chat bot"
 msgstr "Hi 我是「Cofacts 真的假的」訊息查證機器人～"
 
-#: src/webhook/handlers/utils.js:614
+#: src/webhook/handlers/utils.js:625
 #, javascript-format
 msgid "Thank you for sharing “${ inputSummary }”"
 msgstr "感謝您的分享 “${ inputSummary }”"
@@ -823,3 +804,43 @@ msgstr ""
 "對訊息保持懷疑很好唷！ 👍\n"
 "\n"
 "不過我目前還不認得「${ inputSummary }」。可以請你幫我一個忙嗎？"
+
+#: src/liff/components/FeedbackForm.svelte:22
+msgid "Please help Cofacts editors"
+msgstr "幫幫 Cofacts 闢謠志工"
+
+#: src/liff/components/FeedbackForm.svelte:31
+msgid "It's glad to see the reply is helpful."
+msgstr "很開心這則 Cofacts 回應有幫助到您。"
+
+#: src/liff/components/FeedbackForm.svelte:39
+msgid "Please provide your comment above"
+msgstr "請在上面輸入寶貴建議"
+
+#: src/liff/components/FeedbackForm.svelte:40
+msgid "Close"
+msgstr "關閉"
+
+#: src/liff/pages/NegativeFeedback.svelte:41
+msgid "Report not helpful"
+msgstr "表示回應沒幫助"
+
+#: src/liff/pages/PositiveFeedback.svelte:42
+msgid "Report reply helpful"
+msgstr "表示回應有幫助"
+
+#: src/liff/components/FeedbackForm.svelte:34
+msgid "We are sorry that the reply is not helpful to you."
+msgstr "很遺憾這則 Cofacts 回應對您沒有幫助。"
+
+#: src/liff/components/FeedbackForm.svelte:35
+msgid "How can we make it helpful to you?"
+msgstr "請問您覺得怎麼改才會更有幫助呢？"
+
+#: src/liff/components/FeedbackForm.svelte:33
+msgid "I think the reply is helpful and I want to add..."
+msgstr "這個回應有幫助到我，我想補充⋯⋯"
+
+#: src/liff/components/FeedbackForm.svelte:36
+msgid "I think the reply is not helpful and I suggest..."
+msgstr "這個回應不太有幫助，我建議⋯⋯"

--- a/src/liff/components/Button.stories.svelte
+++ b/src/liff/components/Button.stories.svelte
@@ -45,3 +45,10 @@
     <Button variant="outlined">variant = outlined</Button>
   </div>
 </Story>
+
+<Story name="Font colors">
+  <div class="colorBg">
+    <Button variant="contained" style="color: rebeccapurple;">rebeccapurple</Button>
+    <Button variant="outlined" style="color: rebeccapurple;">rebeccapurple</Button>
+  </div>
+</Story>

--- a/src/liff/components/Button.svelte
+++ b/src/liff/components/Button.svelte
@@ -21,16 +21,32 @@
     border-radius: 32px;
     transition: background-color .2s;
     cursor: pointer;
+    color: inherit;
   }
 
   .outlined {
     background: transparent;
     border: 2px solid currentColor;
     padding: 6px 10px; /* shrink padding for border */
+
+    position: relative;
   }
 
-  .outlined:hover {
-    background: rgba(255, 255, 255, 0.8);
+  .outlined::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background-color: currentColor;
+    border-radius: 32px;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .outlined:hover::before {
+    opacity: 0.2;
   }
 
   .contained {

--- a/src/liff/components/FeedbackForm.stories.svelte
+++ b/src/liff/components/FeedbackForm.stories.svelte
@@ -1,0 +1,37 @@
+<script>
+  import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+  import FeedbackForm from "./FeedbackForm.svelte";
+</script>
+
+<Meta
+  title="FeedbackForm"
+  component={FeedbackForm}
+  argTypes={{
+    onVote: {action: 'onVote'},
+    onComment: {action: 'onComment'},
+    score: {
+      options: [null, 1, -1],
+      control: {type: 'radio'}
+    }
+  }}
+/>
+
+<Template let:args>
+  <FeedbackForm
+    {...args}
+    on:vote={args.onVote}
+    on:comment={args.onComment}
+  />
+</Template>
+
+<Story name="No Data"/>
+
+<Story
+  name="Upvoted"
+  args={{ score: 1 }}
+/>
+
+<Story
+  name="Downvoted"
+  args={{ score: -1 }}
+/>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -57,7 +57,19 @@
   }
 
   .form {
-    display: contents;
+    display: flex;
+    flex-flow: column;
+    position: relative; /* for .bg-icon */
+    gap: 4px;
+  }
+
+  .form :global(.bg-icon) {
+    position: absolute;
+    width: 76px;
+    height: 76px;
+    top: -12px;
+    right: -12px;
+    opacity: 0.16;
   }
 
   .form :global(textarea) {
@@ -115,6 +127,7 @@
   {#if score !== null}
     <form class="form" on:submit|preventDefault={handleCommentSubmit}>
       {#if score === 1}
+        <ThumbsUpIcon class="bg-icon" />
         <p>{t`It's glad to see the reply is helpful.`}</p>
         <p class="emphasize">
           {t`Do you have anything to add about the reply?`}
@@ -124,6 +137,7 @@
           placeholder={t`I think the reply is useful and I want to add`}
         />
       {:else if score === -1}
+        <ThumbsDownIcon class="bg-icon" />
         <p>{t`We are sorry that the reply is not useful to you.`}</p>
         <p class="emphasize">
           {t`How can we make it useful to you?`}

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -28,22 +28,23 @@
     gap: 4px;
     color: #fff;
     font-size: 16px;
+    background: var(--bg);
+  }
+
+  section.notVotedYet {
+    --bg: var(--primary500);
+  }
+
+  section.upvoted {
+    --bg: var(--green1);
+  }
+
+  section.downvoted {
+    --bg: var(--red1);
   }
 
   p {
     margin: 0;
-  }
-
-  section.notVotedYet {
-    background: var(--primary500);
-  }
-
-  section.upvoted {
-    background: var(--green1);
-  }
-
-  section.downvoted {
-    background: var(--red1);
   }
 
   .buttons {
@@ -85,6 +86,7 @@
   <div class="buttons" style={`margin: 8px 0 ${ score === null ? 4 : 16 }px`}>
     <Button
       variant={score === -1 ? 'outlined' : 'contained'}
+      style={`color: ${score === -1 ? '#fff' : 'var(--bg)'};`}
       {disabled}
       on:click={() => dispatch('vote', 1)}
     >
@@ -97,6 +99,7 @@
     </Button>
     <Button
       variant={score === 1 ? 'outlined' : 'contained'}
+      style={`color: ${score === 1 ? '#fff' : 'var(--bg)'};`}
       {disabled}
       on:click={() => dispatch('vote', -1)}
     >
@@ -130,7 +133,7 @@
           placeholder={t`I think the reply is not useful and I suggest`}
         />
       {/if}
-      <div class="buttons" style="margin-top: 16px">
+      <div class="buttons" style="margin-top: 16px;">
         <Button type="submit" {disabled}>
           {t`Submit`}
         </Button>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -12,10 +12,10 @@
   /** Vote status. Values: null | 1 | -1 */
   export let score = null;
   export let disabled = false;
+  export let comment = '';
 
   const dispatch = createEventDispatcher();
-  const handleCommentSubmit = event => {
-    const comment = event.target.elements.comment.value;
+  const handleCommentSubmit = () => {
     dispatch('comment', comment);
   }
 </script>
@@ -137,6 +137,7 @@
         <TextArea
           name="comment"
           placeholder={t`I think the reply is useful and I want to add`}
+          bind:value={comment}
         />
       {:else if score === -1}
         <ThumbsDownIcon class="bg-icon" />
@@ -147,11 +148,18 @@
         <TextArea
           name="comment"
           placeholder={t`I think the reply is not useful and I suggest`}
+          bind:value={comment}
         />
       {/if}
       <div class="buttons" style="margin-top: 16px;">
-        <Button type="submit" {disabled}>
-          {t`Submit`}
+        <Button type="submit" disabled={disabled || (score === -1 && comment.length === 0)}>
+          {#if comment.length > 0}
+            {t`Submit`}
+          {:else if score === -1}
+            {t`Please provide your comment above`}
+          {:else}
+            {t`Close`}
+          {/if}
         </Button>
       </div>
     </form>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -136,18 +136,18 @@
         </p>
         <TextArea
           name="comment"
-          placeholder={t`I think the reply is useful and I want to add`}
+          placeholder={t`I think the reply is helpful and I want to add...`}
           bind:value={comment}
         />
       {:else if score === -1}
         <ThumbsDownIcon class="bg-icon" />
-        <p>{t`We are sorry that the reply is not useful to you.`}</p>
+        <p>{t`We are sorry that the reply is not helpful to you.`}</p>
         <p class="emphasize">
-          {t`How can we make it useful to you?`}
+          {t`How can we make it helpful to you?`}
         </p>
         <TextArea
           name="comment"
-          placeholder={t`I think the reply is not useful and I suggest`}
+          placeholder={t`I think the reply is not helpful and I suggest...`}
           bind:value={comment}
         />
       {/if}

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -1,0 +1,120 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import { t } from 'ttag';
+
+  import TextArea from './TextArea.svelte';
+  import Button from './Button.svelte';
+  import ThumbsUpIcon from './icons/ThumbsUpIcon.svelte';
+  import ThumbsUpOutlineIcon from './icons/ThumbsUpOutlineIcon.svelte';
+  import ThumbsDownIcon from './icons/ThumbsDownIcon.svelte';
+  import ThumbsDownOutlineIcon from './icons/ThumbsDownOutlineIcon.svelte';
+
+  /** Vote status. Values: null | 1 | -1 */
+  export let score = null;
+  export let disabled = false;
+
+  const dispatch = createEventDispatcher();
+  const handleCommentSubmit = event => {
+    const comment = event.target.elements.comment.value;
+    dispatch('comment', comment);
+  }
+</script>
+
+<style>
+  section {
+    padding: 16px;
+    display: flex;
+    flex-flow: column;
+    gap: 8px;
+    color: #fff;
+    font-size: 16px;
+  }
+
+  section.notVotedYet {
+    background: var(--primary500);
+  }
+
+  section.upvoted {
+    background: var(--green1);
+  }
+
+  section.downvoted {
+    background: var(--red1);
+  }
+
+  .buttons {
+    display: flex;
+    gap: 8px;
+  }
+
+  .emphasize {
+    font-weight: 700;
+  }
+</style>
+
+<section
+  class:notVotedYet={score === null}
+  class:upvoted={score === 1}
+  class:downvoted={score === -1}
+  {...$$restProps}
+>
+  {#if score === null}
+    <p>{t`Please help Cofacts editors`}</p>
+  {/if}
+  <p class:emphasize={score === null}>
+    {t`Is this reply useful?`}
+  </p>
+  <div class="buttons">
+    <Button
+      variant={score === -1 ? 'outlined' : 'contained'}
+      {disabled}
+      on:click={() => dispatch('vote', 1)}
+    >
+      {#if score === 1}
+        <ThumbsUpIcon />
+      {:else}
+        <ThumbsUpOutlineIcon />
+      {/if}
+      {t`Yes`}
+    </Button>
+    <Button
+      variant={score === 1 ? 'outlined' : 'contained'}
+      {disabled}
+      on:click={() => dispatch('vote', -1)}
+    >
+      {#if score === -1}
+        <ThumbsDownIcon />
+      {:else}
+        <ThumbsDownOutlineIcon />
+      {/if}
+      {t`No`}
+    </Button>
+  </div>
+
+  {#if score !== null}
+    <form on:submit|preventDefault={handleCommentSubmit}>
+      {#if score === 1}
+        <p>{t`It's glad to see the reply is helpful.`}</p>
+        <p class="emphasize">
+          {t`Do you have anything to add about the reply?`}
+        </p>
+        <TextArea
+          name="comment"
+          placeholder={t`I think the reply is useful and I want to add`}
+        />
+      {:else if score === -1}
+        <p>{t`We are sorry that the reply is not useful to you.`}</p>
+        <p class="emphasize">
+          {t`How can we make it useful to you?`}
+        </p>
+        <TextArea
+          name="comment"
+          placeholder={t`I think the reply is not useful and I suggest`}
+        />
+      {/if}
+      <Button type="submit" {disabled}>
+        {t`Submit`}
+      </Button>
+    </form>
+  {/if}
+</section>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -25,9 +25,13 @@
     padding: 16px;
     display: flex;
     flex-flow: column;
-    gap: 8px;
+    gap: 4px;
     color: #fff;
     font-size: 16px;
+  }
+
+  p {
+    margin: 0;
   }
 
   section.notVotedYet {
@@ -47,6 +51,20 @@
     gap: 8px;
   }
 
+  .buttons > :global(*) {
+    flex: 1;
+  }
+
+  .form {
+    display: contents;
+  }
+
+  .form :global(textarea) {
+    margin-top: 12px;
+    min-height: 120px;
+    flex: 1; /* extend to container size */
+  }
+
   .emphasize {
     font-weight: 700;
   }
@@ -64,7 +82,7 @@
   <p class:emphasize={score === null}>
     {t`Is this reply useful?`}
   </p>
-  <div class="buttons">
+  <div class="buttons" style={`margin: 8px 0 ${ score === null ? 4 : 16 }px`}>
     <Button
       variant={score === -1 ? 'outlined' : 'contained'}
       {disabled}
@@ -92,7 +110,7 @@
   </div>
 
   {#if score !== null}
-    <form on:submit|preventDefault={handleCommentSubmit}>
+    <form class="form" on:submit|preventDefault={handleCommentSubmit}>
       {#if score === 1}
         <p>{t`It's glad to see the reply is helpful.`}</p>
         <p class="emphasize">
@@ -112,9 +130,11 @@
           placeholder={t`I think the reply is not useful and I suggest`}
         />
       {/if}
-      <Button type="submit" {disabled}>
-        {t`Submit`}
-      </Button>
+      <div class="buttons" style="margin-top: 16px">
+        <Button type="submit" {disabled}>
+          {t`Submit`}
+        </Button>
+      </div>
     </form>
   {/if}
 </section>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -56,14 +56,16 @@
     flex: 1;
   }
 
-  .form {
+  form {
     display: flex;
     flex-flow: column;
     position: relative; /* for .bg-icon */
+    flex: 1; /* extend to container size */
     gap: 4px;
+    margin: 0; /* reset browser native style */
   }
 
-  .form :global(.bg-icon) {
+  form :global(.bg-icon) {
     position: absolute;
     width: 76px;
     height: 76px;
@@ -72,9 +74,9 @@
     opacity: 0.16;
   }
 
-  .form :global(textarea) {
+  form :global(textarea) {
     margin-top: 12px;
-    min-height: 120px;
+    min-height: 80px;
     flex: 1; /* extend to container size */
   }
 
@@ -125,7 +127,7 @@
   </div>
 
   {#if score !== null}
-    <form class="form" on:submit|preventDefault={handleCommentSubmit}>
+    <form on:submit|preventDefault={handleCommentSubmit}>
       {#if score === 1}
         <ThumbsUpIcon class="bg-icon" />
         <p>{t`It's glad to see the reply is helpful.`}</p>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -95,7 +95,7 @@
     <p>{t`Please help Cofacts editors`}</p>
   {/if}
   <p class:emphasize={score === null}>
-    {t`Is this reply useful?`}
+    {t`Is the reply helpful?`}
   </p>
   <div class="buttons" style={`margin: 8px 0 ${ score === null ? 4 : 16 }px`}>
     <Button

--- a/src/liff/index.css
+++ b/src/liff/index.css
@@ -50,4 +50,7 @@ html {
 
 body {
   background: var(--secondary50);
+  display: flex;
+  flex-flow: column;
+  min-height: 100%;
 }

--- a/src/liff/pages/NegativeFeedback.svelte
+++ b/src/liff/pages/NegativeFeedback.svelte
@@ -1,13 +1,11 @@
 <script>
   import { onMount } from 'svelte';
   import { t } from 'ttag';
-  import Button from '../components/Button.svelte';
-  import TextArea from '../components/TextArea.svelte';
+  import FeedbackForm from '../components/FeedbackForm.svelte' ;
   import { DOWNVOTE_PREFIX } from 'src/lib/sharedUtils';
-  import { gql, assertInClient, assertSameSearchSession, sendMessages } from '../lib';
+  import { gql, assertInClient, assertSameSearchSession, sendMessages, page } from '../lib';
 
   let processing = false;
-  let comment = '';
 
   // Submitting feedback without comment first
   onMount(async () => {
@@ -20,8 +18,15 @@
     `();
   });
 
-  const handleSubmit = async () => {
+  const handleVote = (e) => {
+    if(e.detail === 1) {
+      page.set('feedback/yes')
+    }
+  }
+
+  const handleComment = async (e) => {
     processing = true;
+    const comment = (e.detail || '').trim()
 
     await sendMessages([
       {
@@ -39,33 +44,14 @@
 </svelte:head>
 
 <style>
-  main {
-    padding: 16px;
-    display: flex;
-    flex-flow: column;
-    gap: 8px;
-  }
-
-  main :global(.input) {
-    border: 2px solid var(--secondary300);
+  :global(.negative-form) {
+    flex: 1;
   }
 </style>
 
-<main>
-  <p>{t`Your feedback has been recorded. We are sorry that the reply is not useful to you.`}</p>
-  <strong>{t`How can we make it useful to you?`}</strong>
-
-  <TextArea
-    class="input"
-    bind:value={comment}
-    rows={8}
-    placeholder={t`I think the reply is not useful and I suggest`}
-  />
-
-  <Button
-    on:click={handleSubmit}
-    disabled={processing}
-  >
-    {t`Submit`}
-  </Button>
-</main>
+<FeedbackForm
+  class="negative-form"
+  score={-1}
+  on:vote={handleVote}
+  on:comment={handleComment}
+/>

--- a/src/liff/pages/NegativeFeedback.svelte
+++ b/src/liff/pages/NegativeFeedback.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <svelte:head>
-  <title>{t`Report not useful`}</title>
+  <title>{t`Report not helpful`}</title>
 </svelte:head>
 
 <style>

--- a/src/liff/pages/NegativeFeedback.svelte
+++ b/src/liff/pages/NegativeFeedback.svelte
@@ -26,7 +26,7 @@
 
   const handleComment = async (e) => {
     processing = true;
-    const comment = (e.detail || '').trim()
+    const comment = (e.detail || '').trim();
 
     await sendMessages([
       {

--- a/src/liff/pages/PositiveFeedback.svelte
+++ b/src/liff/pages/PositiveFeedback.svelte
@@ -25,7 +25,7 @@
     }
   }
 
-  const handleComment = async () => {
+  const handleComment = async (e) => {
     processing = true;
     const comment = (e.detail || '').trim();
 

--- a/src/liff/pages/PositiveFeedback.svelte
+++ b/src/liff/pages/PositiveFeedback.svelte
@@ -1,14 +1,12 @@
 <script>
   import { onMount } from 'svelte';
   import { t } from 'ttag';
-  import TextArea from '../components/TextArea.svelte';
-  import Button from '../components/Button.svelte';
+  import FeedbackForm from '../components/FeedbackForm.svelte' ;
 
   import { UPVOTE_PREFIX } from 'src/lib/sharedUtils';
-  import { gql, assertInClient, assertSameSearchSession, sendMessages } from '../lib';
+  import { gql, assertInClient, assertSameSearchSession, sendMessages, page } from '../lib';
 
   let processing = false;
-  let comment = '';
 
   // Submitting feedback without comment first
   onMount(async () => {
@@ -21,8 +19,15 @@
     `();
   });
 
-  const handleSubmit = async () => {
+  const handleVote = (e) => {
+    if(e.detail === -1) {
+      page.set('feedback/no')
+    }
+  }
+
+  const handleComment = async () => {
     processing = true;
+    const comment = (e.detail || '').trim();
 
     await sendMessages([
       {
@@ -40,34 +45,14 @@
 </svelte:head>
 
 <style>
-  main {
-    padding: 16px;
-    display: flex;
-    flex-flow: column;
-    gap: 8px;
-  }
-
-  main :global(.input) {
-    border: 2px solid var(--secondary300);
+  :global(.positive-form) {
+    flex: 1;
   }
 </style>
 
-<main>
-  <p>{t`We have recorded your feedback. It's glad to see the reply is helpful.`}</p>
-
-  <strong>{t`Do you have anything to add about the reply?`}</strong>
-
-  <TextArea
-    class="input"
-    bind:value={comment}
-    rows={8}
-    placeholder={t`I think the reply is useful and I want to add`}
-  />
-
-  <Button
-    on:click={handleSubmit}
-    disabled={processing}
-  >
-    {t`Submit`}
-  </Button>
-</main>
+<FeedbackForm
+  class="positive-form"
+  score={1}
+  on:vote={handleVote}
+  on:comment={handleComment}
+/>

--- a/src/liff/pages/PositiveFeedback.svelte
+++ b/src/liff/pages/PositiveFeedback.svelte
@@ -41,7 +41,7 @@
 </script>
 
 <svelte:head>
-  <title>{t`Report reply useful`}</title>
+  <title>{t`Report reply helpful`}</title>
 </svelte:head>
 
 <style>


### PR DESCRIPTION
This PR implements `FeedbackForm` and updates LIFF feedback pages.
Figma: https://www.figma.com/file/DvmAQjMJCncuPORWKnljM1/Cofacts-website-MrOrz?node-id=3042%3A2

This PR also refactors the following components:
1. `Button`
    - applies `color` set outside `Button`
    - use transparent version of text color for button background when hovering on a "outline" Button.
2. app.css
    - apply column flexbox to `body`
    - make `body` at least screen size

## `FeedbackForm` component

### No score given
![positive-negative](https://user-images.githubusercontent.com/108608/125168082-39913280-e1d6-11eb-8c2e-58b7a0f55357.gif)

### `score === 1`
User can hit "close" directly, or fill in their reasons.
![positive](https://user-images.githubusercontent.com/108608/125168163-9c82c980-e1d6-11eb-99aa-664ed24d14f6.gif)

### `score === -1`
Stops user from submitting negative feedback without reasons.
![cannot-submit](https://user-images.githubusercontent.com/108608/125168198-d0f68580-e1d6-11eb-9393-c85aa4a69bb2.gif)

## Sending positive feedback flow

https://user-images.githubusercontent.com/108608/125195275-8c76f280-e287-11eb-9b2a-6bab539f8e42.mp4

## Sending negative feedback flow

https://user-images.githubusercontent.com/108608/125195041-76b4fd80-e286-11eb-8d80-442bb26a3b5c.mp4

## Switching between positive and negative feedback flow
Even when user first clicked "Not helpful", after changing to "Helpful", the submitted feedback becomes "helpful".

https://user-images.githubusercontent.com/108608/125194954-0dcd8580-e286-11eb-8980-21cce8f81fd6.mp4

