### PR TITLE
Fix "not identical" unit test by making test input and mock data more distinct

### DIFF
--- a/src/webhook/handlers/__tests__/groupMessage.test.js
+++ b/src/webhook/handlers/__tests__/groupMessage.test.js
@@ -276,7 +276,7 @@ describe('groupMessage', () => {
   });
 
   it('should handle input is not identical to article ', async () => {
-    event.input = '我知道黑啤愛吃蛾哦！';
+    event.input = '我知道黑啤愛吃兔寶寶哦！';
     gql.__push(apiResult.invalidArticleReply);
     expect((await groupMessage(event)).replies).toBeUndefined();
     expect(gql.__finished()).toBe(true);
@@ -285,7 +285,7 @@ describe('groupMessage', () => {
         Array [
           undefined,
           "__INIT__",
-          "我知道黑啤愛吃蛾哦！",
+          "我知道黑啤愛吃兔寶寶哦！",
           "group",
         ],
       ]

--- a/src/webhook/handlers/__tests__/groupMessage.test.js
+++ b/src/webhook/handlers/__tests__/groupMessage.test.js
@@ -276,7 +276,7 @@ describe('groupMessage', () => {
   });
 
   it('should handle input is not identical to article ', async () => {
-    event.input = '我知道黑啤愛吃蠶寶寶哦！';
+    event.input = '我知道黑啤愛吃蛾哦！';
     gql.__push(apiResult.invalidArticleReply);
     expect((await groupMessage(event)).replies).toBeUndefined();
     expect(gql.__finished()).toBe(true);
@@ -285,7 +285,7 @@ describe('groupMessage', () => {
         Array [
           undefined,
           "__INIT__",
-          "我知道黑啤愛吃蠶寶寶哦！",
+          "我知道黑啤愛吃蛾哦！",
           "group",
         ],
       ]


### PR DESCRIPTION
Unit test on master branch is broken when we [drop the similarity threshold to 0.8](https://github.com/cofacts/rumors-line-bot/pull/298).

The broken test case is "groupMessage should handle input is not identical to article".

The root cause is that the similarity between test input `我知道黑啤愛吃蠶寶寶哦！`  and mockup `我不會說我知道黑啤愛吃蠶寶寶哦！` is higher than the new threshold 0.8. 

The test case is meant to be testing the behavior when test input is lower than the threshold. Therefore, this PR makes the test input more dissimilar with the mockup data, so that we can test the desired branch and thus fix the test.


```javascript
const ss = require('string-similarity')
ss.compareTwoStrings('我不會說我知道黑啤愛吃蠶寶寶哦！', '我知道黑啤愛吃蠶寶寶哦！') // 0.8461538461538461
ss.compareTwoStrings('我不會說我知道黑啤愛吃蠶寶寶哦！', '我知道黑啤愛吃兔寶寶哦！') // 0.6923076923076923
```