### PR TITLE
Revamp no reply flow

### DIFF
--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -50,19 +50,19 @@ msgstr "出處"
 msgid "This reply has no ${ prompt } and it may be biased"
 msgstr "此回應沒有${prompt}，請自行斟酌回應之可信度。"
 
-#: src/webhook/handlers/choosingArticle.js:151
+#: src/webhook/handlers/choosingArticle.js:154
 msgid "Volunteer editors have published several replies to this message."
 msgstr "真的假的查證志工對這則訊息發表了多則看法唷！"
 
-#: src/webhook/handlers/choosingArticle.js:273
+#: src/webhook/handlers/choosingArticle.js:276
 msgid "Let's pick one"
 msgstr "選一則來閱讀吧"
 
-#: src/webhook/handlers/choosingArticle.js:252
+#: src/webhook/handlers/choosingArticle.js:255
 msgid "Take a look"
 msgstr "看他怎麼說"
 
-#: src/webhook/handlers/choosingArticle.js:289
+#: src/webhook/handlers/choosingArticle.js:292
 #, javascript-format
 msgid "Visit ${ articleUrl } for more replies."
 msgstr "更多回應請到：${ articleUrl }"
@@ -132,11 +132,11 @@ msgstr "回報此訊息"
 msgid "Please choose the most similar message from the list."
 msgstr "請從下列選擇您要查的訊息。"
 
-#: src/webhook/handlers/choosingArticle.js:277
+#: src/webhook/handlers/choosingArticle.js:280
 msgid "Please take a look at the following replies."
 msgstr "請從下列選擇您要查看的回應。"
 
-#: src/webhook/handlers/choosingArticle.js:198
+#: src/webhook/handlers/choosingArticle.js:201
 #, javascript-format
 msgid "Someone thinks it ${ typeWords }"
 msgstr "有人認為它${typeWords}"
@@ -228,32 +228,32 @@ msgstr "查看回報的訊息"
 msgid "We've received feedback from you and ${ _otherFeedbackCount } other users!"
 msgstr "感謝您與其他 ${_otherFeedbackCount} 人的評價。"
 
-#: src/webhook/handlers/choosingArticle.js:43
+#: src/webhook/handlers/choosingArticle.js:46
 #: src/webhook/handlers/choosingReply.js:86
 msgid "Please choose from provided options."
 msgstr "請從上面的選項中做選擇。"
 
-#: src/webhook/handlers/choosingArticle.js:155
+#: src/webhook/handlers/choosingArticle.js:158
 #, javascript-format
 msgid "${ countOfType.RUMOR } of them say it ❌ contains misinformation."
 msgstr "${ countOfType.RUMOR } 人認為它 ❌ 含有不實訊息。"
 
-#: src/webhook/handlers/choosingArticle.js:158
+#: src/webhook/handlers/choosingArticle.js:161
 msgid "${ countOfType.NOT_RUMOR } of them says it ⭕ contains true information."
 msgstr "${ countOfType.NOT_RUMOR } 人認為它 ⭕ 含有真實訊息。"
 
-#: src/webhook/handlers/choosingArticle.js:163
+#: src/webhook/handlers/choosingArticle.js:166
 #, javascript-format
 msgid ""
 "${ countOfType.OPINIONATED } of them says it 💬 contains personal "
 "perspective."
 msgstr "${ countOfType.OPINIONATED } 人認為它 💬 含有個人意見。"
 
-#: src/webhook/handlers/choosingArticle.js:168
+#: src/webhook/handlers/choosingArticle.js:171
 msgid "${ countOfType.NOT_ARTICLE } of them says it ⚠️️ is out of scope of Cofacts."
 msgstr "${ countOfType.NOT_ARTICLE } 人認為它 ⚠️️ 不在 Cofacts 的查證範圍。"
 
-#: src/webhook/handlers/choosingArticle.js:254
+#: src/webhook/handlers/choosingArticle.js:257
 #: src/webhook/handlers/initState.js:203
 #, javascript-format
 msgid "I choose “${ displayTextWhenChosen }”"
@@ -262,7 +262,6 @@ msgstr "我要選「${displayTextWhenChosen}」"
 #: src/liff/pages/Comment.svelte:93
 #: src/liff/pages/Reason.svelte:79
 #: src/liff/pages/Source.svelte:33
-#: src/webhook/handlers/choosingArticle.js:302
 #: src/webhook/handlers/utils.js:463
 msgid "Provide more info"
 msgstr "提供更多資訊"
@@ -778,7 +777,7 @@ msgstr "Hi 我是「Cofacts 真的假的」訊息查證機器人～"
 msgid "Thank you for sharing “${ inputSummary }”"
 msgstr "感謝您的分享 “${ inputSummary }”"
 
-#: src/webhook/handlers/choosingArticle.js:62
+#: src/webhook/handlers/choosingArticle.js:65
 msgid ""
 "I see. Don't trust the message just yet!\n"
 "May I have your help?"
@@ -786,19 +785,9 @@ msgstr ""
 "這樣呀。請先不要相信這個訊息唷！\n"
 "可以請你幫我一個忙嗎？"
 
-#: src/webhook/handlers/choosingArticle.js:104
+#: src/webhook/handlers/choosingArticle.js:107
 msgid "Provided message is not found."
-msgstr ""
-
-#: src/webhook/handlers/choosingArticle.js:306
-msgid ""
-"I would suggest don't trust this message just yet. To help Cofacts editors "
-"checking the message, please "
-msgstr "先不要相信這個訊息唷，它可能是假的。如果要請闢謠志工查證，請"
-
-#: src/webhook/handlers/choosingArticle.js:310
-msgid "provide more information using the button below. "
-msgstr "點下面的按鈕，提供你找到的情報。"
+msgstr "找不到此訊息。"
 
 #: src/webhook/handlers/initState.js:323
 #, javascript-format
@@ -996,3 +985,32 @@ msgstr "此訊息不存在。"
 #: src/liff/pages/Article.svelte:130
 msgid "The reply does not exist. Maybe it has been deleted by its author."
 msgstr "此回應不存在。或許已經被作者刪掉囉。"
+
+#: src/webhook/handlers/choosingArticle.js:311
+#: src/webhook/handlers/choosingArticle.js:321
+msgid ""
+"This message is already published at Cofacts, waiting for nice volunteers "
+"to fact-check.\n"
+"Don’t trust the message just yet!"
+msgstr " 此訊息已經被收錄至 Cofacts 真的假的，有待好心人來查證。請先不要相信這個訊息唷！"
+
+#: src/webhook/handlers/choosingArticle.js:328
+msgid "View reported message"
+msgstr "檢視回報訊息"
+
+#: src/webhook/handlers/choosingArticle.js:337
+msgid "In the meantime, you may consider:"
+msgstr "接下來您可以："
+
+#: src/webhook/handlers/choosingArticle.js:340
+#: src/webhook/handlers/utils.js:669
+msgid "Provide more detail"
+msgstr "提供更多情報"
+
+#: src/webhook/handlers/utils.js:682
+msgid "It would help fact checkers a lot if you provide more detail :)"
+msgstr "您可以提供更多關於此訊息的情報給查證志工，讓好心人更容易查真假唷！"
+
+#: src/webhook/handlers/utils.js:695
+msgid "Provide detail"
+msgstr "提供更多情報"

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -468,6 +468,7 @@ Object {
       "type": "flex",
     },
   ],
+  "state": "CHOOSING_ARTICLE",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;
@@ -1298,6 +1299,7 @@ Object {
       "type": "text",
     },
   ],
+  "state": "CHOOSING_ARTICLE",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;
@@ -1507,6 +1509,7 @@ Object {
       "type": "flex",
     },
   ],
+  "state": "CHOOSING_ARTICLE",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;
@@ -1547,58 +1550,147 @@ Object {
   "isSkipUser": false,
   "replies": Array [
     Object {
-      "altText": "📱 Please proceed on your mobile phone.",
+      "altText": "This message is already published at Cofacts, waiting for nice volunteers to fact-check.\\\\nDon’t trust the message just yet!",
       "contents": Object {
         "body": Object {
           "contents": Array [
             Object {
-              "contents": Array [
-                Object {
-                  "text": "I would suggest don't trust this message just yet. To help Cofacts editors checking the message, please ",
-                  "type": "span",
-                },
-                Object {
-                  "color": "#ffb600",
-                  "text": "provide more information using the button below. ",
-                  "type": "span",
-                  "weight": "bold",
-                },
-              ],
+              "text": "This message is already published at Cofacts, waiting for nice volunteers to fact-check.
+Don’t trust the message just yet!",
               "type": "text",
               "wrap": true,
             },
-          ],
-          "layout": "vertical",
-          "paddingAll": "lg",
-          "spacing": "md",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
             Object {
               "action": Object {
-                "label": "ℹ️ Provide more info",
+                "label": "View reported message",
                 "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=source&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYzc2ZDhhZTljY2QxYWRhNGYwNmM0ZTE1MTVkNDY0NjYiLCJleHAiOjE1Nzc5MjMyMDB9.ZxHN5etvaneWUumNx9bqdBA_6IPmBIQ5sfz7jneJNvI",
+                "uri": "https://dev.cofacts.tw/article/article-id",
               },
-              "color": "#ffb600",
-              "style": "primary",
+              "margin": "md",
               "type": "button",
             },
           ],
           "layout": "vertical",
           "type": "box",
         },
-        "styles": Object {
-          "body": Object {
-            "separator": true,
-          },
+        "type": "bubble",
+      },
+      "type": "flex",
+    },
+    Object {
+      "altText": "In the meantime, you may consider:",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "In the meantime, you may consider:",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
         },
         "type": "bubble",
       },
       "type": "flex",
     },
+    Object {
+      "altText": "Provide more detail",
+      "contents": Object {
+        "contents": Array [
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "It would help fact checkers a lot if you provide more detail :)",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
+            },
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Provide detail",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=comment&articleId=article-id",
+                  },
+                  "color": "#00B172",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
+            },
+            "header": Object {
+              "contents": Array [
+                Object {
+                  "color": "#00B172",
+                  "size": "lg",
+                  "text": "Provide more detail",
+                  "type": "text",
+                },
+              ],
+              "layout": "vertical",
+              "paddingBottom": "none",
+              "type": "box",
+            },
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Your friends may know the answer 🌟 Share your question to friends, maybe someone can help!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
+            },
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share on LINE",
+                    "type": "uri",
+                    "uri": "line://msg/text/?Please%20help%20me%20verify%20if%20this%20is%20true%3A%20https%3A%2F%2Fdev.cofacts.tw%2Farticle%2Farticle-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "Share on Facebook",
+                    "type": "uri",
+                    "uri": "https://www.facebook.com/dialog/share?openExternalBrowser=1&app_id=719656818195367&display=popup&hashtag=%23ReportedToCofacts&href=https%3A%2F%2Fdev.cofacts.tw%2Farticle%2Farticle-id",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
+            },
+            "type": "bubble",
+          },
+        ],
+        "type": "carousel",
+      },
+      "type": "flex",
+    },
   ],
+  "state": "__INIT__",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -13,7 +13,6 @@ Object {
     "timestamp": 1519019734813,
     "type": "postback",
   },
-  "isSkipUser": false,
   "replies": Array [
     Object {
       "text": "I see. Don't trust the message just yet!
@@ -130,7 +129,6 @@ Object {
     "timestamp": 1519019734813,
     "type": "postback",
   },
-  "isSkipUser": false,
   "replies": Array [
     Object {
       "text": "👨‍👩‍👧‍👦  Volunteer editors have published several replies to this message.
@@ -487,7 +485,6 @@ Object {
     "timestamp": 1519019734813,
     "type": "postback",
   },
-  "isSkipUser": false,
   "replies": Array [
     Object {
       "text": "👨‍👩‍👧‍👦  Volunteer editors have published several replies to this message.
@@ -1327,7 +1324,6 @@ Object {
     "timestamp": 1519019734813,
     "type": "postback",
   },
-  "isSkipUser": false,
   "replies": Array [
     Object {
       "text": "👨‍👩‍👧‍👦  Volunteer editors have published several replies to this message.
@@ -1511,24 +1507,6 @@ Object {
 }
 `;
 
-exports[`should select article with just one reply 1`] = `
-Object {
-  "data": Object {
-    "searchedText": "Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply",
-    "selectedArticleId": "article-id",
-    "selectedArticleText": "Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply ",
-  },
-  "event": Object {
-    "input": "AV--O3nfyCdS-nWhujMD",
-    "type": "postback",
-  },
-  "isSkipUser": true,
-  "replies": undefined,
-  "state": "CHOOSING_REPLY",
-  "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
-}
-`;
-
 exports[`should select article with no replies 1`] = `
 Object {
   "data": Object {
@@ -1544,7 +1522,6 @@ Object {
     "timestamp": 1519019734813,
     "type": "postback",
   },
-  "isSkipUser": false,
   "replies": Array [
     Object {
       "altText": "This message is already published at Cofacts, waiting for nice volunteers to fact-check.\\\\nDon’t trust the message just yet!",

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -468,7 +468,6 @@ Object {
       "type": "flex",
     },
   ],
-  "state": "CHOOSING_ARTICLE",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;
@@ -1299,7 +1298,6 @@ Object {
       "type": "text",
     },
   ],
-  "state": "CHOOSING_ARTICLE",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;
@@ -1509,7 +1507,6 @@ Object {
       "type": "flex",
     },
   ],
-  "state": "CHOOSING_ARTICLE",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;
@@ -1690,7 +1687,6 @@ Don’t trust the message just yet!",
       "type": "flex",
     },
   ],
-  "state": "__INIT__",
   "userId": "Uc76d8ae9ccd1ada4f06c4e1515d46466",
 }
 `;

--- a/src/webhook/handlers/__tests__/choosingArticle.test.js
+++ b/src/webhook/handlers/__tests__/choosingArticle.test.js
@@ -30,6 +30,7 @@ it('should select article by articleId', async () => {
   gql.__push(apiResult.selectedArticleId);
 
   const params = {
+    state: 'CHOOSING_ARTICLE',
     data: {
       searchedText:
         '《緊急通知》\n台北馬偕醫院傳來訊息：\n資深醫生（林清風）傳來：「請大家以後千萬不要再吃生魚片了！」\n因為最近已經發現- 好多病人因為吃了生魚片，胃壁附著《海獸胃腺蟲》，大小隻不一定，有的病人甚至胃壁上滿滿都是無法夾出來，驅蟲藥也很難根治，罹患機率每個國家的人都一樣。\n尤其；鮭魚的含蟲量最高、最可怕！\n請傳給朋友，讓他們有所警惕!',
@@ -83,7 +84,6 @@ it('should select article by articleId', async () => {
 it('throws ManipulationError when articleId is not valid', async () => {
   gql.__push({ data: { GetArticle: null } });
 
-  // Simulate Article URL input
   const params = {
     data: {},
     event: {
@@ -105,6 +105,7 @@ it('should select article and have OPINIONATED and NOT_ARTICLE replies', async (
   gql.__push(apiResult.multipleReplies);
 
   const params = {
+    state: 'CHOOSING_ARTICLE',
     data: {
       searchedText:
         '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',
@@ -287,6 +288,7 @@ it('should select article and slice replies when over 10', async () => {
   gql.__push(apiResult.elevenReplies);
 
   const params = {
+    state: 'CHOOSING_ARTICLE',
     data: {
       searchedText:
         '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',

--- a/src/webhook/handlers/__tests__/choosingArticle.test.js
+++ b/src/webhook/handlers/__tests__/choosingArticle.test.js
@@ -30,7 +30,6 @@ it('should select article by articleId', async () => {
   gql.__push(apiResult.selectedArticleId);
 
   const params = {
-    state: 'CHOOSING_ARTICLE',
     data: {
       searchedText:
         '《緊急通知》\n台北馬偕醫院傳來訊息：\n資深醫生（林清風）傳來：「請大家以後千萬不要再吃生魚片了！」\n因為最近已經發現- 好多病人因為吃了生魚片，胃壁附著《海獸胃腺蟲》，大小隻不一定，有的病人甚至胃壁上滿滿都是無法夾出來，驅蟲藥也很難根治，罹患機率每個國家的人都一樣。\n尤其；鮭魚的含蟲量最高、最可怕！\n請傳給朋友，讓他們有所警惕!',
@@ -105,7 +104,6 @@ it('should select article and have OPINIONATED and NOT_ARTICLE replies', async (
   gql.__push(apiResult.multipleReplies);
 
   const params = {
-    state: 'CHOOSING_ARTICLE',
     data: {
       searchedText:
         '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',
@@ -288,7 +286,6 @@ it('should select article and slice replies when over 10', async () => {
   gql.__push(apiResult.elevenReplies);
 
   const params = {
-    state: 'CHOOSING_ARTICLE',
     data: {
       searchedText:
         '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',

--- a/src/webhook/handlers/choosingArticle.js
+++ b/src/webhook/handlers/choosingArticle.js
@@ -14,6 +14,7 @@ import {
   createArticleShareBubble,
 } from './utils';
 import ga from 'src/lib/ga';
+import choosingReply from './choosingReply';
 import UserSettings from 'src/database/models/userSettings';
 
 import UserArticleLink from '../../database/models/userArticleLink';
@@ -40,7 +41,7 @@ function reorderArticleReplies(articleReplies) {
 // https://developers.line.me/en/docs/messaging-api/reference/#template-messages
 
 export default async function choosingArticle(params) {
-  let { data, state, event, userId, replies, isSkipUser } = params;
+  let { data, state, event, userId, replies } = params;
 
   if (event.type !== 'postback') {
     throw new ManipulationError(t`Please choose from provided options.`);
@@ -67,7 +68,6 @@ export default async function choosingArticle(params) {
         },
         createAskArticleSubmissionConsentReply(userId, data.sessionId),
       ],
-      isSkipUser,
     };
   }
 
@@ -123,8 +123,8 @@ export default async function choosingArticle(params) {
   if (articleReplies.length === 1) {
     visitor.send();
 
-    // choose for user
-    return {
+    // choose reply for user
+    return choosingReply({
       data,
       event: {
         type: 'postback',
@@ -132,11 +132,8 @@ export default async function choosingArticle(params) {
       },
       userId,
       replies,
-      // override state to 'CHOOSING_REPLY'
       state: 'CHOOSING_REPLY',
-      // handleInput again
-      isSkipUser: true,
-    };
+    });
   }
 
   if (articleReplies.length !== 0) {
@@ -367,5 +364,5 @@ Don’t trust the message just yet!`,
 
   visitor.send();
 
-  return { data, event, userId, replies, isSkipUser };
+  return { data, event, userId, replies };
 }

--- a/src/webhook/handlers/choosingArticle.js
+++ b/src/webhook/handlers/choosingArticle.js
@@ -363,11 +363,9 @@ Don’t trust the message just yet!`,
         }
       }
     `({ id: selectedArticleId }, { userId });
-
-    state = '__INIT__';
   }
 
   visitor.send();
 
-  return { data, event, userId, replies, isSkipUser, state };
+  return { data, event, userId, replies, isSkipUser };
 }

--- a/src/webhook/handlers/choosingArticle.js
+++ b/src/webhook/handlers/choosingArticle.js
@@ -305,12 +305,36 @@ export default async function choosingArticle(params) {
     const { allowNewReplyUpdate } = await UserSettings.findOrInsertByUserId(
       userId
     );
-
     replies = [
-      createTextMessage(
-        t`This message is already published at ${articleUrl} , waiting for nice volunteers to fact-check. Don’t trust the message just yet!`
-      ),
-      createTextMessage(t`In the meantime, you may consider:`),
+      {
+        type: 'flex',
+        altText: t`This message is already published at Cofacts, waiting for nice volunteers to fact-check.\nDon’t trust the message just yet!`,
+        contents: {
+          type: 'bubble',
+          body: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              {
+                type: 'text',
+                wrap: true,
+                text: t`This message is already published at Cofacts, waiting for nice volunteers to fact-check.
+Don’t trust the message just yet!`,
+              },
+              {
+                type: 'button',
+                action: {
+                  type: 'uri',
+                  label: t`View reported message`,
+                  uri: articleUrl,
+                },
+                margin: 'md',
+              },
+            ],
+          },
+        },
+      },
+      createTextMessage({ text: t`In the meantime, you may consider:` }),
       {
         type: 'flex',
         altText: t`Provide more detail`,

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -654,9 +654,8 @@ export function isEventExpired(timestamp, milliseconds = 30 * 1000) {
 export const POSTBACK_NO_ARTICLE_FOUND = '__NO_ARTICLE_FOUND__';
 
 /**
- *
  * @param {string} articleId
- * @returns {object} Flex bubble messasge object
+ * @returns {object} Flex bubble messasge object that opens a Comment LIFF
  */
 export function createCommentBubble(articleId) {
   return {
@@ -711,14 +710,14 @@ export function createCommentBubble(articleId) {
  *
  * This prevents user to "share" Cofacts chatbot's text to Cofacts chatbot itself.
  *
- * @param {string} text
- * @param {Object[] | undefined} contents - Optional contents field for span objects.
+ * @param {Object} textProps - https://developers.line.biz/en/reference/messaging-api/#f-text.
+ *   type & wrap is specified by default.
  * @returns {Object} A single flex bubble message
  */
-export function createTextMessage(text, contents = undefined) {
+export function createTextMessage(textProps) {
   return {
     type: 'flex',
-    altText: text,
+    altText: textProps.text,
     contents: {
       type: 'bubble',
       body: {
@@ -728,8 +727,7 @@ export function createTextMessage(text, contents = undefined) {
           {
             type: 'text',
             wrap: true,
-            text,
-            contents,
+            ...textProps,
           },
         ],
       },

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -652,3 +652,87 @@ export function isEventExpired(timestamp, milliseconds = 30 * 1000) {
 }
 
 export const POSTBACK_NO_ARTICLE_FOUND = '__NO_ARTICLE_FOUND__';
+
+/**
+ *
+ * @param {string} articleId
+ * @returns {object} Flex bubble messasge object
+ */
+export function createCommentBubble(articleId) {
+  return {
+    type: 'bubble',
+    header: {
+      type: 'box',
+      layout: 'vertical',
+      contents: [
+        {
+          type: 'text',
+          text: t`Provide more detail`,
+          size: 'lg',
+          color: '#00B172',
+        },
+      ],
+      paddingBottom: 'none',
+    },
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      contents: [
+        {
+          type: 'text',
+          text: t`It would help fact checkers a lot if you provide more detail :)`,
+          wrap: true,
+        },
+      ],
+    },
+    footer: {
+      type: 'box',
+      layout: 'vertical',
+      contents: [
+        {
+          type: 'button',
+          action: {
+            type: 'uri',
+            label: t`Provide detail`,
+            uri: `${process.env.LIFF_URL}?p=comment&articleId=${articleId}`,
+          },
+          style: 'primary',
+          color: '#00B172',
+        },
+      ],
+      spacing: 'sm',
+    },
+  };
+}
+
+/**
+ * Creates a single flex bubble message that acts identical to text message, but cannot be copied
+ * nor forwarded by the user.
+ *
+ * This prevents user to "share" Cofacts chatbot's text to Cofacts chatbot itself.
+ *
+ * @param {string} text
+ * @param {Object[] | undefined} contents - Optional contents field for span objects.
+ * @returns {Object} A single flex bubble message
+ */
+export function createTextMessage(text, contents = undefined) {
+  return {
+    type: 'flex',
+    altText: text,
+    contents: {
+      type: 'bubble',
+      body: {
+        type: 'box',
+        layout: 'vertical',
+        contents: [
+          {
+            type: 'text',
+            wrap: true,
+            text,
+            contents,
+          },
+        ],
+      },
+    },
+  };
+}


### PR DESCRIPTION
As discussed in https://g0v.hackmd.io/eo8NM1VGQ7qxaamBZXRPtA#7-No-replies---Thanks , this PR changes the no-reply flow to use the new carousel that opens [new comment LIFF](https://github.com/cofacts/rumors-line-bot/pull/300).

Refactor: replace `isSkipUser: true` with calling `choosingReply` directly. This makes logic much more straightforward.

## Before translation

<img width="555" alt="圖片" src="https://user-images.githubusercontent.com/108608/162559140-a4eae591-476f-49a7-8b2b-740a9ed6cb0d.png">
<img width="622" alt="圖片" src="https://user-images.githubusercontent.com/108608/162559225-80b11c2d-8db2-43bc-8789-185ae050c062.png">

## After translation

![圖片](https://user-images.githubusercontent.com/108608/162559464-e85a6b66-c482-4daf-98c8-43d8e2ab62f4.png)

