### PR TITLE
Revamp viewed articles list

### DIFF
--- a/src/liff/components/Card.stories.svelte
+++ b/src/liff/components/Card.stories.svelte
@@ -1,14 +1,7 @@
 <script>
   import { Meta, Story } from "@storybook/addon-svelte-csf";
   import Card from "./Card.svelte";
-
-  function argsToStyle(args) {
-    return Object.entries(args)
-      .map(([key, value]) => value && `${key}: ${value};`)
-      .filter(s => s)
-      .join('')
-  }
-
+  import { argsToStyle } from "./storiesUtils"
 </script>
 
 <Meta

--- a/src/liff/components/FullpagePrompt.stories.svelte
+++ b/src/liff/components/FullpagePrompt.stories.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Meta, Story } from "@storybook/addon-svelte-csf";
+  import FullpagePrompt from "./FullpagePrompt.svelte";
+</script>
+
+<Meta
+  title="FullpagePrompt"
+  component={FullpagePrompt}
+  args={{
+    children: "Texts here are centered at page",
+  }}
+/>
+
+<Story name="Default" let:args>
+  <!-- Simulates <body>, which is a column flexbox -->
+  <div style="display: flex; flex-flow: column; height: 100vh">
+    <FullpagePrompt>{args.children}</FullpagePrompt>
+  </div>
+</Story>

--- a/src/liff/components/FullpagePrompt.svelte
+++ b/src/liff/components/FullpagePrompt.svelte
@@ -1,0 +1,7 @@
+<style>
+  div {
+    margin: auto 0;
+    align-self: center;
+  }
+</style>
+<div><slot /></div>

--- a/src/liff/components/Header.stories.svelte
+++ b/src/liff/components/Header.stories.svelte
@@ -1,7 +1,6 @@
 <script>
   import { Meta, Story } from "@storybook/addon-svelte-csf";
   import Header from "./Header.svelte";
-  import { argsToStyle } from "./storiesUtils"
 </script>
 
 <Meta

--- a/src/liff/components/Header.stories.svelte
+++ b/src/liff/components/Header.stories.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Meta, Story } from "@storybook/addon-svelte-csf";
+  import Header from "./Header.svelte";
+  import { argsToStyle } from "./storiesUtils"
+</script>
+
+<Meta
+  title="Header"
+  component={Header}
+  args={{
+    text: 'Section header text here'
+  }}
+/>
+
+<Story name="Default" let:args>
+  <Header>
+    {args.text}
+  </Header>
+</Story>

--- a/src/liff/components/Header.svelte
+++ b/src/liff/components/Header.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let style;
+</script>
+<style>
+  h1 {
+    font-weight: 700;
+    font-size: 1em;
+    color: var(--secondary300);
+    margin: 24px 16px 8px;
+  }
+
+  h1:first-of-type {
+    margin-top: 8px;
+  }
+</style>
+<h1 {style}>
+  <slot />
+</h1>

--- a/src/liff/components/Pagination.svelte
+++ b/src/liff/components/Pagination.svelte
@@ -23,7 +23,7 @@
 
 <style>
   .container {
-    margin: 8px 0;
+    margin: 16px;
     display: flex;
     color: var(--secondary500);
   }

--- a/src/liff/components/Spacer.stories.svelte
+++ b/src/liff/components/Spacer.stories.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Meta, Story } from "@storybook/addon-svelte-csf";
+  import Spacer from "./Spacer.svelte";
+  import { argsToStyle } from "./storiesUtils"
+</script>
+
+<Meta
+  title="Spacer"
+  component={Spacer}
+  args={{
+    color: '--secondary100',
+    '--dot-size': '4px',
+  }}
+/>
+
+<Story name="Default" let:args>
+  <Spacer style={argsToStyle(args)} />
+</Story>

--- a/src/liff/components/Spacer.svelte
+++ b/src/liff/components/Spacer.svelte
@@ -6,19 +6,19 @@
     display: flex;
     justify-content: center;
     color: var(--secondary100);
-    --default-dot-size: 4px;
-    padding: var(--dot-size, var(--default-dot-size));
+    --dot-size: 4px;
+    padding: var(--dot-size);
   }
 
   div::before {
     content: '';
-    width: var(--dot-size, var(--default-dot-size));
-    height: var(--dot-size, var(--default-dot-size));
-    border-radius: var(--dot-size, var(--default-dot-size));
+    width: var(--dot-size);
+    height: var(--dot-size);
+    border-radius: var(--dot-size);
     background: currentColor;
 
-    box-shadow: calc(2 * var(--dot-size, var(--default-dot-size))) 0 currentColor,
-      calc(-2 * var(--dot-size, var(--default-dot-size))) 0 currentColor;
+    box-shadow: calc(2 * var(--dot-size)) 0 currentColor,
+      calc(-2 * var(--dot-size)) 0 currentColor;
   }
 </style>
 <div {style} />

--- a/src/liff/components/Spacer.svelte
+++ b/src/liff/components/Spacer.svelte
@@ -1,0 +1,24 @@
+<script>
+  export let style;
+</script>
+<style>
+  div {
+    display: flex;
+    justify-content: center;
+    color: var(--secondary100);
+    --default-dot-size: 4px;
+    padding: var(--dot-size, var(--default-dot-size));
+  }
+
+  div::before {
+    content: '';
+    width: var(--dot-size, var(--default-dot-size));
+    height: var(--dot-size, var(--default-dot-size));
+    border-radius: var(--dot-size, var(--default-dot-size));
+    background: currentColor;
+
+    box-shadow: calc(2 * var(--dot-size, var(--default-dot-size))) 0 currentColor,
+      calc(-2 * var(--dot-size, var(--default-dot-size))) 0 currentColor;
+  }
+</style>
+<div {style} />

--- a/src/liff/components/ViewedArticle.svelte
+++ b/src/liff/components/ViewedArticle.svelte
@@ -1,6 +1,7 @@
 <script>
   import { t, ngettext, msgid } from 'ttag';
   import { format } from 'src/lib/sharedUtils';
+  import Card from './Card.svelte';
 
   /**
    * The userArticleLink from GraphQL
@@ -34,40 +35,32 @@
 </script>
 
 <style>
-  article {
-    margin: 0 0 12px;
-    padding: 16px;
-    background: #fff;
+  :global(.ViewedArticle-root) {
     cursor: pointer;
+    --gap: 8px;
   }
 
   header {
     display: flex;
     justify-content: space-between;
-    font-size: 12px;
-    line-height: 20px;
-    color: #ADADAD;
-    letter-spacing: 0.25px;
+    color: var(--secondary200);
   }
   .unread {
     color: #fff;
-    background: #FFB600;
+    background: var(--primary500);
     padding: 0 4px;
     border-radius: 4px;
     font-weight: bold;
   }
   main {
     overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-
-    font-size: 12px;
-    line-height: 20px;
-    letter-spacing: 0.25px;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
   }
 </style>
 
-<article on:click>
+<Card class="ViewedArticle-root" on:click>
   <header>
     <span class={newArticleReplyCount ? 'unread' : ''}>
       {#if !article}
@@ -89,4 +82,4 @@
       {article.text}
     {/if}
   </main>
-</article>
+</Card>

--- a/src/liff/components/storiesUtils.js
+++ b/src/liff/components/storiesUtils.js
@@ -1,0 +1,13 @@
+/**
+ * In storybooks, it converts args to style string to demonstrate customizable styles
+ * for this component.
+ *
+ * @param {object} args - args in storybook
+ * @returns {string} a HTML style attribute string
+ */
+export function argsToStyle(args) {
+  return Object.entries(args)
+    .map(([key, value]) => value && `${key}: ${value};`)
+    .filter(s => s)
+    .join('');
+}

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import { t } from 'ttag';
   import { gql } from '../lib';
+  import FullpagePrompt from '../components/FullpagePrompt.svelte';
+  import Header from '../components/Header.svelte';
   import ArticleCard from '../components/ArticleCard.svelte';
 
   const params = new URLSearchParams(location.search);
@@ -113,34 +115,16 @@
     : `There are ${articleReplies.length} Cofacts replies for this message`
 </script>
 
-<style>
-  .loading {
-    align-self: center;
-    margin: auto 0;
-  }
-
-  h1 {
-    font-weight: 700;
-    font-size: 1em;
-    color: var(--secondary300);
-    margin: 24px 16px 8px;
-  }
-
-  h1:first-of-type {
-    margin-top: 8px;
-  }
-</style>
-
 <svelte:head>
   <title>{t`IM check`} | {t`Cofacts chatbot`}</title>
 </svelte:head>
 
 {#if !articleData }
-  <p class="loading">{t`Loading IM data...`}</p>
+  <FullpagePrompt>{t`Loading IM data...`}</FullpagePrompt>
 {:else}
-  <h1>
+  <Header>
     {t`Suspicious messages`}
-  </h1>
+  </Header>
   <ArticleCard
     text={articleData.text}
     replyRequestCount={articleData.replyRequestCount}
@@ -157,7 +141,7 @@
       {/if}
     </button>
   {:else}
-    <h1>{replySectionTitle}</h1>
+    <ListHeader>{replySectionTitle}</ListHeader>
     <ul>
       {#each articleReplies as articleReply (articleReply.reply.id)}
         <li>

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -141,7 +141,7 @@
       {/if}
     </button>
   {:else}
-    <ListHeader>{replySectionTitle}</ListHeader>
+    <Header>{replySectionTitle}</Header>
     <ul>
       {#each articleReplies as articleReply (articleReply.reply.id)}
         <li>

--- a/src/liff/pages/Articles.svelte
+++ b/src/liff/pages/Articles.svelte
@@ -81,10 +81,20 @@
   })
 </script>
 <style>
-  .total {
-    font-size: 12px;
-    line-height: 20px;
-    color: #ADADAD;
+  .loading {
+    margin: auto 0;
+    align-self: center;
+  }
+  h1 {
+    font-weight: 700;
+    font-size: 1em;
+    color: var(--secondary300);
+    margin: 8px 16px;
+  }
+  .articles {
+    display: grid;
+    grid-auto-flow: row;
+    row-gap: 12px;
   }
 </style>
 
@@ -93,16 +103,18 @@
 </svelte:head>
 
 {#if linksData === null}
-  <p>{t`Fetching viewed messages`}...</p>
+  <p class="loading">{t`Fetching viewed messages`}...</p>
 {:else}
-  <p class="total">{totalCountStr}</p>
-  {#each linksData.edges as linkEdge (linkEdge.cursor)}
-    <ViewedArticle
-      userArticleLink={linkEdge.node}
-      article={articleMap[linkEdge.node.articleId]}
-      on:click={() => selectArticle(linkEdge.node.articleId)}
-    />
-  {/each}
+  <h1>{totalCountStr}</h1>
+  <div class="articles">
+    {#each linksData.edges as linkEdge (linkEdge.cursor)}
+      <ViewedArticle
+        userArticleLink={linkEdge.node}
+        article={articleMap[linkEdge.node.articleId]}
+        on:click={() => selectArticle(linkEdge.node.articleId)}
+      />
+    {/each}
+  </div>
   <Pagination
     disabled={isLoadingData}
     pageInfo={linksData.pageInfo}

--- a/src/liff/pages/Articles.svelte
+++ b/src/liff/pages/Articles.svelte
@@ -3,8 +3,11 @@
   import { t, ngettext, msgid } from 'ttag';
   import { VIEW_ARTICLE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
   import { gql, assertInClient, getArticlesFromCofacts, sendMessages } from '../lib';
+  import FullpagePrompt from '../components/FullpagePrompt.svelte';
   import ViewedArticle from '../components/ViewedArticle.svelte';
   import Pagination from '../components/Pagination.svelte';
+  import Header from '../components/Header.svelte';
+  import Spacer from '../components/Spacer.svelte';
 
   let linksData = null;
   let isLoadingData = false; // If is in process of loadData()
@@ -80,41 +83,25 @@
     await loadData();
   })
 </script>
-<style>
-  .loading {
-    margin: auto 0;
-    align-self: center;
-  }
-  h1 {
-    font-weight: 700;
-    font-size: 1em;
-    color: var(--secondary300);
-    margin: 8px 16px;
-  }
-  .articles {
-    display: grid;
-    grid-auto-flow: row;
-    row-gap: 12px;
-  }
-</style>
 
 <svelte:head>
   <title>{t`Viewed messages`}</title>
 </svelte:head>
 
 {#if linksData === null}
-  <p class="loading">{t`Fetching viewed messages`}...</p>
+  <FullpagePrompt>{t`Fetching viewed messages`}...</FullpagePrompt>
 {:else}
-  <h1>{totalCountStr}</h1>
-  <div class="articles">
-    {#each linksData.edges as linkEdge (linkEdge.cursor)}
-      <ViewedArticle
-        userArticleLink={linkEdge.node}
-        article={articleMap[linkEdge.node.articleId]}
-        on:click={() => selectArticle(linkEdge.node.articleId)}
-      />
-    {/each}
-  </div>
+  <Header>{totalCountStr}</Header>
+  {#each linksData.edges as linkEdge, idx (linkEdge.cursor)}
+    {#if idx > 0}
+      <Spacer />
+    {/if}
+    <ViewedArticle
+      userArticleLink={linkEdge.node}
+      article={articleMap[linkEdge.node.articleId]}
+      on:click={() => selectArticle(linkEdge.node.articleId)}
+    />
+  {/each}
   <Pagination
     disabled={isLoadingData}
     pageInfo={linksData.pageInfo}


### PR DESCRIPTION
- Applies <Card> to viewed articles
    - Figma mockup: https://www.figma.com/file/DvmAQjMJCncuPORWKnljM1/Cofacts-website-MrOrz?node-id=3207%3A282
- Extracts common components to share with single article page

![image](https://user-images.githubusercontent.com/108608/128910744-f86bd860-7aeb-4c97-b297-17d8b4bbdb70.png)

(One page should have 25 articles. I changed to 5 when taking the picture in order to show the pagination buttons.)

This PR also extracts the following common components that shares with single article page:

## `Spacer`
color and dot size are adjustable via CSS.

![spacer](https://user-images.githubusercontent.com/108608/128911571-3109bff0-27b3-4f4d-b755-8d44367d1927.gif)

## `Header`
Header in the middle of the page will have larger top margin to distinguish itself from the previous section.

![image](https://user-images.githubusercontent.com/108608/128911734-da196657-2a71-4f41-a0ea-8966fa42f962.png)

## `FullpagePrompt`
Text at the center of the page. Should be a direct child of `<body>`, which is a column flex container.
![image](https://user-images.githubusercontent.com/108608/128911811-37d22e12-3167-4b03-8223-61945d3b4977.png)
