### PR TITLE
Improve date string handling & cleanups

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,26 +21,6 @@ module.exports = {
     // Ref: https://stackoverflow.com/a/65772747/1582110
     config.resolve.modules.push(path.resolve(__dirname, '../'));
 
-    config.module.rules.push({
-      test: /\.scss$/,
-      use: [
-        'style-loader',
-        'css-loader',
-        {
-          loader: 'sass-loader',
-          options: {
-            sassOptions: {
-              // Process svelte-material-ui SCSS files in node_modules as well
-              includePaths: [
-                path.resolve(__dirname, '../node_modules'),
-                path.resolve(__dirname, '../src/liff'),
-              ],
-            },
-          },
-        },
-      ],
-    });
-
     return config;
   },
 };

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -843,9 +843,9 @@ msgstr "這個回應不太有幫助，我建議⋯⋯"
 #: src/liff/components/ViewedArticle.svelte:31
 #, javascript-format
 msgid "Viewed ${ dateString }"
-msgstr "在 ${ dateString } 看過"
+msgstr "在${ dateString }看過"
 
 #: src/lib/sharedUtils.js:109
 #, javascript-format
 msgid "${ dateStr } ago"
-msgstr "${ dateStr } 前"
+msgstr "${ dateStr }前"

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -842,7 +842,7 @@ msgstr "這個回應不太有幫助，我建議⋯⋯"
 
 #: src/liff/components/ViewedArticle.svelte:31
 #, javascript-format
-msgid "Viewed ${ dateString }"
+msgid "Viewed on ${ dateString }"
 msgstr "在${ dateString }看過"
 
 #: src/lib/sharedUtils.js:109

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -523,11 +523,6 @@ msgstr[0] "${ replyCount } 則回應"
 msgid "See replies of"
 msgstr "查看這篇的回應"
 
-#: src/liff/components/ViewedArticle.svelte:31
-#, javascript-format
-msgid "Viewed ${ fromNow } ago"
-msgstr "${fromNow}前看過"
-
 #: src/liff/components/ViewedArticle.svelte:25
 #, javascript-format
 msgid "${ newArticleReplyCount } new reply"
@@ -844,3 +839,13 @@ msgstr "這個回應有幫助到我，我想補充⋯⋯"
 #: src/liff/components/FeedbackForm.svelte:36
 msgid "I think the reply is not helpful and I suggest..."
 msgstr "這個回應不太有幫助，我建議⋯⋯"
+
+#: src/liff/components/ViewedArticle.svelte:31
+#, javascript-format
+msgid "Viewed ${ dateString }"
+msgstr "在 ${ dateString } 看過"
+
+#: src/lib/sharedUtils.js:109
+#, javascript-format
+msgid "${ dateStr } ago"
+msgstr "${ dateStr } 前"

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "svelte": "^3.38.2",
         "svelte-loader": "github:sveltejs/svelte-loader",
         "terser-webpack-plugin": "^2.3.5",
-        "ttag-cli": "^1.9.1",
+        "ttag-cli": "^1.9.3",
         "webpack": "^4.42.1",
         "webpack-cli": "^3.3.11",
         "webpack-dev-server": "^3.11.0"
@@ -9670,6 +9670,20 @@
       "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
       "dev": true
     },
+    "node_modules/babel-plugin-const-enum": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-const-enum/-/babel-plugin-const-enum-1.1.0.tgz",
+      "integrity": "sha512-HcqyEOv8IUXY/pEe/4b/6yW2SfilxlII+2Ok4l5vkE8UrN4gFgGqhhSPFbVuX0dIyG8TSHvt+7qccOI1kjynUw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.5.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -9934,6 +9948,19 @@
       "resolved": "https://registry.npmjs.org/plural-forms/-/plural-forms-0.5.3.tgz",
       "integrity": "sha512-t/hkjsTeDwaK9n/z6tUiSHySTC8sPnTiS5YF3Y5p4L+eomzXh7O0vEemkjwb68/82w0Rjw4uED3X84X7vXf9lg==",
       "dev": true
+    },
+    "node_modules/babel-preset-const-enum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-const-enum/-/babel-preset-const-enum-1.0.0.tgz",
+      "integrity": "sha512-DHfcv3mkgIqPaFODzig3Esb91cCqZlnImSl7VAwJDtIsqJvx4H08kpl051um68gjqnAXg5up5nnn6NK+Cq0blA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-const-enum": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
     },
     "node_modules/babel-preset-jest": {
       "version": "24.9.0",
@@ -15558,12 +15585,14 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15573,12 +15602,14 @@
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15589,12 +15620,14 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15605,12 +15638,14 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15620,24 +15655,28 @@
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15647,6 +15686,7 @@
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15656,12 +15696,14 @@
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -15674,6 +15716,7 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15683,12 +15726,14 @@
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15705,6 +15750,7 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15725,12 +15771,14 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15743,6 +15791,7 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15752,6 +15801,7 @@
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15762,12 +15812,14 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15777,6 +15829,7 @@
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15789,12 +15842,14 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15807,12 +15862,14 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15823,6 +15880,7 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15833,6 +15891,7 @@
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15845,12 +15904,14 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15868,6 +15929,7 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -15889,6 +15951,7 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15902,6 +15965,7 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15911,12 +15975,14 @@
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15928,6 +15994,7 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15940,6 +16007,7 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15949,6 +16017,7 @@
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15958,6 +16027,7 @@
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15967,6 +16037,7 @@
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15976,6 +16047,7 @@
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -15985,6 +16057,7 @@
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -15995,6 +16068,7 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -16004,12 +16078,14 @@
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
@@ -16025,6 +16101,7 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -16040,6 +16117,7 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -16052,24 +16130,28 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -16079,18 +16161,21 @@
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -16100,6 +16185,7 @@
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -16114,6 +16200,7 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -16126,6 +16213,7 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -16135,6 +16223,7 @@
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -16153,12 +16242,14 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true,
@@ -16168,12 +16259,14 @@
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "optional": true
@@ -28362,10 +28455,11 @@
       }
     },
     "node_modules/ttag-cli": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ttag-cli/-/ttag-cli-1.9.1.tgz",
-      "integrity": "sha512-MzyiyP18znJvpjf4lspyW8H+CIOZDYPcRl8FeM8KgT8DcYuWViAbPY7csmU0Wg4K5+0onScPz2HTDSsV9oHyYg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/ttag-cli/-/ttag-cli-1.9.3.tgz",
+      "integrity": "sha512-eWyuE7BM/zz8h2OXVP0R11DCKY+FUJhymqhsDHA1u4b2LdxOiyfd1MzcmbtswUIxqPlmwujmI0pgIoLcktC/6A==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
         "@babel/generator": "^7.12.5",
@@ -28383,6 +28477,7 @@
         "@babel/template": "^7.10.4",
         "ansi": "^0.3.1",
         "babel-plugin-ttag": "1.7.30",
+        "babel-preset-const-enum": "^1.0.0",
         "chalk": "^2.4.2",
         "cross-spawn": "^5.1.0",
         "estree-walker": "^2.0.1",
@@ -38301,6 +38396,17 @@
         }
       }
     },
+    "babel-plugin-const-enum": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-const-enum/-/babel-plugin-const-enum-1.1.0.tgz",
+      "integrity": "sha512-HcqyEOv8IUXY/pEe/4b/6yW2SfilxlII+2Ok4l5vkE8UrN4gFgGqhhSPFbVuX0dIyG8TSHvt+7qccOI1kjynUw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.5.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.3.3"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -38526,6 +38632,16 @@
           "integrity": "sha512-t/hkjsTeDwaK9n/z6tUiSHySTC8sPnTiS5YF3Y5p4L+eomzXh7O0vEemkjwb68/82w0Rjw4uED3X84X7vXf9lg==",
           "dev": true
         }
+      }
+    },
+    "babel-preset-const-enum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-const-enum/-/babel-preset-const-enum-1.0.0.tgz",
+      "integrity": "sha512-DHfcv3mkgIqPaFODzig3Esb91cCqZlnImSl7VAwJDtIsqJvx4H08kpl051um68gjqnAXg5up5nnn6NK+Cq0blA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-const-enum": "^1.0.0"
       }
     },
     "babel-preset-jest": {
@@ -43114,21 +43230,25 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -43138,11 +43258,13 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -43152,31 +43274,37 @@
         "chownr": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ms": "^2.1.1"
@@ -43185,21 +43313,25 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.6.0"
@@ -43208,11 +43340,13 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -43228,6 +43362,7 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -43241,11 +43376,13 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -43254,6 +43391,7 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -43262,6 +43400,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -43271,16 +43410,19 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -43289,11 +43431,13 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -43302,11 +43446,13 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -43316,6 +43462,7 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.9.0"
@@ -43324,6 +43471,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -43332,11 +43480,13 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "debug": "^3.2.6",
@@ -43347,6 +43497,7 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -43364,6 +43515,7 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -43373,6 +43525,7 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -43381,11 +43534,13 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -43396,6 +43551,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -43407,16 +43563,19 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "wrappy": "1"
@@ -43425,16 +43584,19 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -43444,16 +43606,19 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -43465,6 +43630,7 @@
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -43479,6 +43645,7 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^7.1.3"
@@ -43487,36 +43654,43 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -43525,6 +43699,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -43535,6 +43710,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -43543,11 +43719,13 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -43562,11 +43740,13 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -43575,11 +43755,13 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         }
       }
@@ -53211,9 +53393,9 @@
       }
     },
     "ttag-cli": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ttag-cli/-/ttag-cli-1.9.1.tgz",
-      "integrity": "sha512-MzyiyP18znJvpjf4lspyW8H+CIOZDYPcRl8FeM8KgT8DcYuWViAbPY7csmU0Wg4K5+0onScPz2HTDSsV9oHyYg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/ttag-cli/-/ttag-cli-1.9.3.tgz",
+      "integrity": "sha512-eWyuE7BM/zz8h2OXVP0R11DCKY+FUJhymqhsDHA1u4b2LdxOiyfd1MzcmbtswUIxqPlmwujmI0pgIoLcktC/6A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",
@@ -53232,6 +53414,7 @@
         "@babel/template": "^7.10.4",
         "ansi": "^0.3.1",
         "babel-plugin-ttag": "1.7.30",
+        "babel-preset-const-enum": "^1.0.0",
         "chalk": "^2.4.2",
         "cross-spawn": "^5.1.0",
         "estree-walker": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,8 +79,6 @@
         "npm-run-all": "^4.1.5",
         "optimize-css-assets-webpack-plugin": "^6.0.0",
         "prettier": "=1.13.0",
-        "sass": "^1.26.3",
-        "sass-loader": "^8.0.2",
         "style-loader": "^1.1.3",
         "svelte": "^3.38.2",
         "svelte-loader": "github:sveltejs/svelte-loader",
@@ -26000,46 +25998,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/sass": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.3.tgz",
-      "integrity": "sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": ">=2.0.0 <4.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/sass-loader": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
-      "dev": true,
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "neo-async": "^2.6.1",
-        "schema-utils": "^2.6.1",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      }
-    },
-    "node_modules/sass-loader/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -51410,36 +51368,6 @@
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "sass": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.3.tgz",
-      "integrity": "sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==",
-      "dev": true,
-      "requires": {
-        "chokidar": ">=2.0.0 <4.0.0"
-      }
-    },
-    "sass-loader": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
-      "dev": true,
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "neo-async": "^2.6.1",
-        "schema-utils": "^2.6.1",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "sax": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "svelte": "^3.38.2",
     "svelte-loader": "github:sveltejs/svelte-loader",
     "terser-webpack-plugin": "^2.3.5",
-    "ttag-cli": "^1.9.1",
+    "ttag-cli": "^1.9.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0"

--- a/package.json
+++ b/package.json
@@ -114,8 +114,6 @@
     "npm-run-all": "^4.1.5",
     "optimize-css-assets-webpack-plugin": "^6.0.0",
     "prettier": "=1.13.0",
-    "sass": "^1.26.3",
-    "sass-loader": "^8.0.2",
     "style-loader": "^1.1.3",
     "svelte": "^3.38.2",
     "svelte-loader": "github:sveltejs/svelte-loader",

--- a/src/lib/__tests__/sharedUtils.js
+++ b/src/lib/__tests__/sharedUtils.js
@@ -69,12 +69,17 @@ describe('date-fns', () => {
 
   it('use the default LOCALE', () => {
     const { format, formatDistanceToNow } = require('../sharedUtils');
-    expect(format(new Date(612921600000))).toMatchInlineSnapshot(
-      `"06/04/1989, 12:00 AM"`
-    );
     expect(
       formatDistanceToNow(new Date(Date.now() - 86400000))
     ).toMatchInlineSnapshot(`"1 day"`);
+
+    // Automatically switch between absolute date and relative date
+    expect(format(new Date(Date.now() - 86400000))).toMatchInlineSnapshot(
+      `"1 day ago"`
+    );
+    expect(format(new Date(612921600000))).toMatchInlineSnapshot(
+      `"Jun 4, 1989"`
+    );
   });
 
   it('use other locale', () => {
@@ -82,7 +87,7 @@ describe('date-fns', () => {
 
     const { format, formatDistanceToNow } = require('../sharedUtils');
     expect(format(new Date(612921600000))).toMatchInlineSnapshot(
-      `"89-06-04 上午 12:00"`
+      `"1989-06-04"`
     );
     expect(
       formatDistanceToNow(new Date(Date.now() - 86400000))

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -91,10 +91,23 @@ let locale = require(`date-fns/locale/${(process.env.LOCALE || 'en_US').replace(
 /* istanbul ignore next */
 locale = locale.default ? locale.default : locale;
 
-export function format(date, format = 'Pp', config = {}) {
+function formatAbsolute(date, format = 'PP', config = {}) {
   return dateFnsFormat(date, format, { ...config, locale });
 }
 
 export function formatDistanceToNow(date, config = {}) {
   return dateFnsFormatDistanceToNow(date, { ...config, locale });
+}
+
+const THRESHOLD = 86400 * 2 * 1000; // 2 days in milliseconds
+
+export function format(date) {
+  const now = new Date();
+
+  if (now - date < THRESHOLD) {
+    const dateStr = formatDistanceToNow(date);
+    return t`${dateStr} ago`;
+  }
+
+  return formatAbsolute(date);
 }

--- a/src/liff/components/ViewedArticle.svelte
+++ b/src/liff/components/ViewedArticle.svelte
@@ -1,6 +1,6 @@
 <script>
   import { t, ngettext, msgid } from 'ttag';
-  import { formatDistanceToNow } from 'src/lib/sharedUtils';
+  import { format } from 'src/lib/sharedUtils';
 
   /**
    * The userArticleLink from GraphQL
@@ -27,8 +27,8 @@
 
   let viewedAtStr = '';
   $: {
-    const fromNow = formatDistanceToNow(viewedAt);
-    viewedAtStr = t`Viewed ${fromNow} ago`;
+    const dateString = format(viewedAt);
+    viewedAtStr = t`Viewed ${dateString}`;
   }
 
 </script>

--- a/src/liff/components/ViewedArticle.svelte
+++ b/src/liff/components/ViewedArticle.svelte
@@ -28,7 +28,7 @@
   let viewedAtStr = '';
   $: {
     const dateString = format(viewedAt);
-    viewedAtStr = t`Viewed ${dateString}`;
+    viewedAtStr = t`Viewed on ${dateString}`;
   }
 
 </script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,26 +79,6 @@ module.exports = {
         ],
       },
       {
-        test: /\.scss$/,
-        use: [
-          /**
-           * MiniCssExtractPlugin doesn't support HMR.
-           * For developing, use 'style-loader' instead.
-           * */
-          prod ? MiniCssExtractPlugin.loader : 'style-loader',
-          'css-loader',
-          {
-            loader: 'sass-loader',
-            options: {
-              sassOptions: {
-                // Process svelte-material-ui SCSS files in node_modules as well
-                includePaths: ['./node_modules', './src/liff'],
-              },
-            },
-          },
-        ],
-      },
-      {
         test: /\.css$/,
         use: [
           /**


### PR DESCRIPTION
## Features

- Adjust date formatting
    - `format()` will give "OOO ago" or a fixed date
    - relative date & fixed date threshold is identical to rumors-site's (48 hours)

<img width="872" alt="圖片" src="https://user-images.githubusercontent.com/108608/128608868-e96667eb-730c-4b43-bd08-b45c7eb5bf55.png">

<img width="541" alt="圖片" src="https://user-images.githubusercontent.com/108608/128608524-5c783472-7976-41be-bd92-5663dd87a0b5.png">

## Cleanups

- Upgrade ttag to include ttag-org/ttag-cli#116
- Remove sass-loader, which was added due to svelte-material-ui and should be removed as we no longer uses smui.
