### PR TITLE
Redirect page

### DIFF
--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -851,30 +851,30 @@ msgstr "在${ dateString }看過"
 msgid "${ dateStr } ago"
 msgstr "${ dateStr }前"
 
-#: src/liff/pages/Article.svelte:102
+#: src/liff/pages/Article.svelte:103
 msgid "Cofacts volunteer's reply to the message above"
 msgstr "真的假的查證志工針對以上訊息的回應"
 
-#: src/liff/pages/Article.svelte:103
+#: src/liff/pages/Article.svelte:104
 #, javascript-format
 msgid ""
 "Cofacts volunteers have published ${ articleReplies.length } replies to the "
 "message above"
 msgstr "真的假的查證志工對以上訊息發表了 ${ articleReplies.length } 則回應"
 
-#: src/liff/pages/Article.svelte:105
+#: src/liff/pages/Article.svelte:110
 msgid "IM check"
 msgstr "網傳訊息查證"
 
-#: src/liff/pages/Article.svelte:106
+#: src/liff/pages/Article.svelte:111
 msgid "Cofacts chatbot"
 msgstr "真的假的聊天機器人"
 
-#: src/liff/pages/Article.svelte:107
+#: src/liff/pages/Article.svelte:112
 msgid "Loading IM data..."
 msgstr "載入可疑訊息"
 
-#: src/liff/pages/Article.svelte:108
+#: src/liff/pages/Article.svelte:115
 msgid "Suspicious messages"
 msgstr "網傳可疑訊息"
 
@@ -935,20 +935,45 @@ msgstr ""
 msgid "Edit feedback"
 msgstr "修改評價"
 
-#: src/liff/pages/Article.svelte:116
+#: src/liff/pages/Article.svelte:123
 msgid "Other replies"
 msgstr "其他查核回應"
 
-#: src/liff/pages/Article.svelte:119
+#: src/liff/pages/Article.svelte:126
 msgid ""
 "There are different replies for the message. We suggest read them all here "
 "before you make judgements."
 msgstr "這則訊息有很多不同的查核回應，建議全部讀完再下判斷唷。"
 
-#: src/liff/pages/Article.svelte:120
+#: src/liff/pages/Article.svelte:127
 msgid "Read other replies"
 msgstr "查看其他查核回應"
 
-#: src/liff/components/AppBar.svelte:16
+#: src/liff/pages/Article.svelte:114
 msgid "Open in Cofacts"
 msgstr "在「真的假的」開啟"
+
+#: src/liff/Redirect.svelte:20
+msgid "Proceed"
+msgstr "繼續前往"
+
+#: src/liff/Redirect.svelte:22
+msgid "Let's check the message, together!"
+msgstr "一起來查真假吧！"
+
+#: src/liff/Redirect.svelte:23
+msgid ""
+"You are going to proceed to Cofacts to read the reply for you written by "
+"fact-check volunteers."
+msgstr "您即將前往 Cofacts 真的假的，閱讀闢謠志工為您撰寫的回應。"
+
+#: src/liff/Redirect.svelte:24
+msgid ""
+"If the reply and the reference is helpful to you, please provide positive "
+"feedback. If existing replies can be improved, please login the website and "
+"provide new fact-check replies."
+msgstr "如果回應與出處對您有幫助，請您不吝給予好評；若有更好的寫法，也請登入動手查核、直接寫新回應。"
+
+#: src/liff/Redirect.svelte:25
+msgid "Proceed to read the reply"
+msgstr "前往閱讀查核回應"

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ if (process.env.NODE_ENV === 'production') {
 
       // Set cache header for assets, but always fetch index.html
       setHeaders(res, path) {
-        if (!path.match(/index\.html(?:\.gz)?$/)) {
+        if (!path.match(/\.html(?:\.gz)?$/)) {
           res.setHeader('Cache-Control', 'public, max-age=31536000');
         }
       },

--- a/src/liff/Redirect.svelte
+++ b/src/liff/Redirect.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { onMount } from 'svelte';
+  import { t } from 'ttag';
+  import Button from './components/Button.svelte';
+
+  const currentParams = new URLSearchParams(location.search);
+  const articleId = currentParams.get('articleId');
+  const replyId = currentParams.get('replyId');
+  const newParamsObj = { p: 'article' };
+  if(articleId) newParamsObj.articleId = articleId;
+  if(replyId) newParamsObj.replyId = replyId;
+  const LIFF_URL = `https://liff.line.me/${LIFF_ID}?${new URLSearchParams(newParamsObj).toString()}`;
+
+  onMount(() => {
+    document.getElementById('loading').remove();
+  });
+
+  const handleClick = () => {
+    location.href = LIFF_URL;
+  }
+</script>
+<style>
+</style>
+
+<Button on:click={handleClick} variant="outlined">
+  {t`前往真的假的看回應`}
+</Button>

--- a/src/liff/Redirect.svelte
+++ b/src/liff/Redirect.svelte
@@ -19,6 +19,7 @@
 <style>
   .appbar-link {
     color: var(--blue1);
+    text-decoration: none;
   }
 
   main {
@@ -51,6 +52,8 @@
   :global(.redirectButton.redirectButton) {
     color: var(--blue1);
     min-width: 240px;
+    width: 100%;
+    max-width: 500px;
   }
 </style>
 

--- a/src/liff/Redirect.svelte
+++ b/src/liff/Redirect.svelte
@@ -54,13 +54,13 @@
 </AppBar>
 
 <main>
-  <img src={multipleRepliesBanner} alt="Multiple replies available" />
+  <img src={multipleRepliesBanner} alt="Let's check message together" />
   <h1>{t`Let's check the message, together!`}</h1>
   <p>
-    {t`You are going to proceed to Cofacts to read the reply written by fact-check volunteers.`}
+    {t`You are going to proceed to Cofacts to read the reply for you written by fact-check volunteers.`}
   </p>
   <p>
-    {t`If the reply and the reference is helpful to you, feel free to provide positive feedback to encourage the volunteers!`}
+    {t`If the reply and the reference is helpful to you, please provide positive feedback. If existing replies can be improved, please login the website and provide new fact-check replies.`}
   </p>
   <Button on:click={handleClick} variant="outlined" class="redirectButton">
     {t`Proceed to read the reply`}

--- a/src/liff/Redirect.svelte
+++ b/src/liff/Redirect.svelte
@@ -1,7 +1,8 @@
 <script>
-  import { onMount } from 'svelte';
   import { t } from 'ttag';
   import Button from './components/Button.svelte';
+  import AppBar from './components/AppBar.svelte';
+  import multipleRepliesBanner from '../assets/multiple-replies.png';
 
   const currentParams = new URLSearchParams(location.search);
   const articleId = currentParams.get('articleId');
@@ -11,17 +12,58 @@
   if(replyId) newParamsObj.replyId = replyId;
   const LIFF_URL = `https://liff.line.me/${LIFF_ID}?${new URLSearchParams(newParamsObj).toString()}`;
 
-  onMount(() => {
-    document.getElementById('loading').remove();
-  });
-
   const handleClick = () => {
     location.href = LIFF_URL;
   }
 </script>
 <style>
+  .appbar-link {
+    color: var(--blue1);
+  }
+
+  main {
+    display: grid;
+    grid-auto-flow: column;
+    align-items: center;
+
+    row-gap: 24px;
+    padding: 24px;
+  }
+
+  h1 {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: 0.75px;
+    text-align: center;
+  }
+
+  p {
+    font-size: 16px;
+    letter-spacing: 0.25px;
+  }
+
+  :global(.redirectButton) {
+    color: var(--blue1);
+  }
 </style>
 
-<Button on:click={handleClick} variant="outlined">
-  {t`前往真的假的看回應`}
-</Button>
+<AppBar>
+  <a class="appbar-link" href={LIFF_URL}>
+    {t`Proceed`}
+  </a>
+</AppBar>
+
+<main>
+  <img src={multipleRepliesBanner} alt="Multiple replies available" />
+  <h1>{t`Let's check the message, together!`}</h1>
+  <p>
+    {t`You are going to proceed to Cofacts to read the reply written by fact-check volunteers.`}
+  </p>
+  <p>
+    {t`If the reply and the reference is helpful to you, feel free to provide positive feedback to encourage the volunteers!`}
+  </p>
+  <Button on:click={handleClick} variant="outlined" class="redirectButton">
+    {t`Proceed to read the reply`}
+  </Button>
+</main>
+

--- a/src/liff/Redirect.svelte
+++ b/src/liff/Redirect.svelte
@@ -2,7 +2,7 @@
   import { t } from 'ttag';
   import Button from './components/Button.svelte';
   import AppBar from './components/AppBar.svelte';
-  import multipleRepliesBanner from '../assets/multiple-replies.png';
+  import multipleRepliesBanner from './assets/multiple-replies.png';
 
   const currentParams = new URLSearchParams(location.search);
   const articleId = currentParams.get('articleId');
@@ -23,11 +23,15 @@
 
   main {
     display: grid;
-    grid-auto-flow: column;
-    align-items: center;
+    grid-auto-flow: row;
+    justify-items: center;
 
     row-gap: 24px;
     padding: 24px;
+  }
+
+  .main-img {
+    max-width: 100%;
   }
 
   h1 {
@@ -35,15 +39,18 @@
     font-weight: 700;
     letter-spacing: 0.75px;
     text-align: center;
+    margin: 0;
   }
 
   p {
     font-size: 16px;
     letter-spacing: 0.25px;
+    margin: 0;
   }
 
-  :global(.redirectButton) {
+  :global(.redirectButton.redirectButton) {
     color: var(--blue1);
+    min-width: 240px;
   }
 </style>
 
@@ -54,7 +61,7 @@
 </AppBar>
 
 <main>
-  <img src={multipleRepliesBanner} alt="Let's check message together" />
+  <img class="main-img" src={multipleRepliesBanner} alt="Let's check message together" />
   <h1>{t`Let's check the message, together!`}</h1>
   <p>
     {t`You are going to proceed to Cofacts to read the reply for you written by fact-check volunteers.`}

--- a/src/liff/components/AppBar.svelte
+++ b/src/liff/components/AppBar.svelte
@@ -1,15 +1,5 @@
 <script>
-  import { t } from 'ttag';
-  import { VIEW_ARTICLE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
   import logo from '../assets/logo.svg';
-  import NewWindowIcon from './icons/NewWindowIcon.svelte';
-
-  export let articleId;
-
-  const articleUrl = getArticleURL(articleId);
-  const openLink = liff.isInClient() ?
-    `https://line.me/R/oaMessage/@cofacts?${encodeURIComponent(`${VIEW_ARTICLE_PREFIX}${articleUrl}`)}` :
-    getArticleURL(articleId);
 </script>
 
 <style>
@@ -28,28 +18,9 @@
   .logo {
     margin-right: auto;
   }
-
-  a {
-    color: var(--secondary300);
-    font-weight: 700;
-    font-size: 14px;
-    letter-spacing: 0.25px;
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-  }
-
-  a > :global(svg) {
-    margin-left: 8px;
-  }
 </style>
 
 <header>
   <img class="logo" src={logo} alt="Cofacts 真的假的" />
-  {#if articleId }
-    <a href={openLink}>
-      {t`Open in Cofacts`}
-      <NewWindowIcon />
-    </a>
-  {/if}
+  <slot />
 </header>

--- a/src/liff/index.html
+++ b/src/liff/index.html
@@ -1,4 +1,4 @@
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -15,7 +15,7 @@
   import { ArticleReplyCard_articleReply } from '../components/fragments';
   import improveBanner from '../assets/improve-reply-banner.png';
   import multipleRepliesBanner from '../assets/multiple-replies.png';
-  import NewWindowIcon from './icons/NewWindowIcon.svelte';
+  import NewWindowIcon from '../components/icons/NewWindowIcon.svelte';
 
   const params = new URLSearchParams(location.search);
   const articleId = params.get('articleId');

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { t } from 'ttag';
   import { gql } from '../lib';
-  import { gaTitle, getArticleURL } from 'src/lib/sharedUtils';
+  import { gaTitle, getArticleURL, VIEW_ARTICLE_PREFIX } from 'src/lib/sharedUtils';
   import AppBar from '../components/AppBar.svelte';
   import SingleColorLogo from '../components/icons/SingleColorLogo.svelte';
   import FullpagePrompt from '../components/FullpagePrompt.svelte';
@@ -15,6 +15,7 @@
   import { ArticleReplyCard_articleReply } from '../components/fragments';
   import improveBanner from '../assets/improve-reply-banner.png';
   import multipleRepliesBanner from '../assets/multiple-replies.png';
+  import NewWindowIcon from './icons/NewWindowIcon.svelte';
 
   const params = new URLSearchParams(location.search);
   const articleId = params.get('articleId');
@@ -101,9 +102,27 @@
   $: replySectionTitle = articleReplies.length === 1
     ? t`Cofacts volunteer's reply to the message above`
     : t`Cofacts volunteers have published ${articleReplies.length} replies to the message above`
+
+  const appbarHref = liff.isInClient() ?
+    `https://line.me/R/oaMessage/@cofacts?${encodeURIComponent(`${VIEW_ARTICLE_PREFIX}${articleUrl}`)}` :
+    getArticleURL(articleId);
 </script>
 
 <style>
+  .appbar-link {
+    color: var(--secondary300);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.25px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+  }
+
+  .appbar-link > :global(svg) {
+    margin-left: 8px;
+  }
+
   .improve-banner > img {
     margin-top: 24px;
     width: 100%;
@@ -131,7 +150,14 @@
 {#if !articleData }
   <FullpagePrompt>{t`Loading IM data...`}</FullpagePrompt>
 {:else}
-  <AppBar {articleId} />
+  <AppBar>
+    {#if articleId }
+      <a class="appbar-link" href={appbarHref}>
+        {t`Open in Cofacts`}
+        <NewWindowIcon />
+      </a>
+    {/if}
+  </AppBar>
   <Header>
     {t`Suspicious messages`}
   </Header>

--- a/src/liff/redirect.html
+++ b/src/liff/redirect.html
@@ -1,0 +1,32 @@
+<html lang="zh-TW">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/static/favicon.png" type="image/png" />
+    <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
+    <title>前往 Cofacts 真的假的</title>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= htmlWebpackPlugin.options.GA_ID %>"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '<%= htmlWebpackPlugin.options.GA_ID %>', { send_page_view: false });
+    </script>
+  </head>
+  <body>
+    <div id="loading">
+      <!-- Removed by redirect.js -->
+      <style>
+        #loading {
+          height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+      </style>
+      Loading...
+    </div>
+  </body>
+</html>

--- a/src/liff/redirect.html
+++ b/src/liff/redirect.html
@@ -12,7 +12,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '<%= htmlWebpackPlugin.options.GA_ID %>', { send_page_view: false });
+      gtag('config', '<%= htmlWebpackPlugin.options.GA_ID %>');
     </script>
   </head>
   <body>

--- a/src/liff/redirect.js
+++ b/src/liff/redirect.js
@@ -1,0 +1,4 @@
+import 'normalize.css';
+import './index.css';
+
+console.log('Redirect: hello world');

--- a/src/liff/redirect.js
+++ b/src/liff/redirect.js
@@ -3,3 +3,4 @@ import './index.css';
 import Redirect from './Redirect.svelte';
 
 new Redirect({ target: document.body });
+document.getElementById('loading').remove();

--- a/src/liff/redirect.js
+++ b/src/liff/redirect.js
@@ -1,4 +1,5 @@
 import 'normalize.css';
 import './index.css';
+import Redirect from './Redirect.svelte';
 
-console.log('Redirect: hello world');
+new Redirect({ target: document.body });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,8 @@ const babelLoaderConfig = {
 
 module.exports = {
   entry: {
-    bundle: ['./src/liff/index.js'],
+    index: './src/liff/index.js',
+    redirect: './src/liff/redirect.js',
   },
   resolve: {
     alias: {
@@ -123,9 +124,18 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: './src/liff/index.html',
+      chunks: ['index'],
       // custom constants passed to index.html via htmlWebpackPlugin.options
       ROLLBAR_ENV: process.env.ROLLBAR_ENV,
       ROLLBAR_CLIENT_TOKEN: process.env.ROLLBAR_CLIENT_TOKEN,
+      GA_ID: process.env.GA_ID,
+    }),
+    new HtmlWebpackPlugin({
+      inject: true,
+      template: './src/liff/redirect.html',
+      filename: 'redirect.html',
+      chunks: ['redirect'],
+      // custom constants passed to index.html via htmlWebpackPlugin.options
       GA_ID: process.env.GA_ID,
     }),
     new CompressionPlugin(),


### PR DESCRIPTION
- Implements redirect LIFF that allows user to confirm on redirection from `<LIFF_URL>/redirect.html?articleId=<articleId>&replyId=<replyId>` to `<LIFF_URL>/index.html?p=article&articleId=<articleId>&replyId=<replyId>`
- Adds `redirect.html` config to webpack
- Refactor: Remove predefined action button from `<AppBar>` so that each page can customize their own action button
- Refactor: Remove cache-control from static middleware for all HTML pages (previously only `index.html`)

URL: 
Figma spec: https://www.figma.com/file/DvmAQjMJCncuPORWKnljM1/Cofacts-LIFF?node-id=3667%3A304

## Wide

<img width="827" alt="圖片" src="https://user-images.githubusercontent.com/108608/135737548-27a5801b-49f0-47c2-b9cc-e4c52fabf5d3.png">

## Mobile
<img width="409" alt="圖片" src="https://user-images.githubusercontent.com/108608/135737581-c349087e-c97b-4f14-9985-f9ad563bac9d.png">

## Link

<img width="810" alt="圖片" src="https://user-images.githubusercontent.com/108608/135737567-7a8a23af-53b3-4fdf-be4b-70b872b0ff4f.png">

