### PR TITLE
Replace "編輯" with "查證志工"

### DIFF
--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -52,7 +52,7 @@ msgstr "此回應沒有${prompt}，請自行斟酌回應之可信度。"
 
 #: src/webhook/handlers/choosingArticle.js:151
 msgid "Volunteer editors have published several replies to this message."
-msgstr "真的假的編輯志工對這則訊息發表了多則看法唷！"
+msgstr "真的假的查證志工對這則訊息發表了多則看法唷！"
 
 #: src/webhook/handlers/choosingArticle.js:273
 msgid "Let's pick one"
@@ -416,7 +416,7 @@ msgid ""
 "To provide more info, please press \"Cancel\"; otherwise, press \"OK\" to "
 "submit the current info directly."
 msgstr ""
-"提供給編輯的資訊可以再豐富一些，會讓編輯回覆越快唷！\n"
+"提供給查證志工的資訊可以再豐富一些，會讓志工更容易查真假唷！\n"
 "\n"
 "\n"
 "${ LENGHEN_HINT }\n"
@@ -436,7 +436,7 @@ msgstr ""
 
 #: src/liff/pages/Reason.svelte:80
 msgid "To help with fact-checking, please tell the editors:"
-msgstr "為了協助查證，請告訴闢謠編輯："
+msgstr "為了協助查證，請告訴闢謠志工："
 
 #: src/liff/pages/Reason.svelte:81
 msgid "Why do you think this is a hoax?"
@@ -784,7 +784,7 @@ msgstr ""
 msgid ""
 "I would suggest don't trust this message just yet. To help Cofacts editors "
 "checking the message, please "
-msgstr "先不要相信這個訊息唷，它可能是假的。如果要請闢謠編輯志工查證，請"
+msgstr "先不要相信這個訊息唷，它可能是假的。如果要請闢謠志工查證，請"
 
 #: src/webhook/handlers/choosingArticle.js:310
 msgid "provide more information using the button below. "
@@ -853,14 +853,14 @@ msgstr "${ dateStr }前"
 
 #: src/liff/pages/Article.svelte:102
 msgid "Cofacts volunteer's reply to the message above"
-msgstr "真的假的編輯志工針對以上訊息的回應"
+msgstr "真的假的查證志工針對以上訊息的回應"
 
 #: src/liff/pages/Article.svelte:103
 #, javascript-format
 msgid ""
 "Cofacts volunteers have published ${ articleReplies.length } replies to the "
 "message above"
-msgstr "真的假的編輯志工對以上訊息發表了 ${ articleReplies.length } 則回應"
+msgstr "真的假的查證志工對以上訊息發表了 ${ articleReplies.length } 則回應"
 
 #: src/liff/pages/Article.svelte:105
 msgid "IM check"


### PR DESCRIPTION
As discussed in https://g0v.hackmd.io/6mTYVWhLSTWfDcyaxYLaXA?view#%E6%9C%AA%E7%AB%9F%E9%A0%85%E7%9B%AE , we should avoid using "編輯" because it is too ambiguous. We use "查證志工" instead.

![圖片](https://user-images.githubusercontent.com/108608/132513816-6d696429-f7f1-4246-94f2-330c4ba1100b.png)
![圖片](https://user-images.githubusercontent.com/108608/132514272-0c149642-ef16-4d22-a167-15aa1f440cf6.png)
![圖片](https://user-images.githubusercontent.com/108608/132516160-8f51c391-1a88-4e81-ab22-98c8e869a675.png)
![圖片](https://user-images.githubusercontent.com/108608/132516243-7ad2c0e2-de4f-4827-85b8-3547c98ebd3f.png)

