### PR TITLE
Turn URLs in reference section into hyperlinks

### DIFF
--- a/src/liff/__tests__/lib.js
+++ b/src/liff/__tests__/lib.js
@@ -542,3 +542,45 @@ describe('sendMessages', () => {
     `);
   });
 });
+
+describe('linkify', () => {
+  let linkify;
+  beforeAll(() => {
+    global.location = { search: '' };
+    linkify = require('../lib').linkify;
+  });
+
+  afterAll(() => {
+    delete global.location;
+  });
+
+  it('handles empty string', () => {
+    expect(linkify('')).toEqual('');
+  });
+
+  it('handles strings without URL and escapes HTML', () => {
+    expect(
+      linkify(`Foo & bar
+      <script>evil script</script>`)
+    ).toMatchInlineSnapshot(`
+      "Foo &amp; bar
+            &lt;script&gt;evil script&lt;/script&gt;"
+    `);
+  });
+
+  it('converts URLs in string into HTML tags', () => {
+    expect(
+      linkify(`Reference1
+        https://reference1.com?encoded=%E4%B8%AD%E6%96%87
+
+        Reference2
+        https://reference2.com/aaa?id=aaa&bbb=bbb+ccc&c="foo"`)
+    ).toMatchInlineSnapshot(`
+      "Reference1
+              <a href=\\"https://reference1.com?encoded=%E4%B8%AD%E6%96%87\\" >https://reference1.com?encoded=中文</a>
+
+              Reference2
+              <a href=\\"https://reference2.com/aaa?id=aaa&bbb=bbb+ccc&c=%22foo%22\\" >https://reference2.com/aaa?id=aaa&amp;bbb=bbb+ccc&amp;c=\\"foo\\"</a>"
+    `);
+  });
+});

--- a/src/liff/components/ArticleReplyCard.svelte
+++ b/src/liff/components/ArticleReplyCard.svelte
@@ -1,5 +1,6 @@
 <script>
   import { t } from 'ttag';
+  import { linkify } from '../lib';
   import Card from './Card.svelte';
   import ArticleReplyHeader from './ArticleReplyHeader.svelte';
 
@@ -38,7 +39,7 @@
       {articleReply.replyType === 'OPINIONATED' ? t`Opinion Sources` : t`References`}
     </h3>
     <article>
-      {articleReply.reply.reference}
+      {@html linkify(articleReply.reply.reference, 'target="_blank"')}
     </article>
   {:else}
     <p class="noReference">

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -238,3 +238,32 @@ export const sendMessages = async messages => {
     }
   }
 };
+
+/** Sanitize HTML tags */
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+const urlRegExp = /(https?:\/\/\S+)/;
+
+/**
+ *
+ * @param {string} str
+ * @param {string} propStr
+ * @returns {string} HTML string that wraps `str`'s URL with <a> tag with additional props in propStr
+ */
+export function linkify(str, propStr = '') {
+  const tokenized = str.split(urlRegExp).map(s => {
+    if (!s.match(urlRegExp)) return escapeHtml(s);
+
+    // Perform URI encode only when necessary (containing " will break HTML string)
+    const sanitizedUrl = s.includes('"') ? encodeURI(s) : s;
+    return `<a href="${sanitizedUrl}" ${propStr}>${escapeHtml(
+      decodeURIComponent(s)
+    )}</a>`;
+  });
+  return tokenized.join('');
+}


### PR DESCRIPTION
- Implement `linkify()` and its unit test
- Apply `linkify()` reference section
    - All links should open in new tab

## Storybook
![image](https://user-images.githubusercontent.com/108608/131356823-a701a0ab-4ccd-451c-8b3c-e9eac1fa2ab5.png)

## Actual look
![image](https://user-images.githubusercontent.com/108608/131357477-54837c13-9888-427d-9fef-e35c31c11a96.png)
