### PR TITLE
Article page

### DIFF
--- a/src/liff/components/ArticleCard.stories.svelte
+++ b/src/liff/components/ArticleCard.stories.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+  import ArticleCard from "./ArticleCard.svelte";
+</script>
+
+<Meta
+  title="ArticleCard"
+  component={ArticleCard}
+  args={{
+    replyRequestCount: 1,
+    createdAt: new Date(new Date() - 86400000),
+  }}
+/>
+
+<Template let:args>
+  <ArticleCard {...args} />
+</Template>
+
+<Story
+  name="Short text"
+  args={{text: 'Short text\nwith one line break'}}
+/>
+
+<Story
+  name="Long text"
+  args={{text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'}}
+/>
+
+<Story
+  name="Many line breaks"
+  args={{text: 'So\nmany\n\n\nline\nbreaks'}}
+/>

--- a/src/liff/components/ArticleCard.svelte
+++ b/src/liff/components/ArticleCard.svelte
@@ -1,0 +1,81 @@
+<script>
+  import { t, msgid, ngettext } from 'ttag';
+  import { format } from 'src/lib/sharedUtils';
+  import Card from './Card';
+  const MAX_TEXT_HEIGHT = 100; // px
+
+  export let createdAt;
+  const createdAtStr = createdAt ? format(createdAt) : '';
+
+  export let replyRequestCount;
+  const reportCountText = ngettext(
+    msgid`${replyRequestCount} person reported`,
+    `${replyRequestCount} people reported`,
+    replyRequestCount
+  );
+
+  export let text = '';
+
+  // Measured text height.
+  // Default to MAX to trigger collapsed view to avoid too much flicker.
+  //
+  let textHeight = MAX_TEXT_HEIGHT;
+
+  let isExpanded = false;
+  $: isTooLong = textHeight >= MAX_TEXT_HEIGHT;
+
+  function handleExpandClick() {
+    isExpanded = !isExpanded;
+  }
+</script>
+
+<style>
+  .measurerContainer {
+    position: relative;
+    height: 0;
+    overflow: hidden;
+  }
+  .measurer {
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    white-space: pre-line;
+  }
+  aside {
+    color: var(--secondary200);
+  }
+  article {
+    white-space: pre-line;
+  }
+  article.truncated {
+    /* collapse line breaks when truncated to fit in more text */
+    white-space: normal;
+
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+  .expandLink {
+    cursor: pointer;
+    color: var(--blue1);
+    text-decoration: none;
+  }
+</style>
+<div class="measurerContainer">
+  <div class="measurer" bind:clientHeight={textHeight}>
+    {text}
+  </div>
+</div>
+<Card style="--gap: 8px">
+  <aside>{t`First reported on ${createdAtStr}`}｜{reportCountText}</aside>
+  <article
+    class:truncated={isTooLong && !isExpanded}
+  >{text}</article>
+  {#if isTooLong }
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a class="expandLink" role="button" on:click={handleExpandClick}>
+      {isExpanded ? `${t`Show Less`} ▲` : `${t`Show More`} ▼`}
+    </a>
+  {/if}
+</Card>

--- a/src/liff/components/ArticleCard.svelte
+++ b/src/liff/components/ArticleCard.svelte
@@ -31,14 +31,11 @@
 
 <style>
   .measurerContainer {
-    position: relative;
     height: 0;
+    padding: 0 16px;
     overflow: hidden;
   }
   .measurer {
-    position: absolute;
-    left: 16px;
-    right: 16px;
     white-space: pre-line;
   }
   aside {

--- a/src/liff/components/Card.stories.svelte
+++ b/src/liff/components/Card.stories.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+  import { Meta, Story } from "@storybook/addon-svelte-csf";
   import Card from "./Card.svelte";
 
   function argsToStyle(args) {

--- a/src/liff/components/Card.stories.svelte
+++ b/src/liff/components/Card.stories.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+  import Card from "./Card.svelte";
+
+  function argsToStyle(args) {
+    return Object.entries(args)
+      .map(([key, value]) => value && `${key}: ${value};`)
+      .filter(s => s)
+      .join('')
+  }
+
+</script>
+
+<Meta
+  title="Card"
+  component={Card}
+  argTypes={{
+    '--color': {control: {type: 'color'}},
+    '--background': {control: {type: 'color'}},
+    '--gap': {control: {type: 'text'}},
+  }}
+/>
+
+<Story name="Demo" let:args>
+  <Card style={argsToStyle(args)}>
+    <div>Content 1</div>
+    <div>Content 2</div>
+  </Card>
+</Story>

--- a/src/liff/components/Card.svelte
+++ b/src/liff/components/Card.svelte
@@ -4,17 +4,14 @@
 
 <style>
   .card {
-    background: var(--background, #fff);
-    color: var(--color, var(--secondary500));
+    display: grid;
+    grid-auto-flow: row;
+    row-gap: var(--gap, 16px);
 
     padding: 16px;
 
-    /* For iOS devices < 14.7, which does not support flexbox gap... */
-    display: grid;
-    grid-auto-flow: row;
-
-    /* Introduces "--gap" variable */
-    row-gap: var(--gap, 16px);
+    background: var(--background, #fff);
+    color: var(--color, var(--secondary500));
   }
 </style>
 

--- a/src/liff/components/Card.svelte
+++ b/src/liff/components/Card.svelte
@@ -1,0 +1,23 @@
+<script>
+  export let style;
+</script>
+
+<style>
+  .card {
+    background: var(--background, #fff);
+    color: var(--color, var(--secondary500));
+
+    padding: 16px;
+
+    /* For iOS devices < 14.7, which does not support flexbox gap... */
+    display: grid;
+    grid-auto-flow: row;
+
+    /* Introduces "--gap" variable */
+    row-gap: var(--gap, 16px);
+  }
+</style>
+
+<div class="card" {style}>
+  <slot />
+</div>

--- a/src/liff/components/Card.svelte
+++ b/src/liff/components/Card.svelte
@@ -1,5 +1,9 @@
 <script>
+  import clsx from 'clsx';
+
   export let style;
+  let className = '';
+  export { className as class };
 </script>
 
 <style>
@@ -15,6 +19,6 @@
   }
 </style>
 
-<div class="card" {style}>
+<div class={clsx('card', className)} {style}>
   <slot />
 </div>

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -22,10 +22,11 @@
 
 <style>
   section {
+    display: grid;
+    grid-auto-flow: row;
+    row-gap: 4px;
     padding: 16px;
-    display: flex;
-    flex-flow: column;
-    gap: 4px;
+
     color: #fff;
     font-size: 16px;
     background: var(--bg);
@@ -48,20 +49,18 @@
   }
 
   .buttons {
-    display: flex;
-    gap: 8px;
-  }
-
-  .buttons > :global(*) {
-    flex: 1;
+    display: grid;
+    grid-auto-flow: column;
+    column-gap: 8px;
   }
 
   form {
-    display: flex;
-    flex-flow: column;
+    display: grid;
+    grid-auto-flow: row;
+    row-gap: 4px;
+
     position: relative; /* for .bg-icon */
     flex: 1; /* extend to container size */
-    gap: 4px;
     margin: 0; /* reset browser native style */
   }
 

--- a/src/liff/components/FeedbackForm.svelte
+++ b/src/liff/components/FeedbackForm.svelte
@@ -22,9 +22,8 @@
 
 <style>
   section {
-    display: grid;
-    grid-auto-flow: row;
-    row-gap: 4px;
+    display: flex;
+    flex-flow: column;
     padding: 16px;
 
     color: #fff;
@@ -55,9 +54,8 @@
   }
 
   form {
-    display: grid;
-    grid-auto-flow: row;
-    row-gap: 4px;
+    display: flex;
+    flex-flow: column;
 
     position: relative; /* for .bg-icon */
     flex: 1; /* extend to container size */
@@ -74,7 +72,7 @@
   }
 
   form :global(textarea) {
-    margin-top: 12px;
+    margin: 16px 0 20px;
     min-height: 80px;
     flex: 1; /* extend to container size */
   }
@@ -91,12 +89,12 @@
   {...$$restProps}
 >
   {#if score === null}
-    <p>{t`Please help Cofacts editors`}</p>
+    <p style="margin-bottom: 4px;">{t`Please help Cofacts editors`}</p>
   {/if}
   <p class:emphasize={score === null}>
     {t`Is the reply helpful?`}
   </p>
-  <div class="buttons" style={`margin: 8px 0 ${ score === null ? 4 : 16 }px`}>
+  <div class="buttons" style={`margin: 12px 0 ${ score === null ? 0 : 20 }px`}>
     <Button
       variant={score === -1 ? 'outlined' : 'contained'}
       style={`color: ${score === -1 ? '#fff' : 'var(--bg)'};`}
@@ -130,7 +128,7 @@
       {#if score === 1}
         <ThumbsUpIcon class="bg-icon" />
         <p>{t`It's glad to see the reply is helpful.`}</p>
-        <p class="emphasize">
+        <p class="emphasize" style="margin-top: 4px;">
           {t`Do you have anything to add about the reply?`}
         </p>
         <TextArea
@@ -141,7 +139,7 @@
       {:else if score === -1}
         <ThumbsDownIcon class="bg-icon" />
         <p>{t`We are sorry that the reply is not helpful to you.`}</p>
-        <p class="emphasize">
+        <p class="emphasize" style="margin-top: 4px;">
           {t`How can we make it helpful to you?`}
         </p>
         <TextArea
@@ -150,7 +148,7 @@
           bind:value={comment}
         />
       {/if}
-      <div class="buttons" style="margin-top: 16px;">
+      <div class="buttons">
         <Button type="submit" disabled={disabled || (score === -1 && comment.length === 0)}>
           {#if comment.length > 0}
             {t`Submit`}

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -1,6 +1,8 @@
 <script>
   import { onMount } from 'svelte';
+  import { t } from 'ttag';
   import { gql } from '../lib';
+  import ArticleCard from '../components/ArticleCard.svelte';
 
   const params = new URLSearchParams(location.search);
   const articleId = params.get('articleId');
@@ -8,6 +10,7 @@
 
   let articleData;
   let articleReplies = [];
+  let createdAt;
 
   const articleReplyFields = `
     ownVote
@@ -28,6 +31,7 @@
           text
           replyRequestCount
           requestedForReply
+          createdAt
 
           articleReplies(status: NORMAL) {
             ${articleReplyFields}
@@ -40,6 +44,7 @@
 
     articleReplies = list.filter(({reply}) => replyId ? reply.id === replyId : true);
     articleData = rest;
+    createdAt = new Date(articleData.createdAt);
 
     // Send event to Google Analytics
     gtag('event', 'ViewArticle', {
@@ -104,17 +109,34 @@
   }
 </script>
 
+<style>
+  h1 {
+    font-weight: 700;
+    font-size: 1em;
+    color: var(--secondary300);
+    margin: 24px 16px 8px;
+  }
+
+  h1:first-of-type {
+    margin-top: 8px;
+  }
+</style>
+
 <svelte:head>
-  <title>Cofacts 網友協作回應</title>
+  <title>{t`IM check`} | {t`Cofacts chatbot`}</title>
 </svelte:head>
 
 {#if !articleData }
-  <p>載入中...</p>
+  <p style="align-self: center; margin: auto 0;">{t`Loading IM data...`}</p>
 {:else}
-  <details>
-    <summary>網友回報可疑訊息</summary>
-    {articleData.text}
-  </details>
+  <h1>
+    {t`Suspicious messages`}
+  </h1>
+  <ArticleCard
+    text={articleData.text}
+    replyRequestCount={articleData.replyRequestCount}
+    createdAt={createdAt}
+  />
 
   {#if articleReplies.length === 0}
     <p>有 {articleData.replyRequestCount} 人回報說看到此訊息。</p>


### PR DESCRIPTION
## Features
- Implements `Card`
- Use `Card` in `ViewedArticle`
- Implements `ArticleCard` that uses `Card`
    - Used in article page ([figma](https://www.figma.com/file/DvmAQjMJCncuPORWKnljM1/Cofacts-website-MrOrz?node-id=3047%3A246))
    - Calculates text height and show "Expand" only when needed
- Use `ArticleCard` in article page

## Bugfix
- Fix gaps between `FeedbackForm`controls
    - iOS < 14.7 does not support flexbox `gap`
    - We use ordinary margin for irregular layouts and `display: grid` + `grid-auto-flow: xxx` to + `xxx-gap` to replace flexbox `gap`