### PR TITLE
Reply request form for LIFF

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ We use dimemsion `Message Source` (Custom Dimemsion1) to classify different even
 11. Other LIFF operations
   - `LIFF` / `page_redirect` / `App` is sent on LIFF redirect, with value being redirect count.
   - `LIFF` / `ViewArticle` / `<articleId>` when article page with `articleId` is opened
+  - `LIFF` / `Comment` / `<articleId>` when comment page with `articleId` is opened
   - `LIFF` / `ViewReply` / `<replyId>` for each displayed reply in article page
 
 12. Tutorial

--- a/src/graphql/cofacts-api.graphql
+++ b/src/graphql/cofacts-api.graphql
@@ -102,6 +102,23 @@ type Query {
     """
     before: String
   ): ListReplyRequestConnection
+  ListBlockedUsers(
+    filter: ListBlockedUsersFilter
+    orderBy: [ListBlockedUsersOrderBy]
+
+    """Returns only first <first> results"""
+    first: Int = 10
+
+    """
+    Specify a cursor, returns results after this cursor. cannot be used with "before".
+    """
+    after: String
+
+    """
+    Specify a cursor, returns results before this cursor. cannot be used with "after".
+    """
+    before: String
+  ): UserConnection!
   ValidateSlug(slug: String!): ValidationResult
 }
 
@@ -119,19 +136,30 @@ type Article implements Node {
   Connections between this article and replies. Sorted by the logic described in https://github.com/cofacts/rumors-line-bot/issues/78.
   """
   articleReplies(
-    """When specified, returns only article replies with the specified status"""
+    """
+    Deprecated. Please use statuses instead. When specified, returns only article replies with the specified status
+    """
     status: ArticleReplyStatusEnum
+
+    """Returns only article replies with the specified statuses"""
+    statuses: [ArticleReplyStatusEnum!] = [NORMAL]
   ): [ArticleReply]
   articleCategories(
     """
-    When specified, returns only article categories with the specified status
+    Deprecated. Please use statuses instead. When specified, returns only article categories with the specified status
     """
     status: ArticleCategoryStatusEnum
+
+    """Returns only article categories with the specified statuses"""
+    statuses: [ArticleCategoryStatusEnum!] = [NORMAL]
   ): [ArticleCategory]
 
   """Number of normal article categories"""
   categoryCount: Int
-  replyRequests: [ReplyRequest]
+  replyRequests(
+    """Returns only article replies with the specified statuses"""
+    statuses: [ReplyRequestStatusEnum!] = [NORMAL]
+  ): [ReplyRequest]
   replyRequestCount: Int
   lastRequestedAt: String
 
@@ -204,11 +232,16 @@ type ArticleReply {
 
   """The user who conencted this reply and this article."""
   user: User
+  userId: String!
+  appId: String!
   canUpdateStatus: Boolean
   feedbackCount: Int
   positiveFeedbackCount: Int
   negativeFeedbackCount: Int
-  feedbacks: [ArticleReplyFeedback]
+  feedbacks(
+    """Returns only aricle reply feedbacks with the specified statuses"""
+    statuses: [ArticleReplyFeedbackStatusEnum!] = [NORMAL]
+  ): [ArticleReplyFeedback]
 
   """
   The feedback of current user. null when not logged in or not voted yet.
@@ -229,10 +262,11 @@ type Reply implements Node {
   type: ReplyTypeEnum
   reference: String
   articleReplies(
-    """
-    When specified, returns only reply connections with the specified status
-    """
+    """Deprecated. Please use statuses instead."""
     status: ArticleReplyStatusEnum
+
+    """Returns only article replies with the specified statuses"""
+    statuses: [ArticleReplyStatusEnum!] = [NORMAL]
   ): [ArticleReply]
 
   """
@@ -259,8 +293,8 @@ type Reply implements Node {
   ): ReplyConnection
 }
 
-type User {
-  id: String
+type User implements Node {
+  id: ID!
   slug: String
 
   """Returns only for current user. Returns `null` otherwise."""
@@ -309,6 +343,9 @@ type User {
     """List only the contributions between the specific time range."""
     dateRange: TimeRangeInput
   ): [Contribution]
+
+  """If not null, the user is blocked with the announcement in this string."""
+  blockedReason: String
 }
 
 enum AvatarTypeEnum {
@@ -368,6 +405,9 @@ enum ReplyTypeEnum {
 enum ArticleReplyStatusEnum {
   NORMAL
   DELETED
+
+  """Created by a blocked user violating terms of use."""
+  BLOCKED
 }
 
 """Data behind a hyperlink"""
@@ -467,6 +507,7 @@ type ArticleReplyFeedback implements Node {
   comment: String
   createdAt: String
   updatedAt: String
+  status: ArticleReplyFeedbackStatusEnum!
 
   """User's vote on the articleReply"""
   vote: FeedbackVote
@@ -486,6 +527,13 @@ type ArticleReplyFeedback implements Node {
   articleReply: ArticleReply
 }
 
+enum ArticleReplyFeedbackStatusEnum {
+  NORMAL
+
+  """Created by a blocked user violating terms of use."""
+  BLOCKED
+}
+
 enum FeedbackVote {
   UPVOTE
   NEUTRAL
@@ -502,6 +550,8 @@ type ArticleCategory implements Node {
 
   """The user who updated this category with this article."""
   user: User
+  userId: String!
+  appId: String!
   canUpdateStatus: Boolean
   feedbackCount: Int
   positiveFeedbackCount: Int
@@ -572,6 +622,9 @@ type ArticleCategoryConnectionPageInfo implements PageInfo {
 enum ArticleCategoryStatusEnum {
   NORMAL
   DELETED
+
+  """Created by a blocked user violating terms of use."""
+  BLOCKED
 }
 
 """
@@ -595,6 +648,7 @@ type ArticleCategoryFeedback {
 
 type ReplyRequest implements Node {
   id: ID!
+  articleId: ID!
   userId: String
   appId: String
 
@@ -611,6 +665,15 @@ type ReplyRequest implements Node {
   The feedback of current user. null when not logged in or not voted yet.
   """
   ownVote: FeedbackVote
+  article: Article!
+  status: ReplyRequestStatusEnum!
+}
+
+enum ReplyRequestStatusEnum {
+  NORMAL
+
+  """Created by a blocked user violating terms of use."""
+  BLOCKED
 }
 
 type ArticleConnection implements Connection {
@@ -664,6 +727,23 @@ type Analytics {
 }
 
 input ListArticleFilter {
+  """Show only articles created by a specific app."""
+  appId: String
+
+  """Show only articles created by the specific user."""
+  userId: String
+
+  """
+  List only the articles that were created between the specific time range.
+  """
+  createdAt: TimeRangeInput
+
+  """If given, only list out articles with specific IDs"""
+  ids: [ID!]
+
+  """Only list the articles created by the currently logged in user"""
+  selfOnly: Boolean
+
   """List only the articles whose number of replies matches the criteria."""
   replyCount: RangeInput
 
@@ -682,26 +762,12 @@ input ListArticleFilter {
   replyRequestCount: RangeInput
 
   """
-  List only the articles that were created between the specific time range.
-  """
-  createdAt: TimeRangeInput
-
-  """
   List only the articles that were replied between the specific time range.
   """
   repliedAt: TimeRangeInput
 
-  """Show only articles from a specific user."""
-  appId: String
-
-  """Show only articles from a specific user."""
-  userId: String
-
   """
-  
-              Specify an articleId here to show only articles from the sender of that specified article.
-              When specified, it overrides the settings of appId and userId.
-            
+  Specify an articleId here to show only articles from the sender of that specified article.
   """
   fromUserOfArticleId: String
 
@@ -762,23 +828,29 @@ input ListArticleOrderBy {
 }
 
 input ListReplyFilter {
-  userId: String
+  """Show only replies created by a specific app."""
   appId: String
-  moreLikeThis: MoreLikeThisInput
 
-  """List the replies created by the requester themselves"""
+  """Show only replies created by the specific user."""
+  userId: String
+
+  """
+  List only the replies that were created between the specific time range.
+  """
+  createdAt: TimeRangeInput
+
+  """If given, only list out replies with specific IDs"""
+  ids: [ID!]
+
+  """Only list the replies created by the currently logged in user"""
   selfOnly: Boolean
+  moreLikeThis: MoreLikeThisInput
 
   """[Deprecated] use types instead."""
   type: ReplyTypeEnum
 
   """List the replies of certain types"""
   types: [ReplyTypeEnum]
-
-  """
-  List only the replies that were created between the specific time range.
-  """
-  createdAt: TimeRangeInput
 }
 
 """
@@ -839,8 +911,24 @@ type ListArticleReplyFeedbackConnectionPageInfo implements PageInfo {
 }
 
 input ListArticleReplyFeedbackFilter {
-  userId: String
+  """Show only article reply feedbacks created by a specific app."""
   appId: String
+
+  """Show only article reply feedbacks created by the specific user."""
+  userId: String
+
+  """
+  List only the article reply feedbacks that were created between the specific time range.
+  """
+  createdAt: TimeRangeInput
+
+  """If given, only list out article reply feedbacks with specific IDs"""
+  ids: [ID!]
+
+  """
+  Only list the article reply feedbacks created by the currently logged in user
+  """
+  selfOnly: Boolean
   articleId: String
   replyId: String
 
@@ -851,14 +939,12 @@ input ListArticleReplyFeedbackFilter {
   vote: [FeedbackVote]
 
   """
-  List only the article reply feedbacks that were created within the specific time range.
-  """
-  createdAt: TimeRangeInput
-
-  """
   List only the article reply feedbacks that were last updated within the specific time range.
   """
   updatedAt: TimeRangeInput
+
+  """List only the article reply feedbacks with the selected statuses"""
+  statuses: [ArticleReplyFeedbackStatusEnum!] = [NORMAL]
 }
 
 """
@@ -895,10 +981,26 @@ type ListReplyRequestConnectionPageInfo implements PageInfo {
 }
 
 input ListReplyRequestFilter {
-  userId: String
+  """Show only reply requests created by a specific app."""
   appId: String
-  articleId: String
+
+  """Show only reply requests created by the specific user."""
+  userId: String
+
+  """
+  List only the reply requests that were created between the specific time range.
+  """
   createdAt: TimeRangeInput
+
+  """If given, only list out reply requests with specific IDs"""
+  ids: [ID!]
+
+  """Only list the reply requests created by the currently logged in user"""
+  selfOnly: Boolean
+  articleId: String
+
+  """List only reply requests with specified statuses"""
+  statuses: [ReplyRequestStatusEnum!] = [NORMAL]
 }
 
 """
@@ -907,6 +1009,41 @@ An entry of orderBy argument. Specifies field name and the sort order. Only one 
 input ListReplyRequestOrderBy {
   createdAt: SortOrderEnum
   vote: SortOrderEnum
+}
+
+type UserConnection implements Connection {
+  """
+  The total count of the entire collection, regardless of "before", "after".
+  """
+  totalCount: Int!
+  edges: [UserConnectionEdge!]!
+  pageInfo: UserConnectionPageInfo!
+}
+
+type UserConnectionEdge implements Edge {
+  node: User!
+  cursor: String!
+  score: Float
+  highlight: Highlights
+}
+
+type UserConnectionPageInfo implements PageInfo {
+  lastCursor: String
+  firstCursor: String
+}
+
+input ListBlockedUsersFilter {
+  """
+  List only the blocked users that were registered between the specific time range.
+  """
+  createdAt: TimeRangeInput
+}
+
+"""
+An entry of orderBy argument. Specifies field name and the sort order. Only one field name is allowd per entry.
+"""
+input ListBlockedUsersOrderBy {
+  createdAt: SortOrderEnum
 }
 
 type ValidationResult {

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -5,6 +5,7 @@
   import Articles from './pages/Articles.svelte';
   import Source from './pages/Source.svelte';
   import Reason from './pages/Reason.svelte';
+  import Comment from './pages/Comment.svelte';
   import UserSetting from './pages/UserSetting.svelte';
   import PositiveFeedback from './pages/PositiveFeedback.svelte';
   import NegativeFeedback from './pages/NegativeFeedback.svelte';
@@ -13,10 +14,12 @@
     article: Article,
     articles: Articles,
     source: Source,
-    reason: Reason,
     'feedback/yes': PositiveFeedback,
     'feedback/no': NegativeFeedback,
     setting: UserSetting,
+    comment: Comment,
+    // Legacy reply request form
+    reason: Reason,
   };
 
   // Send pageview with correct path on each page change.

--- a/src/liff/components/ReplyRequestForm.stories.svelte
+++ b/src/liff/components/ReplyRequestForm.stories.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+  import ReplyRequestForm from "./ReplyRequestForm.svelte";
+</script>
+
+<Meta
+  title="ReplyRequestForm"
+  component={ReplyRequestForm}
+  argTypes={{
+    searchedText: {type: 'string'},
+    disabled: {type: 'boolean'},
+    reason: {type: 'string'},
+    onSubmit: {action: 'onSubmit'},
+  }}
+/>
+
+<Template let:args>
+  <ReplyRequestForm
+    {...args}
+    on:submit={args.onSubmit}
+  />
+</Template>
+
+<Story name="Default"/>
+
+<Story
+  name="Blocks identical message"
+  args={{
+    reason: 'This message is identical to searchText, will be blocked on submit',
+    searchedText: 'This message is identical to searchText, will be blocked on submit',
+  }}
+/>

--- a/src/liff/components/ReplyRequestForm.svelte
+++ b/src/liff/components/ReplyRequestForm.svelte
@@ -86,6 +86,7 @@ ${LENGHEN_HINT}`
   <TextArea
     name="reason"
     bind:value={reason}
+    disabled={disabled}
     placeholder={t`Ex: I googled using (some keyword) and found that... / I found different opinion on (some website) saying that...`}
   />
 

--- a/src/liff/components/ReplyRequestForm.svelte
+++ b/src/liff/components/ReplyRequestForm.svelte
@@ -89,11 +89,12 @@ ${LENGHEN_HINT}`
     placeholder={t`Ex: I googled using (some keyword) and found that... / I found different opinion on (some website) saying that...`}
   />
 
-  <Button type="submit" disabled={disabled}>
-    {#if reason.length === 0}
+  <Button
+    type="submit"
+    disabled={disabled}
+  >
+    {#if reason.length > 0}
       {t`Submit`}
-    {:else if vote === 'DOWNVOTE'}
-      {t`Please provide your comment above`}
     {:else}
       {t`Close`}
     {/if}

--- a/src/liff/components/ReplyRequestForm.svelte
+++ b/src/liff/components/ReplyRequestForm.svelte
@@ -1,0 +1,101 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import { t } from 'ttag';
+
+  import TextArea from './TextArea.svelte';
+  import Button from './Button.svelte';
+
+  /* The text of the article being asked */
+  export let searchedText = '';
+  export let disabled = false;
+  export let reason = '';
+
+  const SUFFICIENT_REASON_LENGTH = 40;
+  const LENGHEN_HINT = /* t: Guidance in LIFF */ t`
+You may try:
+1. Express your thought more
+2. Google for more info
+3. Look for similar content using search box on Facebook`;
+
+  const REASON_SUGGESTION = /* t: Guidance in LIFF */ t`
+It would help fact-checking editors a lot if you provide more info :)
+
+${LENGHEN_HINT}
+
+To provide more info, please press "Cancel"; otherwise, press "OK" to submit the current info directly.`;
+
+  const DUP_SUGGESTION = /* t: Guidance in LIFF */ t`
+The info you provide should not be identical to the message itself.
+
+${LENGHEN_HINT}`
+
+  const dispatch = createEventDispatcher();
+  const handleSubmit = () => {
+    const trimmedReason = reason.trim();
+    if(searchedText === trimmedReason) {
+      alert(DUP_SUGGESTION);
+      return;
+    }
+
+    if(
+      trimmedReason.length < SUFFICIENT_REASON_LENGTH &&
+      !confirm(REASON_SUGGESTION)
+    ) {
+      return;
+    }
+
+    dispatch('submit', trimmedReason);
+  }
+</script>
+
+<style>
+  form {
+    display: flex;
+    flex-flow: column;
+    padding: 16px;
+
+    flex: 1; /* extend to container size */
+    margin: 0; /* reset browser native style */
+
+    color: #fff;
+    font-size: 16px;
+    background: var(--orange1);
+  }
+
+  p {
+    margin: 0;
+  }
+
+  .emphasize {
+    font-weight: 700;
+  }
+
+  form :global(textarea) {
+    margin: 16px 0 20px;
+    min-height: 80px;
+    flex: 1; /* extend to container size */
+  }
+</style>
+
+<form on:submit|preventDefault={handleSubmit}>
+  <p class="emphasize">
+    {t`To help with fact-checking, please tell the editors:`}<br />
+    {t`Why do you think this is a hoax?`}
+  </p>
+
+  <TextArea
+    name="reason"
+    bind:value={reason}
+    placeholder={t`Ex: I googled using (some keyword) and found that... / I found different opinion on (some website) saying that...`}
+  />
+
+  <Button type="submit" disabled={disabled}>
+    {#if reason.length === 0}
+      {t`Submit`}
+    {:else if vote === 'DOWNVOTE'}
+      {t`Please provide your comment above`}
+    {:else}
+      {t`Close`}
+    {/if}
+  </Button>
+</form>

--- a/src/liff/pages/Comment.svelte
+++ b/src/liff/pages/Comment.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { t, ngettext, msgid } from 'ttag';
+  import { gaTitle } from 'src/lib/sharedUtils';
   import ReplyRequestForm from '../components/ReplyRequestForm.svelte';
   import { gql } from '../lib';
 
@@ -14,8 +15,10 @@
   onMount(async () => {
     // Load searchedText from API
     const {data, errors} = await gql`
-      query GetCurrentUserRequestInLIFF($articleId: string) {
-        ListReplyRequests({filter: {articleId: $articleId, selfOnly: true}) {
+      query GetCurrentUserRequestInLIFF($articleId: String) {
+        ListReplyRequests(
+          filter: {articleId: $articleId, selfOnly: true}
+        ) {
           edges {
             node {
               id
@@ -49,15 +52,15 @@
     });
   });
 
-  const handleSubmit = async (reason) => {
+  const handleSubmit = async e => {
     processing = true;
     const {data, errors} = await gql`
-      mutation UpdateReasonInLIFF($articleId: string, $reason: string) {
+      mutation UpdateReasonInLIFF($articleId: String!, $reason: String) {
         CreateOrUpdateReplyRequest(articleId: $articleId, reason: $reason) {
           replyRequestCount
         }
       }
-    `({articleId});
+    `({articleId, reason: (e.detail || '').trim()});
     processing = false;
 
     if(errors) {

--- a/src/liff/pages/Comment.svelte
+++ b/src/liff/pages/Comment.svelte
@@ -8,8 +8,9 @@
   const params = new URLSearchParams(location.search);
   const articleId = params.get('articleId');
 
+  let isLoading = true;
+  let isSubmitting = false;
   let searchedText = null;
-  let processing = false;
   let reason = '';
 
   onMount(async () => {
@@ -32,6 +33,8 @@
       }
     `({articleId});
 
+    isLoading = false;
+
     if(errors) {
       alert(errors[0].message);
       return;
@@ -53,7 +56,7 @@
   });
 
   const handleSubmit = async e => {
-    processing = true;
+    isSubmitting = true;
     const {data, errors} = await gql`
       mutation UpdateReasonInLIFF($articleId: String!, $reason: String) {
         CreateOrUpdateReplyRequest(articleId: $articleId, reason: $reason) {
@@ -61,7 +64,7 @@
         }
       }
     `({articleId, reason: (e.detail || '').trim()});
-    processing = false;
+    isSubmitting = false;
 
     if(errors) {
       alert(errors[0].message);
@@ -101,7 +104,7 @@
   <ReplyRequestForm
     reason={reason}
     searchedText={searchedText}
-    disabled={processing}
+    disabled={isSubmitting || isLoading}
     on:submit={handleSubmit}
   />
 </main>

--- a/src/liff/pages/Comment.svelte
+++ b/src/liff/pages/Comment.svelte
@@ -56,6 +56,7 @@
   });
 
   const handleSubmit = async e => {
+    const reason = (e.detail || '').trim();
     isSubmitting = true;
     const {data, errors} = await gql`
       mutation UpdateReasonInLIFF($articleId: String!, $reason: String) {
@@ -63,11 +64,16 @@
           replyRequestCount
         }
       }
-    `({articleId, reason: (e.detail || '').trim()});
+    `({articleId, reason});
     isSubmitting = false;
 
     if(errors) {
       alert(errors[0].message);
+      return;
+    }
+
+    if(!reason) {
+      liff.closeWindow();
       return;
     }
 


### PR DESCRIPTION
Spec: https://g0v.hackmd.io/@mrorz/cofacts-meeting-notes/%2FOdOwYeKjQsSyUVzuE-BGiw
Figma: https://www.figma.com/file/DvmAQjMJCncuPORWKnljM1/Cofacts-LIFF?node-id=3053%3A133

Staging test URL:
- LIFF: https://liff.line.me/1563196602-X6mLdDkW?p=comment&articleId=3tu9btf8s50sm
- Corresponding article: https://dev.cofacts.tw/article/3tu9btf8s50sm

- This PR introduces a `ReplyRequestForm` component for LIFF
    - Blocks same content from searched text (existing behavior in reason LIFF)
    - Encourage user to write more content (existing behavior in reason LIFF)
    - props
        - searchedText: the searched article text. Used to detect if the user's reason is identical to message.
        - disabled: boolean. If true, disable the textarea and the button.
        - reason: the reason text input
    - event handlers
        - submit: reason text will be trimmed and passed through `event.detail`.

- "comment" page
    - Calls Cofacts API to get current reply request, article text
    - Closes window after submission
    - Thank user if they input anything (in an alert)

## Default appearance
![圖片](https://user-images.githubusercontent.com/108608/161443496-2ffcea07-c991-4c68-8973-7d90d1ddd612.png)
<img width="595" alt="image" src="https://user-images.githubusercontent.com/108608/161611560-69612e2b-6a42-4154-9e3b-bd71ee8a9c7d.png">

## Loads existing reply request
![圖片](https://user-images.githubusercontent.com/108608/161443484-082edf9c-5122-4aad-b5ad-7137f62e17ea.png)

## Close without writing
![close](https://user-images.githubusercontent.com/108608/161612005-3b5eccca-199c-4987-8adb-ba66237ccaf3.gif)

## Thank-you message and then close
![thanks](https://user-images.githubusercontent.com/108608/161612488-9fb0cc65-4f9c-4373-bc42-29b587e9c873.gif)

## Block submission then reason is identical to searchedText
![image](https://user-images.githubusercontent.com/108608/161674537-d9980f2e-40a1-4ace-afd0-67de46a39fed.png)

