### PR TITLE
Add API that monitors queue status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run i18n:validate
-      - run: npm run test --ignore-scripts -- --coverage
+      - run: npm run test --ignore-scripts -- --coverage --detectOpenHandles
       - name: Update coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run i18n:validate
-      - run: npm run test --ignore-scripts -- --coverage --detectOpenHandles
+      - run: npm run test --ignore-scripts -- --coverage
       - name: Update coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/src/graphql/__tests__/index.js
+++ b/src/graphql/__tests__/index.js
@@ -4,6 +4,7 @@ jest.mock('../lineClient');
 import { getContext } from '../';
 import { sign } from 'src/lib/jwt';
 import redis from 'src/lib/redisClient';
+import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
 import { verifyIDToken } from '../lineClient';
 
 beforeEach(() => {
@@ -234,4 +235,12 @@ describe('getContext', () => {
       }
     `);
   });
+});
+
+// As graphql/index actually loads all resolvers, the queue instances are created
+// and should be closed after this test.
+//
+afterAll(async () => {
+  await groupEventQueue.close();
+  await expiredGroupEventQueue.close();
 });

--- a/src/graphql/__tests__/index.js
+++ b/src/graphql/__tests__/index.js
@@ -1,10 +1,11 @@
 jest.mock('src/lib/redisClient');
 jest.mock('../lineClient');
+// Avoid loading src/lib/queue, which really connects to redis
+jest.mock('src/lib/queues', () => ({}));
 
 import { getContext } from '../';
 import { sign } from 'src/lib/jwt';
 import redis from 'src/lib/redisClient';
-import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
 import { verifyIDToken } from '../lineClient';
 
 beforeEach(() => {
@@ -235,12 +236,4 @@ describe('getContext', () => {
       }
     `);
   });
-});
-
-// As graphql/index actually loads all resolvers, the queue instances are created
-// and should be closed after this test.
-//
-afterAll(async () => {
-  await groupEventQueue.close();
-  await expiredGroupEventQueue.close();
 });

--- a/src/graphql/__tests__/queue.js
+++ b/src/graphql/__tests__/queue.js
@@ -1,0 +1,110 @@
+import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
+import { gql } from '../testUtils';
+import MockDate from 'mockdate';
+
+beforeEach(async () => {
+  await groupEventQueue.removeJobs('*');
+  await expiredGroupEventQueue.removeJobs('*');
+});
+afterAll(async () => {
+  await groupEventQueue.close();
+  await expiredGroupEventQueue.close();
+});
+
+it('returns info for empty queues', async () => {
+  const result = await gql`
+    {
+      queue {
+        queueName
+        jobCounts {
+          waiting
+          active
+          completed
+          failed
+          delayed
+        }
+        isPaused
+        lastWaitingAt
+        lastCompletedAt
+      }
+    }
+  `();
+
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "queue": Array [
+          Object {
+            "isPaused": false,
+            "jobCounts": Object {
+              "active": 0,
+              "completed": 0,
+              "delayed": 0,
+              "failed": 0,
+              "waiting": 0,
+            },
+            "lastCompletedAt": null,
+            "lastWaitingAt": null,
+            "queueName": "groupEventQueue",
+          },
+          Object {
+            "isPaused": false,
+            "jobCounts": Object {
+              "active": 0,
+              "completed": 0,
+              "delayed": 0,
+              "failed": 0,
+              "waiting": 0,
+            },
+            "lastCompletedAt": null,
+            "lastWaitingAt": null,
+            "queueName": "expiredGroupEventQueue",
+          },
+        ],
+      },
+    }
+  `);
+});
+
+it('returns waiting job info', async () => {
+  MockDate.set(612921600000);
+  await groupEventQueue.add({ foo: 'bar' });
+  await expiredGroupEventQueue.add({ foo: 'bar' });
+
+  const resultQueued = await gql`
+    {
+      queue {
+        queueName
+        jobCounts {
+          waiting
+        }
+        lastWaitingAt
+      }
+    }
+  `();
+
+  MockDate.reset();
+
+  expect(resultQueued).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "queue": Array [
+          Object {
+            "jobCounts": Object {
+              "waiting": 1,
+            },
+            "lastWaitingAt": 1989-06-04T00:00:00.000Z,
+            "queueName": "groupEventQueue",
+          },
+          Object {
+            "jobCounts": Object {
+              "waiting": 1,
+            },
+            "lastWaitingAt": 1989-06-04T00:00:00.000Z,
+            "queueName": "expiredGroupEventQueue",
+          },
+        ],
+      },
+    }
+  `);
+});

--- a/src/graphql/__tests__/queue.js
+++ b/src/graphql/__tests__/queue.js
@@ -1,3 +1,15 @@
+jest.mock('src/lib/queues', () => {
+  const Bull = require('bull');
+  return {
+    groupEventQueue: new Bull('test_queue_groupEventQueue', {
+      redis: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+    }),
+    expiredGroupEventQueue: new Bull('test_queue_expiredGroupEventQueue', {
+      redis: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+    }),
+  };
+});
+
 import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
 import { gql } from '../testUtils';
 import MockDate from 'mockdate';
@@ -47,7 +59,7 @@ it('returns info for empty queues', async () => {
             },
             "lastCompletedAt": null,
             "lastWaitingAt": null,
-            "queueName": "groupEventQueue",
+            "queueName": "test_queue_groupEventQueue",
           },
           Object {
             "isPaused": false,
@@ -60,7 +72,7 @@ it('returns info for empty queues', async () => {
             },
             "lastCompletedAt": null,
             "lastWaitingAt": null,
-            "queueName": "expiredGroupEventQueue",
+            "queueName": "test_queue_expiredGroupEventQueue",
           },
         ],
       },
@@ -96,14 +108,14 @@ it('returns waiting job info', async () => {
               "waiting": 1,
             },
             "lastWaitingAt": 1989-06-04T00:00:00.000Z,
-            "queueName": "groupEventQueue",
+            "queueName": "test_queue_groupEventQueue",
           },
           Object {
             "jobCounts": Object {
               "waiting": 1,
             },
             "lastWaitingAt": 1989-06-04T00:00:00.000Z,
-            "queueName": "expiredGroupEventQueue",
+            "queueName": "test_queue_expiredGroupEventQueue",
           },
         ],
       },

--- a/src/graphql/__tests__/queue.js
+++ b/src/graphql/__tests__/queue.js
@@ -7,6 +7,8 @@ beforeEach(async () => {
   await expiredGroupEventQueue.removeJobs('*');
 });
 afterAll(async () => {
+  await groupEventQueue.removeJobs('*');
+  await expiredGroupEventQueue.removeJobs('*');
   await groupEventQueue.close();
   await expiredGroupEventQueue.close();
 });

--- a/src/graphql/resolvers/Query.js
+++ b/src/graphql/resolvers/Query.js
@@ -1,11 +1,16 @@
 import UserArticleLink from 'src/database/models/userArticleLink';
 import UserSettings from 'src/database/models/userSettings';
+import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
 import { processConnection } from '../utils/connection';
 
 export default {
   insights() {
     // Resolvers in next level
     return {};
+  },
+
+  queue() {
+    return [groupEventQueue, expiredGroupEventQueue];
   },
 
   setting(root, args, context) {

--- a/src/graphql/resolvers/QueueInfo.js
+++ b/src/graphql/resolvers/QueueInfo.js
@@ -13,15 +13,15 @@ export default {
 
   async lastCompletedAt(queue) {
     // Latest job = 1st job
-    const lastCompletedJobs = await queue.getCompleted(0, 0);
-    if (!lastCompletedJobs || !lastCompletedJobs[0]) return null;
-    return new Date(lastCompletedJobs[0].timestamp);
+    const lastJobs = await queue.getCompleted(0, 0);
+    if (!lastJobs || !lastJobs[0]) return null;
+    return new Date(lastJobs[0].timestamp);
   },
 
   async lastWaitingAt(queue) {
     // Latest job = 1st job
-    const lastCompletedJobs = await queue.getWaiting(0, 0);
-    if (!lastCompletedJobs || !lastCompletedJobs[0]) return null;
-    return new Date(lastCompletedJobs.timestamp);
+    const lastJobs = await queue.getWaiting(0, 0);
+    if (!lastJobs || !lastJobs[0]) return null;
+    return new Date(lastJobs[0].timestamp);
   },
 };

--- a/src/graphql/resolvers/QueueInfo.js
+++ b/src/graphql/resolvers/QueueInfo.js
@@ -1,0 +1,27 @@
+export default {
+  queueName(queue) {
+    return queue.name;
+  },
+
+  jobCounts(queue) {
+    return queue.getJobCounts();
+  },
+
+  isPaused(queue) {
+    return queue.isPaused();
+  },
+
+  async lastCompletedAt(queue) {
+    // Latest job = 1st job
+    const lastCompletedJobs = await queue.getCompleted(0, 0);
+    if (!lastCompletedJobs || !lastCompletedJobs[0]) return null;
+    return new Date(lastCompletedJobs[0].timestamp);
+  },
+
+  async lastWaitingAt(queue) {
+    // Latest job = 1st job
+    const lastCompletedJobs = await queue.getWaiting(0, 0);
+    if (!lastCompletedJobs || !lastCompletedJobs[0]) return null;
+    return new Date(lastCompletedJobs.timestamp);
+  },
+};

--- a/src/graphql/testUtils.js
+++ b/src/graphql/testUtils.js
@@ -1,5 +1,7 @@
 // ./index.js contains imports to redisClient, which should be mocked in unit tests.
 jest.mock('src/lib/redisClient');
+// Avoid loading src/lib/queue, which really connects to redis
+jest.mock('src/lib/queues', () => ({}));
 
 import { graphql } from 'graphql';
 import { schema } from './';

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -1,7 +1,10 @@
 directive @auth(check: [String]) on FIELD_DEFINITION
 
 type Query {
-  insights: MessagingAPIInsight
+  insights: MessagingAPIInsight!
+
+  # Open monitor metrics of the job queue
+  queue: [QueueInfo!]!
 
   # Current user's chatbot context
   context: UserContext @auth
@@ -163,6 +166,30 @@ enum MessagingAPIInsightStatus {
   READY
   UNREADY
   OUT_OF_SERVICE
+}
+
+type QueueInfo {
+  queueName: String!
+
+  # https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queuegetjobcounts
+  jobCounts: QueueJobCountInfo!
+
+  # https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queueispaused
+  isPaused: Boolean!
+
+  # Timestamp of the last job in "completed" state. Null if no job in completed state yet.
+  lastCompletedAt: Date
+
+  # Timestamp of the last job in "waiting" state. Null if no job in waiting state yet.
+  lastWaitingAt: Date
+}
+
+type QueueJobCountInfo {
+  waiting: Int!
+  active: Int!
+  completed: Int!
+  failed: Int!
+  delayed: Int!
 }
 
 type UserContext {

--- a/src/lib/queues.js
+++ b/src/lib/queues.js
@@ -1,0 +1,10 @@
+import Bull from 'bull';
+
+export const groupEventQueue = new Bull('groupEventQueue', {
+  redis: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+  // limiter: { max: 600, duration: 10 * 1000 },
+});
+export const expiredGroupEventQueue = new Bull('expiredGroupEventQueue', {
+  redis: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+  // limiter: { max: 600, duration: 10 * 1000 },
+});

--- a/src/webhook/__tests__/index.js
+++ b/src/webhook/__tests__/index.js
@@ -8,10 +8,11 @@ import Koa from 'koa';
 import request from 'supertest';
 import MockDate from 'mockdate';
 
-import webhookRouter, { groupEventQueue, expiredGroupEventQueue } from '../';
+import webhookRouter from '../';
 import UserSettings from '../../database/models/userSettings';
 import Client from '../../database/mongoClient';
 import lineClient from 'src/webhook/lineClient';
+import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
 import redis from 'src/lib/redisClient';
 import {
   createGreetingMessage,

--- a/src/webhook/handlers/__tests__/groupHandler.test.js
+++ b/src/webhook/handlers/__tests__/groupHandler.test.js
@@ -34,8 +34,8 @@ beforeEach(async () => {
 afterEach(async () => {
   // Clean all job channel
   // https://github.com/OptimalBits/bull/issues/709
-  emptyQueue(jobQueue);
-  emptyQueue(expiredJobQueue);
+  await emptyQueue(jobQueue);
+  await emptyQueue(expiredJobQueue);
   await jobQueue.close();
   await expiredJobQueue.close();
 });

--- a/src/webhook/handlers/groupHandler.js
+++ b/src/webhook/handlers/groupHandler.js
@@ -7,6 +7,10 @@ import lineClient from 'src/webhook/lineClient';
 import processGroupEvent from './processGroupEvent';
 import rollbar from 'src/lib/rollbar';
 
+const DEFAULT_JOBQUEUE_CONCURRENCY = isNaN(+process.env.JOBQUEUE_CONCURRENCY)
+  ? 3
+  : +process.env.JOBQUEUE_CONCURRENCY;
+
 export default class {
   /**
    *  expired queue start only when there's no jobs in jobQueue
@@ -19,7 +23,7 @@ export default class {
   constructor(
     jobQueue,
     expiredJobQueue,
-    concurrency = process.env.JOBQUEUE_CONCURRENCY || 3
+    concurrency = DEFAULT_JOBQUEUE_CONCURRENCY
   ) {
     this.expiredJobQueue = expiredJobQueue;
     this.jobQueue = jobQueue;

--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -6,6 +6,7 @@ import redis from 'src/lib/redisClient';
 import lineClient from './lineClient';
 import checkSignatureAndParse from './checkSignatureAndParse';
 import handleInput from './handleInput';
+import { groupEventQueue, expiredGroupEventQueue } from 'src/lib/queues';
 import GroupHandler from './handlers/groupHandler';
 import {
   downloadFile,
@@ -20,7 +21,6 @@ import {
   createGreetingMessage,
   createTutorialMessage,
 } from './handlers/tutorial';
-import Bull from 'bull';
 
 const userIdBlacklist = (process.env.USERID_BLACKLIST || '').split(',');
 
@@ -322,14 +322,6 @@ redis.set('imageProcessingCount', 0);
 
 const router = Router();
 
-export const groupEventQueue = new Bull('groupEventQueue', {
-  redis: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
-  // limiter: { max: 600, duration: 10 * 1000 },
-});
-export const expiredGroupEventQueue = new Bull('expiredGroupEventQueue', {
-  redis: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
-  // limiter: { max: 600, duration: 10 * 1000 },
-});
 const groupHandler = new GroupHandler(groupEventQueue, expiredGroupEventQueue);
 // Routes that is after protection of checkSignature
 //


### PR DESCRIPTION
Related: TODO items in broken group chat https://g0v.hackmd.io/bhL6csQ8T1e81E2De7ZS5Q#%E7%BE%A4%E7%B5%84%E5%8A%9F%E8%83%BD%E5%A3%9E%E6%8E%89-update

1. Fixes #260 
2. Moves queue instance to `src/lib/queues.js` so that it can be shared across webhook & GraphQL resolvers
3. Add `queue` open API that returns queue stats for monitor
    - Dunno know how to test "completed" queue QQ
    - Just added test case for "waiting"

Deployed to staging:
![圖片](https://user-images.githubusercontent.com/108608/154792646-56a06df0-396d-48f1-80d5-3b54c59020c1.png)
