### PR TITLE
Set cache-control for assets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,13 @@ if (process.env.NODE_ENV === 'production') {
     serve({
       rootDir: path.join(__dirname, '../liff'),
       rootPath: '/liff',
+
+      // Set cache header for assets, but always fetch index.html
+      setHeaders(res, path) {
+        if (!path.match(/index\.html(?:\.gz)?$/)) {
+          res.setHeader('Cache-Control', 'public, max-age=31536000');
+        }
+      },
     })
   );
 } else {


### PR DESCRIPTION
As discussed in [slack](https://g0v-tw.slack.com/archives/C2PPMRQGP/p1630552367020400?thread_ts=1630433602.014900&cid=C2PPMRQGP), after we remove max-age in #284, cloudflare never caches our asset files.

This is because
- koa-send (used by koa-static-server we are currently using) sets `max-age` to 0 if we do not specify any max-age: https://github.com/koajs/send/blob/master/index.js#L60
- [Default cache behavior of cloudflare](https://developers.cloudflare.com/cache/about/default-cache-behavior) will respect max-age: 0 when it is given

In this PR we override `Cache-Control` using [`setHeaders` option](https://github.com/koajs/send#setheaders) so that whenever koa-send serves a file that is not `index.html`, we attach a 1-year long max-age in the response header.

## HTML
![image](https://user-images.githubusercontent.com/108608/131790478-2615c1cb-26ba-423a-8726-3cd7c6cb1b68.png)

## Assets that is not HTML
![image](https://user-images.githubusercontent.com/108608/131790707-a8bdbff2-9aad-46eb-9fe0-39962e74d383.png)