### PR TITLE
Send article content as title when submitting LIFF events

### DIFF
--- a/src/lib/ga.js
+++ b/src/lib/ga.js
@@ -1,11 +1,5 @@
 import ua from 'universal-analytics';
-import GraphemeSplitter from 'grapheme-splitter';
-const splitter = new GraphemeSplitter();
-
-// When document title is too long, event will be dropped.
-// See: https://github.com/cofacts/rumors-line-bot/issues/97
-//
-const DOCUMENT_TITLE_LENGTH = 800;
+import { gaTitle } from './sharedUtils';
 
 /**
  * Sends a screen view and returns the visitor
@@ -30,13 +24,7 @@ export default function ga(
   visitor.screenview(state, 'rumors-line-bot');
 
   if (documentTitle) {
-    visitor.set(
-      'dt',
-      splitter
-        .splitGraphemes(documentTitle)
-        .slice(0, DOCUMENT_TITLE_LENGTH)
-        .join('')
-    );
+    visitor.set('dt', gaTitle(documentTitle));
   }
 
   visitor.set('cd1', messageSource);

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -5,6 +5,7 @@
 import { t } from 'ttag';
 import dateFnsFormat from 'date-fns/format';
 import dateFnsFormatDistanceToNow from 'date-fns/formatDistanceToNow';
+import GraphemeSplitter from 'grapheme-splitter';
 
 const SITE_URLS = (process.env.SITE_URLS || 'https://cofacts.g0v.tw').split(
   ','
@@ -124,4 +125,22 @@ export function createTypeWords(type) {
       return t`Invalid request`;
   }
   return 'Undefined';
+}
+
+const splitter = new GraphemeSplitter();
+
+// When document title is too long, event will be dropped.
+// See: https://github.com/cofacts/rumors-line-bot/issues/97
+//
+const DOCUMENT_TITLE_LENGTH = 800;
+
+/**
+ * @param {string} title
+ * @returns {string} valid title for Google Analytics
+ */
+export function gaTitle(title) {
+  return splitter
+    .splitGraphemes(title)
+    .slice(0, DOCUMENT_TITLE_LENGTH)
+    .join('');
 }

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { t } from 'ttag';
   import { gql } from '../lib';
+  import { gaTitle } from 'src/lib/sharedUtils';
   import FullpagePrompt from '../components/FullpagePrompt.svelte';
   import Header from '../components/Header.svelte';
   import ArticleCard from '../components/ArticleCard.svelte';
@@ -44,6 +45,7 @@
     createdAt = new Date(articleData.createdAt);
 
     // Send event to Google Analytics
+    gtag('set', { page_title: gaTitle(articleData.text) });
     gtag('event', 'ViewArticle', {
       event_category: 'LIFF',
       event_label: articleId,


### PR DESCRIPTION
Adds article content as document title in the following GA events (`Event category` / `Event action` / `Event label`):
- `LIFF` / `ViewArticle` / `<articleId>`
- `LIFF` / `ViewReply` / `<replyId>`

This will be useful to generate a message search trend report with message search capability in https://datastudio.google.com/reporting/18J8jZYumsoaCPBk9bdRd97GKvi_W5v-r/page/p_44cex908mc

![image](https://user-images.githubusercontent.com/108608/132167356-2ebdf02b-bcf1-4edb-b071-09dff6122d37.png)
