### PR TITLE
Remove LIFF max-age header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ if (process.env.NODE_ENV === 'production') {
     serve({
       rootDir: path.join(__dirname, '../liff'),
       rootPath: '/liff',
-      maxage: 31536000 * 1000, // https://stackoverflow.com/a/7071880/1582110
     })
   );
 } else {


### PR DESCRIPTION
As discussed in https://g0v.hackmd.io/E1-ajzinSwCyacGG228VsQ#LIFF-HTML-%E8%A2%AB-cache-%E4%BD%8F%E7%9A%84%E5%95%8F%E9%A1%8C

We should not cache LIFF HTML. Therefore, we delete maxage and just use Cloudflare to cache.