### PR TITLE
Revamp submission flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,13 +339,12 @@ We use dimemsion `Message Source` (Custom Dimemsion1) to classify different even
   - If we found a articles in database that matches the message:
     - `UserInput` / `ArticleSearch` / `ArticleFound`
     - `Article` / `Search` / `<article id>` for each article found
-  - When user opens LIFF providing source, page view for page `/source` is sent.
   - If nothing found in database:
     - `UserInput` / `ArticleSearch` / `ArticleNotFound`
   - If articles found in database but is not what user want:
     - `UserInput` / `ArticleSearch` / `ArticleFoundButNoHit`
-  - When user provides source (includes invalid source)
-    - `UserInput` / `ProvidingSource` / `<source value>`
+  - When user provides source
+    - `UserInput` / `IsForwarded` / `Yes` | `No`
   - Matches one of Dialogflow intents
     - `UserInput` / `ChatWithBot` / `<intent name>`
 
@@ -366,7 +365,6 @@ We use dimemsion `Message Source` (Custom Dimemsion1) to classify different even
 
 5. User want to submit a new article
   - `Article` / `Create` / `Yes`
-  - `Article` / `ProvidingSource` / `<articleId>/<source value>`
 
 6. User does not want to submit an article
   - `Article` / `Create` / `No`

--- a/src/webhook/handleInput.js
+++ b/src/webhook/handleInput.js
@@ -5,6 +5,7 @@ import choosingReply from './handlers/choosingReply';
 import askingReplyFeedback from './handlers/askingReplyFeedback';
 import askingArticleSubmissionConsent from './handlers/askingArticleSubmissionConsent';
 import askingReplyRequestReason from './handlers/askingReplyRequestReason';
+import askingArticleSource from './handlers/askingArticleSource';
 import defaultState from './handlers/defaultState';
 import { ManipulationError } from './handlers/utils';
 import {
@@ -114,6 +115,10 @@ export default async function handleInput({ data = {} }, event, userId) {
         }
         case 'TUTORIAL': {
           params = tutorial(params);
+          break;
+        }
+        case 'ASKING_ARTICLE_SOURCE': {
+          params = await askingArticleSource(params);
           break;
         }
 

--- a/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
@@ -6,7 +6,7 @@ Array [
     "body": Object {
       "contents": Array [
         Object {
-          "text": "Your submission is now recorded at https://dev.cofacts.tw/article/new-article-id",
+          "text": "It would help fact checkers a lot if you provide more detail :)",
           "type": "text",
           "wrap": true,
         },
@@ -18,27 +18,30 @@ Array [
       "contents": Array [
         Object {
           "action": Object {
-            "label": "See reported message",
+            "label": "Provide detail",
             "type": "uri",
-            "uri": "https://dev.cofacts.tw/article/new-article-id",
+            "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=comment&articleId=new-article-id",
           },
-          "color": "#ffb600",
-          "style": "primary",
-          "type": "button",
-        },
-        Object {
-          "action": Object {
-            "label": "Provide more info",
-            "type": "uri",
-            "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE1Nzc4MzY4MDAwMDAsInN1YiI6InVzZXItaWQtMCIsImV4cCI6MTU3NzkyMzIwMH0.8BerlnWZ5tp5Voipq2feE3W1sWxadJ9whgrIitn1h5U",
-          },
-          "color": "#ffb600",
+          "color": "#00B172",
           "style": "primary",
           "type": "button",
         },
       ],
       "layout": "vertical",
       "spacing": "sm",
+      "type": "box",
+    },
+    "header": Object {
+      "contents": Array [
+        Object {
+          "color": "#00B172",
+          "size": "lg",
+          "text": "Provide more detail",
+          "type": "text",
+        },
+      ],
+      "layout": "vertical",
+      "paddingBottom": "none",
       "type": "box",
     },
     "type": "bubble",
@@ -142,80 +145,16 @@ Array [
 ]
 `;
 
-exports[`should redirect user to other fact-checkers for invalid options 1`] = `
+exports[`should submit article if user agrees to submit 1`] = `
 Object {
   "data": Object {
     "foundArticleIds": Array [],
     "searchedText": "Some text forwarded by the user",
-  },
-  "event": Object {
-    "input": "1️⃣ I got the message from:
-Somewhere outside LINE",
-    "type": "message",
-  },
-  "isSkipUser": undefined,
-  "replies": Array [
-    Object {
-      "text": "Thanks for the info.",
-      "type": "text",
-    },
-    Object {
-      "altText": "We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.",
-      "contents": Object {
-        "body": Object {
-          "contents": Array [
-            Object {
-              "text": "We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.",
-              "type": "text",
-              "wrap": true,
-            },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "MyGoPen 真人查證",
-                "type": "uri",
-                "uri": "https://line.me/R/ti/p/%40imygopen",
-              },
-              "color": "#333333",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "styles": Object {
-          "body": Object {
-            "separator": true,
-          },
-        },
-        "type": "bubble",
-      },
-      "type": "flex",
-    },
-  ],
-  "userId": undefined,
-}
-`;
-
-exports[`should submit article when valid source is provided 1`] = `
-Object {
-  "data": Object {
-    "foundArticleIds": Array [],
-    "searchedText": "Some text forwarded by the user",
-    "selectedArticleId": "new-article-id",
     "sessionId": 1577923200000,
   },
   "event": Object {
-    "input": "1️⃣ I got the message from:
-A LINE group",
-    "type": "message",
+    "input": "__POSTBACK_YES__",
+    "type": "postback",
   },
   "isSkipUser": undefined,
   "replies": Array [
@@ -227,7 +166,7 @@ A LINE group",
             "body": Object {
               "contents": Array [
                 Object {
-                  "text": "Your submission is now recorded at https://dev.cofacts.tw/article/new-article-id",
+                  "text": "It would help fact checkers a lot if you provide more detail :)",
                   "type": "text",
                   "wrap": true,
                 },
@@ -239,27 +178,30 @@ A LINE group",
               "contents": Array [
                 Object {
                   "action": Object {
-                    "label": "See reported message",
+                    "label": "Provide detail",
                     "type": "uri",
-                    "uri": "https://dev.cofacts.tw/article/new-article-id",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=comment&articleId=new-article-id",
                   },
-                  "color": "#ffb600",
-                  "style": "primary",
-                  "type": "button",
-                },
-                Object {
-                  "action": Object {
-                    "label": "Provide more info",
-                    "type": "uri",
-                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=reason&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE1Nzc5MjMyMDAwMDAsInN1YiI6InVzZXJJZCIsImV4cCI6MTU3ODAwOTYwMH0.NNLTji977VFNyYJ0Mplj63tAUBrzifCmNtWp-0dHrus",
-                  },
-                  "color": "#ffb600",
+                  "color": "#00B172",
                   "style": "primary",
                   "type": "button",
                 },
               ],
               "layout": "vertical",
               "spacing": "sm",
+              "type": "box",
+            },
+            "header": Object {
+              "contents": Array [
+                Object {
+                  "color": "#00B172",
+                  "size": "lg",
+                  "text": "Provide more detail",
+                  "type": "text",
+                },
+              ],
+              "layout": "vertical",
+              "paddingBottom": "none",
               "type": "box",
             },
             "type": "bubble",

--- a/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
@@ -159,6 +159,51 @@ Object {
   "isSkipUser": undefined,
   "replies": Array [
     Object {
+      "altText": "The message has now been recorded at Cofacts for volunteers to fact-check. Thank you for submitting!",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "The message has now been recorded at Cofacts for volunteers to fact-check. Thank you for submitting!",
+              "type": "text",
+              "wrap": true,
+            },
+            Object {
+              "action": Object {
+                "label": "View reported message",
+                "type": "uri",
+                "uri": "https://dev.cofacts.tw/article/new-article-id",
+              },
+              "margin": "md",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "type": "flex",
+    },
+    Object {
+      "altText": "In the meantime, you can:",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "In the meantime, you can:",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "type": "flex",
+    },
+    Object {
       "altText": "Your submission is now recorded at https://dev.cofacts.tw/article/new-article-id",
       "contents": Object {
         "contents": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -48,29 +48,41 @@ Object {
           "layout": "vertical",
           "type": "box",
         },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "displayText": "Yes, I forwarded it as a whole",
+                "label": "Yes, I forwarded it",
+                "type": "postback",
+              },
+              "color": "#333333",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "displayText": "No, typed it myself",
+                "label": "No, typed it myself",
+                "type": "postback",
+              },
+              "color": "#333333",
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
-      },
-      "quickReply": Object {
-        "items": Array [
-          Object {
-            "action": Object {
-              "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
-              "displayText": "Yes, I forwarded it as a whole",
-              "label": "Yes, I forwarded it",
-              "type": "postback",
-            },
-            "type": "action",
-          },
-          Object {
-            "action": Object {
-              "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
-              "displayText": "No, typed it myself",
-              "label": "No, typed it myself",
-              "type": "postback",
-            },
-            "type": "action",
-          },
-        ],
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -52,9 +52,9 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "data": "{\\"input\\":\\"__POSTBACK_YES__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
                 "displayText": "Yes, I forwarded it as a whole",
-                "label": "Yes, I forwarded it",
+                "label": "Yes, I forwarded it as a whole",
                 "type": "postback",
               },
               "color": "#333333",
@@ -63,7 +63,7 @@ Object {
             },
             Object {
               "action": Object {
-                "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "data": "{\\"input\\":\\"__POSTBACK_NO__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
                 "displayText": "No, typed it myself",
                 "label": "No, typed it myself",
                 "type": "postback",
@@ -93,6 +93,13 @@ Object {
 
 exports[`should create a UserArticleLink when selecting a article 1`] = `
 Array [
+  Object {
+    "_id": "_id",
+    "articleId": "new-article-id",
+    "createdAt": 2020-01-01T00:00:00.000Z,
+    "lastViewedAt": 2020-01-01T00:00:00.000Z,
+    "userId": "user-id-0",
+  },
   Object {
     "_id": "_id",
     "articleId": "article-id",

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -15,84 +15,62 @@ Object {
   },
   "replies": Array [
     Object {
-      "text": "I see. Don't trust the message just yet!
-May I have your help?",
-      "type": "text",
-    },
-    Object {
-      "altText": "🥇 Be the first to report the message",
+      "altText": "I am sorry you cannot find the information “這一篇文章確實是一個⋯⋯” you are looking for. But I would still like to help.
+ May I ask you a quick question?",
       "contents": Object {
         "body": Object {
           "contents": Array [
             Object {
-              "contents": Array [
-                Object {
-                  "text": "Currently we don't have this message in our database. If you think it is probably a rumor, ",
-                  "type": "span",
-                },
-                Object {
-                  "color": "#ffb600",
-                  "text": "press “🆕 Submit to database” to make this message public on Cofacts database ",
-                  "type": "span",
-                  "weight": "bold",
-                },
-                Object {
-                  "text": "for nice volunteers to fact-check. Although you won't receive answers rightaway, you can help the people who receive the same message in the future.",
-                  "type": "span",
-                },
-              ],
+              "text": "I am sorry you cannot find the information “這一篇文章確實是一個⋯⋯” you are looking for. But I would still like to help.
+ May I ask you a quick question?",
               "type": "text",
               "wrap": true,
             },
           ],
           "layout": "vertical",
-          "paddingAll": "lg",
-          "spacing": "md",
           "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "🆕 Submit to database",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=source&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYzc2ZDhhZTljY2QxYWRhNGYwNmM0ZTE1MTVkNDY0NjYiLCJleHAiOjE1Nzc5MjMyMDB9.ZxHN5etvaneWUumNx9bqdBA_6IPmBIQ5sfz7jneJNvI&article_submission=true",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "header": Object {
-          "contents": Array [
-            Object {
-              "flex": 0,
-              "gravity": "center",
-              "text": "🥇",
-              "type": "text",
-            },
-            Object {
-              "color": "#ffb600",
-              "text": "Be the first to report the message",
-              "type": "text",
-              "weight": "bold",
-              "wrap": true,
-            },
-          ],
-          "layout": "horizontal",
-          "paddingAll": "lg",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "styles": Object {
-          "body": Object {
-            "separator": true,
-          },
         },
         "type": "bubble",
+      },
+      "type": "flex",
+    },
+    Object {
+      "altText": "Did you forward this message as a whole to me from the LINE app?",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Did you forward this message as a whole to me from the LINE app?",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "quickReply": Object {
+        "items": Array [
+          Object {
+            "action": Object {
+              "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+              "displayText": "Yes, I forwarded it as a whole",
+              "label": "Yes, I forwarded it",
+              "type": "postback",
+            },
+            "type": "action",
+          },
+          Object {
+            "action": Object {
+              "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+              "displayText": "No, typed it myself",
+              "label": "No, typed it myself",
+              "type": "postback",
+            },
+            "type": "action",
+          },
+        ],
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -95,13 +95,6 @@ exports[`should create a UserArticleLink when selecting a article 1`] = `
 Array [
   Object {
     "_id": "_id",
-    "articleId": "new-article-id",
-    "createdAt": 2020-01-01T00:00:00.000Z,
-    "lastViewedAt": 2020-01-01T00:00:00.000Z,
-    "userId": "user-id-0",
-  },
-  Object {
-    "_id": "_id",
     "articleId": "article-id",
     "createdAt": 2020-01-01T00:00:00.000Z,
     "lastViewedAt": 2020-01-01T00:00:00.000Z,

--- a/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -415,29 +415,41 @@ Object {
           "layout": "vertical",
           "type": "box",
         },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "displayText": "Yes, I forwarded it as a whole",
+                "label": "Yes, I forwarded it",
+                "type": "postback",
+              },
+              "color": "#333333",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "displayText": "No, typed it myself",
+                "label": "No, typed it myself",
+                "type": "postback",
+              },
+              "color": "#333333",
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
-      },
-      "quickReply": Object {
-        "items": Array [
-          Object {
-            "action": Object {
-              "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
-              "displayText": "Yes, I forwarded it as a whole",
-              "label": "Yes, I forwarded it",
-              "type": "postback",
-            },
-            "type": "action",
-          },
-          Object {
-            "action": Object {
-              "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
-              "displayText": "No, typed it myself",
-              "label": "No, typed it myself",
-              "type": "postback",
-            },
-            "type": "action",
-          },
-        ],
       },
       "type": "flex",
     },
@@ -953,29 +965,41 @@ Object {
           "layout": "vertical",
           "type": "box",
         },
+        "footer": Object {
+          "contents": Array [
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "displayText": "Yes, I forwarded it as a whole",
+                "label": "Yes, I forwarded it",
+                "type": "postback",
+              },
+              "color": "#333333",
+              "style": "primary",
+              "type": "button",
+            },
+            Object {
+              "action": Object {
+                "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "displayText": "No, typed it myself",
+                "label": "No, typed it myself",
+                "type": "postback",
+              },
+              "color": "#333333",
+              "style": "primary",
+              "type": "button",
+            },
+          ],
+          "layout": "vertical",
+          "spacing": "sm",
+          "type": "box",
+        },
+        "styles": Object {
+          "body": Object {
+            "separator": true,
+          },
+        },
         "type": "bubble",
-      },
-      "quickReply": Object {
-        "items": Array [
-          Object {
-            "action": Object {
-              "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
-              "displayText": "Yes, I forwarded it as a whole",
-              "label": "Yes, I forwarded it",
-              "type": "postback",
-            },
-            "type": "action",
-          },
-          Object {
-            "action": Object {
-              "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
-              "displayText": "No, typed it myself",
-              "label": "No, typed it myself",
-              "type": "postback",
-            },
-            "type": "action",
-          },
-        ],
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -419,9 +419,9 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "data": "{\\"input\\":\\"__POSTBACK_YES__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
                 "displayText": "Yes, I forwarded it as a whole",
-                "label": "Yes, I forwarded it",
+                "label": "Yes, I forwarded it as a whole",
                 "type": "postback",
               },
               "color": "#333333",
@@ -430,7 +430,7 @@ Object {
             },
             Object {
               "action": Object {
-                "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "data": "{\\"input\\":\\"__POSTBACK_NO__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
                 "displayText": "No, typed it myself",
                 "label": "No, typed it myself",
                 "type": "postback",
@@ -969,9 +969,9 @@ Object {
           "contents": Array [
             Object {
               "action": Object {
-                "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "data": "{\\"input\\":\\"__POSTBACK_YES__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
                 "displayText": "Yes, I forwarded it as a whole",
-                "label": "Yes, I forwarded it",
+                "label": "Yes, I forwarded it as a whole",
                 "type": "postback",
               },
               "color": "#333333",
@@ -980,7 +980,7 @@ Object {
             },
             Object {
               "action": Object {
-                "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+                "data": "{\\"input\\":\\"__POSTBACK_NO__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
                 "displayText": "No, typed it myself",
                 "label": "No, typed it myself",
                 "type": "postback",

--- a/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -382,85 +382,62 @@ Object {
   "isSkipUser": false,
   "replies": Array [
     Object {
-      "text": "It's good that you don't trust that message just yet. 👍
-
-                  However, I currently don't recognize \\"零一二三四五六七八九十\\". May I have your help?",
-      "type": "text",
-    },
-    Object {
-      "altText": "🥇 Be the first to report the message",
+      "altText": "Unfortunately, I currently don’t recognize “零一二三四五六七八九十”, but I would still like to help.
+ May I ask you a quick question?",
       "contents": Object {
         "body": Object {
           "contents": Array [
             Object {
-              "contents": Array [
-                Object {
-                  "text": "Currently we don't have this message in our database. If you think it is probably a rumor, ",
-                  "type": "span",
-                },
-                Object {
-                  "color": "#ffb600",
-                  "text": "press “🆕 Submit to database” to make this message public on Cofacts database ",
-                  "type": "span",
-                  "weight": "bold",
-                },
-                Object {
-                  "text": "for nice volunteers to fact-check. Although you won't receive answers rightaway, you can help the people who receive the same message in the future.",
-                  "type": "span",
-                },
-              ],
+              "text": "Unfortunately, I currently don’t recognize “零一二三四五六七八九十”, but I would still like to help.
+ May I ask you a quick question?",
               "type": "text",
               "wrap": true,
             },
           ],
           "layout": "vertical",
-          "paddingAll": "lg",
-          "spacing": "md",
           "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "🆕 Submit to database",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=source&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE0OTc5OTQwMTc0NDcsInN1YiI6IlVjNzZkOGFlOWNjZDFhZGE0ZjA2YzRlMTUxNWQ0NjQ2NiIsImV4cCI6MTU3NzkyMzIwMH0.V4OTSDA0wDDrlc665JRyjkC0Ux3RFqUM-RN_VNKNCcs&article_submission=true",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "header": Object {
-          "contents": Array [
-            Object {
-              "flex": 0,
-              "gravity": "center",
-              "text": "🥇",
-              "type": "text",
-            },
-            Object {
-              "color": "#ffb600",
-              "text": "Be the first to report the message",
-              "type": "text",
-              "weight": "bold",
-              "wrap": true,
-            },
-          ],
-          "layout": "horizontal",
-          "paddingAll": "lg",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "styles": Object {
-          "body": Object {
-            "separator": true,
-          },
         },
         "type": "bubble",
+      },
+      "type": "flex",
+    },
+    Object {
+      "altText": "Did you forward this message as a whole to me from the LINE app?",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Did you forward this message as a whole to me from the LINE app?",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "quickReply": Object {
+        "items": Array [
+          Object {
+            "action": Object {
+              "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+              "displayText": "Yes, I forwarded it as a whole",
+              "label": "Yes, I forwarded it",
+              "type": "postback",
+            },
+            "type": "action",
+          },
+          Object {
+            "action": Object {
+              "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+              "displayText": "No, typed it myself",
+              "label": "No, typed it myself",
+              "type": "postback",
+            },
+            "type": "action",
+          },
+        ],
       },
       "type": "flex",
     },
@@ -943,85 +920,62 @@ Object {
   "isSkipUser": false,
   "replies": Array [
     Object {
-      "text": "It's good that you don't trust that message just yet. 👍
-
-                  However, I currently don't recognize \\"YouTube · ⋯⋯\\". May I have your help?",
-      "type": "text",
-    },
-    Object {
-      "altText": "🥇 Be the first to report the message",
+      "altText": "Unfortunately, I currently don’t recognize “YouTube · ⋯⋯”, but I would still like to help.
+ May I ask you a quick question?",
       "contents": Object {
         "body": Object {
           "contents": Array [
             Object {
-              "contents": Array [
-                Object {
-                  "text": "Currently we don't have this message in our database. If you think it is probably a rumor, ",
-                  "type": "span",
-                },
-                Object {
-                  "color": "#ffb600",
-                  "text": "press “🆕 Submit to database” to make this message public on Cofacts database ",
-                  "type": "span",
-                  "weight": "bold",
-                },
-                Object {
-                  "text": "for nice volunteers to fact-check. Although you won't receive answers rightaway, you can help the people who receive the same message in the future.",
-                  "type": "span",
-                },
-              ],
+              "text": "Unfortunately, I currently don’t recognize “YouTube · ⋯⋯”, but I would still like to help.
+ May I ask you a quick question?",
               "type": "text",
               "wrap": true,
             },
           ],
           "layout": "vertical",
-          "paddingAll": "lg",
-          "spacing": "md",
           "type": "box",
-        },
-        "footer": Object {
-          "contents": Array [
-            Object {
-              "action": Object {
-                "label": "🆕 Submit to database",
-                "type": "uri",
-                "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=source&token=eyJhbGciOiJIUzI1NiJ9.eyJzZXNzaW9uSWQiOjE0OTc5OTQwMTc0NDcsInN1YiI6IlVjNzZkOGFlOWNjZDFhZGE0ZjA2YzRlMTUxNWQ0NjQ2NiIsImV4cCI6MTU3NzkyMzIwMH0.V4OTSDA0wDDrlc665JRyjkC0Ux3RFqUM-RN_VNKNCcs&article_submission=true",
-              },
-              "color": "#ffb600",
-              "style": "primary",
-              "type": "button",
-            },
-          ],
-          "layout": "vertical",
-          "type": "box",
-        },
-        "header": Object {
-          "contents": Array [
-            Object {
-              "flex": 0,
-              "gravity": "center",
-              "text": "🥇",
-              "type": "text",
-            },
-            Object {
-              "color": "#ffb600",
-              "text": "Be the first to report the message",
-              "type": "text",
-              "weight": "bold",
-              "wrap": true,
-            },
-          ],
-          "layout": "horizontal",
-          "paddingAll": "lg",
-          "spacing": "sm",
-          "type": "box",
-        },
-        "styles": Object {
-          "body": Object {
-            "separator": true,
-          },
         },
         "type": "bubble",
+      },
+      "type": "flex",
+    },
+    Object {
+      "altText": "Did you forward this message as a whole to me from the LINE app?",
+      "contents": Object {
+        "body": Object {
+          "contents": Array [
+            Object {
+              "text": "Did you forward this message as a whole to me from the LINE app?",
+              "type": "text",
+              "wrap": true,
+            },
+          ],
+          "layout": "vertical",
+          "type": "box",
+        },
+        "type": "bubble",
+      },
+      "quickReply": Object {
+        "items": Array [
+          Object {
+            "action": Object {
+              "data": "{\\"input\\":\\"__POSTBACK_IS_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+              "displayText": "Yes, I forwarded it as a whole",
+              "label": "Yes, I forwarded it",
+              "type": "postback",
+            },
+            "type": "action",
+          },
+          Object {
+            "action": Object {
+              "data": "{\\"input\\":\\"__POSTBACK_IS_NOT_FORWARDED__\\",\\"sessionId\\":1497994017447,\\"state\\":\\"ASKING_ARTICLE_SOURCE\\"}",
+              "displayText": "No, typed it myself",
+              "label": "No, typed it myself",
+              "type": "postback",
+            },
+            "type": "action",
+          },
+        ],
       },
       "type": "flex",
     },

--- a/src/webhook/handlers/__tests__/askingArticleSource.test.js
+++ b/src/webhook/handlers/__tests__/askingArticleSource.test.js
@@ -1,5 +1,12 @@
+jest.mock('src/lib/ga');
+import ga from 'src/lib/ga';
+
 import askingArticleSource from '../askingArticleSource';
 import { POSTBACK_YES, POSTBACK_NO } from '../utils';
+
+beforeEach(() => {
+  ga.clearAllMocks();
+});
 
 it('throws on incorrect input', async () => {
   const incorrectParam = {
@@ -181,6 +188,19 @@ it('returns instructions if user did not forward the whole message', async () =>
       },
     ]
   `);
+
+  expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "ea": "IsForwarded",
+          "ec": "UserInput",
+          "el": "No",
+        },
+      ],
+    ]
+  `);
+  expect(ga.sendMock).toHaveBeenCalledTimes(1);
 });
 
 it('sends user submission consent if user forwarded the whole message', async () => {
@@ -302,4 +322,17 @@ it('sends user submission consent if user forwarded the whole message', async ()
       },
     ]
   `);
+
+  expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "ea": "IsForwarded",
+          "ec": "UserInput",
+          "el": "Yes",
+        },
+      ],
+    ]
+  `);
+  expect(ga.sendMock).toHaveBeenCalledTimes(1);
 });

--- a/src/webhook/handlers/__tests__/askingArticleSource.test.js
+++ b/src/webhook/handlers/__tests__/askingArticleSource.test.js
@@ -1,17 +1,315 @@
-import askingArticleSource from '../askingArticleSource';
+import askingArticleSource from "../askingArticleSource";
+import { POSTBACK_YES, POSTBACK_NO } from "../utils";
 
-it('throws on incorrect input', async () => {
+it("throws on incorrect input", async () => {
   const incorrectParam = {
-    data: {
-      searchedText: 'foo',
-    },
-    state: 'ASKING_ARTICLE_SOURCE',
+    data: { searchedText: "foo" },
+    state: "ASKING_ARTICLE_SOURCE",
     event: {
-      input: 'Wrong',
-    },
+      input: "Wrong"
+    }
   };
 
   expect(askingArticleSource(incorrectParam)).rejects.toMatchInlineSnapshot(
     `[Error: Please choose from provided options.]`
   );
+});
+
+it("returns instructions if user did not forward the whole message", async () => {
+  const didNotForwardParam = {
+    data: { searchedText: "foo", sessionId: "the-session-id" },
+    state: "ASKING_ARTICLE_SOURCE",
+    event: {
+      input: POSTBACK_NO
+    }
+  };
+
+  const { replies } = await askingArticleSource(didNotForwardParam);
+  expect(replies).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "altText": "Instructions",
+        "contents": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "contents": Array [
+                  Object {
+                    "text": "I am a bot which only recognizes messages forwarded on LINE, therefore it is important to send me the",
+                    "type": "span",
+                  },
+                  Object {
+                    "color": "#ffb600",
+                    "text": " entire message ",
+                    "type": "span",
+                    "weight": "bold",
+                  },
+                  Object {
+                    "text": "that is being passed around so I can identify it.",
+                    "type": "span",
+                  },
+                ],
+                "text": "Instructions",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+        "type": "flex",
+      },
+      Object {
+        "altText": "You can try:",
+        "contents": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "You can try:",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+        "type": "flex",
+      },
+      Object {
+        "altText": "Provide more detail",
+        "contents": Object {
+          "contents": Array [
+            Object {
+              "body": Object {
+                "contents": Array [
+                  Object {
+                    "text": "If you have access to the whole message on LINE, please use the “Share” function to share it with me.",
+                    "type": "text",
+                    "wrap": true,
+                  },
+                ],
+                "layout": "vertical",
+                "type": "box",
+              },
+              "footer": Object {
+                "contents": Array [
+                  Object {
+                    "action": Object {
+                      "data": "{\\"input\\":\\"📖 tutorial\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"TUTORIAL\\"}",
+                      "displayText": "📖 tutorial",
+                      "label": "See Tutorial",
+                      "type": "postback",
+                    },
+                    "color": "#00B172",
+                    "style": "primary",
+                    "type": "button",
+                  },
+                ],
+                "layout": "vertical",
+                "spacing": "sm",
+                "type": "box",
+              },
+              "header": Object {
+                "contents": Array [
+                  Object {
+                    "color": "#00B172",
+                    "size": "lg",
+                    "text": "Try again with the whole message",
+                    "type": "text",
+                    "wrap": true,
+                  },
+                ],
+                "layout": "vertical",
+                "paddingBottom": "none",
+                "type": "box",
+              },
+              "type": "bubble",
+            },
+            Object {
+              "body": Object {
+                "contents": Array [
+                  Object {
+                    "text": "You can forward your question to another LINE account which provides a human response",
+                    "type": "text",
+                    "wrap": true,
+                  },
+                ],
+                "layout": "vertical",
+                "type": "box",
+              },
+              "footer": Object {
+                "contents": Array [
+                  Object {
+                    "action": Object {
+                      "label": "MyGoPen 真人查證",
+                      "type": "uri",
+                      "uri": "https://line.me/R/ti/p/%40imygopen",
+                    },
+                    "color": "#333333",
+                    "style": "primary",
+                    "type": "button",
+                  },
+                ],
+                "layout": "vertical",
+                "spacing": "sm",
+                "type": "box",
+              },
+              "header": Object {
+                "contents": Array [
+                  Object {
+                    "color": "#333333",
+                    "size": "lg",
+                    "text": "Find a real person",
+                    "type": "text",
+                    "wrap": true,
+                  },
+                ],
+                "layout": "vertical",
+                "paddingBottom": "none",
+                "type": "box",
+              },
+              "type": "bubble",
+            },
+          ],
+          "type": "carousel",
+        },
+        "type": "flex",
+      },
+    ]
+  `);
+});
+
+it("sends user submission consent if user forwarded the whole message", async () => {
+  const didForwardParam = {
+    data: { searchedText: "foo", sessionId: "the-session-id" },
+    state: "ASKING_ARTICLE_SOURCE",
+    event: {
+      input: POSTBACK_YES
+    }
+  };
+
+  const replies = await askingArticleSource(didForwardParam);
+  expect(replies).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "searchedText": "foo",
+        "sessionId": "the-session-id",
+      },
+      "event": Object {
+        "input": "__POSTBACK_YES__",
+      },
+      "replies": Array [
+        Object {
+          "altText": "I see. Don’t trust the message just yet!",
+          "contents": Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "I see. Don’t trust the message just yet!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
+            },
+            "type": "bubble",
+          },
+          "type": "flex",
+        },
+        Object {
+          "altText": "Do you want someone to fact-check this message?",
+          "contents": Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Do you want someone to fact-check this message?",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "type": "box",
+            },
+            "type": "bubble",
+          },
+          "type": "flex",
+        },
+        Object {
+          "altText": "Be the first to report the message",
+          "contents": Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "contents": Array [
+                    Object {
+                      "text": "Currently we don’t have this message in our database. If you think it is most likely a rumor, ",
+                      "type": "span",
+                    },
+                    Object {
+                      "color": "#ffb600",
+                      "text": "press “🆕 Report to database” to make this message public on Cofacts database ",
+                      "type": "span",
+                      "weight": "bold",
+                    },
+                    Object {
+                      "text": "and have volunteers fact-check it. This way you can help the people who receive the same message in the future.",
+                      "type": "span",
+                    },
+                  ],
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "paddingAll": "lg",
+              "spacing": "md",
+              "type": "box",
+            },
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "data": "{\\"input\\":\\"__POSTBACK_YES__\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"ASKING_ARTICLE_SUBMISSION_CONSENT\\"}",
+                    "displayText": "🆕 Report to database",
+                    "label": "🆕 Report to database",
+                    "type": "postback",
+                  },
+                  "color": "#ffb600",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "data": "{\\"input\\":\\"__POSTBACK_NO__\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"ASKING_ARTICLE_SUBMISSION_CONSENT\\"}",
+                    "displayText": "Don’t report",
+                    "label": "Don’t report",
+                    "type": "postback",
+                  },
+                  "color": "#333333",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
+            },
+            "styles": Object {
+              "body": Object {
+                "separator": true,
+              },
+            },
+            "type": "bubble",
+          },
+          "type": "flex",
+        },
+      ],
+      "userId": undefined,
+    }
+  `);
 });

--- a/src/webhook/handlers/__tests__/askingArticleSource.test.js
+++ b/src/webhook/handlers/__tests__/askingArticleSource.test.js
@@ -1,13 +1,13 @@
-import askingArticleSource from "../askingArticleSource";
-import { POSTBACK_YES, POSTBACK_NO } from "../utils";
+import askingArticleSource from '../askingArticleSource';
+import { POSTBACK_YES, POSTBACK_NO } from '../utils';
 
-it("throws on incorrect input", async () => {
+it('throws on incorrect input', async () => {
   const incorrectParam = {
-    data: { searchedText: "foo" },
-    state: "ASKING_ARTICLE_SOURCE",
+    data: { searchedText: 'foo' },
+    state: 'ASKING_ARTICLE_SOURCE',
     event: {
-      input: "Wrong"
-    }
+      input: 'Wrong',
+    },
   };
 
   expect(askingArticleSource(incorrectParam)).rejects.toMatchInlineSnapshot(
@@ -15,13 +15,13 @@ it("throws on incorrect input", async () => {
   );
 });
 
-it("returns instructions if user did not forward the whole message", async () => {
+it('returns instructions if user did not forward the whole message', async () => {
   const didNotForwardParam = {
-    data: { searchedText: "foo", sessionId: "the-session-id" },
-    state: "ASKING_ARTICLE_SOURCE",
+    data: { searchedText: 'foo', sessionId: 'the-session-id' },
+    state: 'ASKING_ARTICLE_SOURCE',
     event: {
-      input: POSTBACK_NO
-    }
+      input: POSTBACK_NO,
+    },
   };
 
   const { replies } = await askingArticleSource(didNotForwardParam);
@@ -183,133 +183,123 @@ it("returns instructions if user did not forward the whole message", async () =>
   `);
 });
 
-it("sends user submission consent if user forwarded the whole message", async () => {
+it('sends user submission consent if user forwarded the whole message', async () => {
   const didForwardParam = {
-    data: { searchedText: "foo", sessionId: "the-session-id" },
-    state: "ASKING_ARTICLE_SOURCE",
+    data: { searchedText: 'foo', sessionId: 'the-session-id' },
+    state: 'ASKING_ARTICLE_SOURCE',
     event: {
-      input: POSTBACK_YES
-    }
+      input: POSTBACK_YES,
+    },
   };
 
-  const replies = await askingArticleSource(didForwardParam);
+  const { replies } = await askingArticleSource(didForwardParam);
   expect(replies).toMatchInlineSnapshot(`
-    Object {
-      "data": Object {
-        "searchedText": "foo",
-        "sessionId": "the-session-id",
-      },
-      "event": Object {
-        "input": "__POSTBACK_YES__",
-      },
-      "replies": Array [
-        Object {
-          "altText": "I see. Don’t trust the message just yet!",
-          "contents": Object {
-            "body": Object {
-              "contents": Array [
-                Object {
-                  "text": "I see. Don’t trust the message just yet!",
-                  "type": "text",
-                  "wrap": true,
-                },
-              ],
-              "layout": "vertical",
-              "type": "box",
-            },
-            "type": "bubble",
-          },
-          "type": "flex",
-        },
-        Object {
-          "altText": "Do you want someone to fact-check this message?",
-          "contents": Object {
-            "body": Object {
-              "contents": Array [
-                Object {
-                  "text": "Do you want someone to fact-check this message?",
-                  "type": "text",
-                  "wrap": true,
-                },
-              ],
-              "layout": "vertical",
-              "type": "box",
-            },
-            "type": "bubble",
-          },
-          "type": "flex",
-        },
-        Object {
-          "altText": "Be the first to report the message",
-          "contents": Object {
-            "body": Object {
-              "contents": Array [
-                Object {
-                  "contents": Array [
-                    Object {
-                      "text": "Currently we don’t have this message in our database. If you think it is most likely a rumor, ",
-                      "type": "span",
-                    },
-                    Object {
-                      "color": "#ffb600",
-                      "text": "press “🆕 Report to database” to make this message public on Cofacts database ",
-                      "type": "span",
-                      "weight": "bold",
-                    },
-                    Object {
-                      "text": "and have volunteers fact-check it. This way you can help the people who receive the same message in the future.",
-                      "type": "span",
-                    },
-                  ],
-                  "type": "text",
-                  "wrap": true,
-                },
-              ],
-              "layout": "vertical",
-              "paddingAll": "lg",
-              "spacing": "md",
-              "type": "box",
-            },
-            "footer": Object {
-              "contents": Array [
-                Object {
-                  "action": Object {
-                    "data": "{\\"input\\":\\"__POSTBACK_YES__\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"ASKING_ARTICLE_SUBMISSION_CONSENT\\"}",
-                    "displayText": "🆕 Report to database",
-                    "label": "🆕 Report to database",
-                    "type": "postback",
-                  },
-                  "color": "#ffb600",
-                  "style": "primary",
-                  "type": "button",
-                },
-                Object {
-                  "action": Object {
-                    "data": "{\\"input\\":\\"__POSTBACK_NO__\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"ASKING_ARTICLE_SUBMISSION_CONSENT\\"}",
-                    "displayText": "Don’t report",
-                    "label": "Don’t report",
-                    "type": "postback",
-                  },
-                  "color": "#333333",
-                  "style": "primary",
-                  "type": "button",
-                },
-              ],
-              "layout": "vertical",
-              "spacing": "sm",
-              "type": "box",
-            },
-            "styles": Object {
-              "body": Object {
-                "separator": true,
+    Array [
+      Object {
+        "altText": "I see. Don’t trust the message just yet!",
+        "contents": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "I see. Don’t trust the message just yet!",
+                "type": "text",
+                "wrap": true,
               },
-            },
-            "type": "bubble",
+            ],
+            "layout": "vertical",
+            "type": "box",
           },
-          "type": "flex",
+          "type": "bubble",
         },
-      ],
-      "userId": undefined,
-    }
+        "type": "flex",
+      },
+      Object {
+        "altText": "Do you want someone to fact-check this message?",
+        "contents": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "Do you want someone to fact-check this message?",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+        "type": "flex",
+      },
+      Object {
+        "altText": "Be the first to report the message",
+        "contents": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "contents": Array [
+                  Object {
+                    "text": "Currently we don’t have this message in our database. If you think it is most likely a rumor, ",
+                    "type": "span",
+                  },
+                  Object {
+                    "color": "#ffb600",
+                    "text": "press “🆕 Report to database” to make this message public on Cofacts database ",
+                    "type": "span",
+                    "weight": "bold",
+                  },
+                  Object {
+                    "text": "and have volunteers fact-check it. This way you can help the people who receive the same message in the future.",
+                    "type": "span",
+                  },
+                ],
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "paddingAll": "lg",
+            "spacing": "md",
+            "type": "box",
+          },
+          "footer": Object {
+            "contents": Array [
+              Object {
+                "action": Object {
+                  "data": "{\\"input\\":\\"__POSTBACK_YES__\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"ASKING_ARTICLE_SUBMISSION_CONSENT\\"}",
+                  "displayText": "🆕 Report to database",
+                  "label": "🆕 Report to database",
+                  "type": "postback",
+                },
+                "color": "#ffb600",
+                "style": "primary",
+                "type": "button",
+              },
+              Object {
+                "action": Object {
+                  "data": "{\\"input\\":\\"__POSTBACK_NO__\\",\\"sessionId\\":\\"the-session-id\\",\\"state\\":\\"ASKING_ARTICLE_SUBMISSION_CONSENT\\"}",
+                  "displayText": "Don’t report",
+                  "label": "Don’t report",
+                  "type": "postback",
+                },
+                "color": "#333333",
+                "style": "primary",
+                "type": "button",
+              },
+            ],
+            "layout": "vertical",
+            "spacing": "sm",
+            "type": "box",
+          },
+          "styles": Object {
+            "body": Object {
+              "separator": true,
+            },
+          },
+          "type": "bubble",
+        },
+        "type": "flex",
+      },
+    ]
   `);
 });

--- a/src/webhook/handlers/__tests__/askingArticleSource.test.js
+++ b/src/webhook/handlers/__tests__/askingArticleSource.test.js
@@ -1,0 +1,17 @@
+import askingArticleSource from '../askingArticleSource';
+
+it('throws on incorrect input', async () => {
+  const incorrectParam = {
+    data: {
+      searchedText: 'foo',
+    },
+    state: 'ASKING_ARTICLE_SOURCE',
+    event: {
+      input: 'Wrong',
+    },
+  };
+
+  expect(askingArticleSource(incorrectParam)).rejects.toMatchInlineSnapshot(
+    `[Error: Please choose from provided options.]`
+  );
+});

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.js
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.js
@@ -57,7 +57,28 @@ it('should thank the user if user does not agree to submit', async () => {
   };
 
   const { replies } = await askingArticleSubmissionConsent(params);
-  expect(replies).toMatchInlineSnapshot();
+  expect(replies).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "altText": "The message has not been reported and won’t be fact-checked. Thanks anyway!",
+        "contents": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "The message has not been reported and won’t be fact-checked. Thanks anyway!",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+        "type": "flex",
+      },
+    ]
+  `);
 });
 
 it('should submit article if user agrees to submit', async () => {

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.js
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.js
@@ -163,7 +163,7 @@ it('should ask user to turn on notification settings if they did not turn it on 
   const results = await askingArticleSubmissionConsent(params);
   MockDate.reset();
 
-  expect(results.replies[0].contents.contents).toMatchSnapshot();
+  expect(results.replies[2].contents.contents).toMatchSnapshot();
 
   delete process.env.NOTIFY_METHOD;
   await UserSettings.setAllowNewReplyUpdate(userId, true);

--- a/src/webhook/handlers/askingArticleSource.js
+++ b/src/webhook/handlers/askingArticleSource.js
@@ -24,6 +24,7 @@ export default async function askingArticleSource(params) {
     case POSTBACK_IS_NOT_FORWARDED:
       replies = [
         createTextMessage({
+          text: t`Instructions`,
           contents: [
             {
               type: 'span',
@@ -31,7 +32,7 @@ export default async function askingArticleSource(params) {
             },
             {
               type: 'span',
-              text: /* t: emphasized text in sentence "It is important to send me the ~ that is being passed around" */ t`entire message`,
+              text: /* t: emphasized text in sentence "It is important to send me the ~ that is being passed around" */ t` entire message `,
               color: '#ffb600',
               weight: 'bold',
             },
@@ -83,7 +84,7 @@ export default async function askingArticleSource(params) {
                       type: 'button',
                       action: createPostbackAction(
                         t`See Tutorial`,
-                        '',
+                        TUTORIAL_STEPS.RICH_MENU,
                         TUTORIAL_STEPS.RICH_MENU,
                         data.sessionId,
                         'TUTORIAL'
@@ -106,7 +107,7 @@ export default async function askingArticleSource(params) {
                       text: t`Find a real person`,
                       wrap: true,
                       size: 'lg',
-                      color: '#00B172',
+                      color: '#333333',
                     },
                   ],
                   paddingBottom: 'none',
@@ -117,7 +118,7 @@ export default async function askingArticleSource(params) {
                   contents: [
                     {
                       type: 'text',
-                      text: t` You can forward your question to another LINE account which provides a human response`,
+                      text: t`You can forward your question to another LINE account which provides a human response`,
                       wrap: true,
                     },
                   ],

--- a/src/webhook/handlers/askingArticleSource.js
+++ b/src/webhook/handlers/askingArticleSource.js
@@ -2,12 +2,13 @@ import { t } from 'ttag';
 import ga from 'src/lib/ga';
 
 import {
-  POSTBACK_IS_FORWARDED,
-  POSTBACK_IS_NOT_FORWARDED,
+  POSTBACK_YES,
+  POSTBACK_NO,
   ManipulationError,
   createTextMessage,
   MANUAL_FACT_CHECKERS,
   createPostbackAction,
+  createAskArticleSubmissionConsentReply,
 } from './utils';
 
 import { TUTORIAL_STEPS } from './tutorial';
@@ -21,7 +22,7 @@ export default async function askingArticleSource(params) {
     default:
       throw new ManipulationError(t`Please choose from provided options.`);
 
-    case POSTBACK_IS_NOT_FORWARDED:
+    case POSTBACK_NO:
       replies = [
         createTextMessage({
           text: t`Instructions`,
@@ -146,7 +147,17 @@ export default async function askingArticleSource(params) {
       state = '__INIT__';
       break;
 
-    case POSTBACK_IS_FORWARDED:
+    case POSTBACK_YES:
+      replies = [
+        createTextMessage({
+          text: t`I see. Don’t trust the message just yet!`,
+        }),
+        createTextMessage({
+          text: t`Do you want someone to fact-check this message?`,
+        }),
+        createAskArticleSubmissionConsentReply(data.sessionId),
+      ];
+      state = 'ASKING_ARTICLE_SUBMISSION_CONSENT';
   }
 
   visitor.send();

--- a/src/webhook/handlers/askingArticleSource.js
+++ b/src/webhook/handlers/askingArticleSource.js
@@ -1,14 +1,19 @@
-import { t, msgid, ngettext } from 'ttag';
+import { t } from 'ttag';
 import ga from 'src/lib/ga';
 
 import {
   POSTBACK_IS_FORWARDED,
   POSTBACK_IS_NOT_FORWARDED,
   ManipulationError,
+  createTextMessage,
+  MANUAL_FACT_CHECKERS,
+  createPostbackAction,
 } from './utils';
 
+import { TUTORIAL_STEPS } from './tutorial';
+
 export default async function askingArticleSource(params) {
-  let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
+  let { data, state, event, userId, replies } = params;
 
   const visitor = ga(userId, state, data.searchedText);
 
@@ -16,11 +21,133 @@ export default async function askingArticleSource(params) {
     default:
       throw new ManipulationError(t`Please choose from provided options.`);
 
-    case POSTBACK_IS_FORWARDED:
     case POSTBACK_IS_NOT_FORWARDED:
+      replies = [
+        createTextMessage({
+          contents: [
+            {
+              type: 'span',
+              text: /* t: ~ entire message that ... */ t`I am a bot which only recognizes messages forwarded on LINE, therefore it is important to send me the`,
+            },
+            {
+              type: 'span',
+              text: /* t: emphasized text in sentence "It is important to send me the ~ that is being passed around" */ t`entire message`,
+              color: '#ffb600',
+              weight: 'bold',
+            },
+            {
+              type: 'span',
+              text: /* t: the entire message ~ */ t`that is being passed around so I can identify it.`,
+            },
+          ],
+        }),
+        createTextMessage({ text: t`You can try:` }),
+        {
+          type: 'flex',
+          altText: t`Provide more detail`,
+          contents: {
+            type: 'carousel',
+            contents: [
+              {
+                type: 'bubble',
+                header: {
+                  type: 'box',
+                  layout: 'vertical',
+                  contents: [
+                    {
+                      type: 'text',
+                      text: t`Try again with the whole message`,
+                      wrap: true,
+                      size: 'lg',
+                      color: '#00B172',
+                    },
+                  ],
+                  paddingBottom: 'none',
+                },
+                body: {
+                  type: 'box',
+                  layout: 'vertical',
+                  contents: [
+                    {
+                      type: 'text',
+                      text: t`If you have access to the whole message on LINE, please use the “Share” function to share it with me.`,
+                      wrap: true,
+                    },
+                  ],
+                },
+                footer: {
+                  type: 'box',
+                  layout: 'vertical',
+                  contents: [
+                    {
+                      type: 'button',
+                      action: createPostbackAction(
+                        t`See Tutorial`,
+                        '',
+                        TUTORIAL_STEPS.RICH_MENU,
+                        data.sessionId,
+                        'TUTORIAL'
+                      ),
+                      style: 'primary',
+                      color: '#00B172',
+                    },
+                  ],
+                  spacing: 'sm',
+                },
+              },
+              {
+                type: 'bubble',
+                header: {
+                  type: 'box',
+                  layout: 'vertical',
+                  contents: [
+                    {
+                      type: 'text',
+                      text: t`Find a real person`,
+                      wrap: true,
+                      size: 'lg',
+                      color: '#00B172',
+                    },
+                  ],
+                  paddingBottom: 'none',
+                },
+                body: {
+                  type: 'box',
+                  layout: 'vertical',
+                  contents: [
+                    {
+                      type: 'text',
+                      text: t` You can forward your question to another LINE account which provides a human response`,
+                      wrap: true,
+                    },
+                  ],
+                },
+                footer: {
+                  type: 'box',
+                  layout: 'vertical',
+                  contents: MANUAL_FACT_CHECKERS.map(({ label, value }) => ({
+                    type: 'button',
+                    action: {
+                      type: 'uri',
+                      label,
+                      uri: value,
+                    },
+                    style: 'primary',
+                    color: '#333333',
+                  })),
+                  spacing: 'sm',
+                },
+              },
+            ],
+          },
+        },
+      ];
+      break;
+
+    case POSTBACK_IS_FORWARDED:
   }
 
   visitor.send();
 
-  return { data, event, userId, replies, isSkipUser };
+  return { data, event, userId, replies };
 }

--- a/src/webhook/handlers/askingArticleSource.js
+++ b/src/webhook/handlers/askingArticleSource.js
@@ -145,6 +145,11 @@ export default async function askingArticleSource(params) {
         },
       ];
       state = '__INIT__';
+      visitor.event({
+        ec: 'UserInput',
+        ea: 'IsForwarded',
+        el: 'No',
+      });
       break;
 
     case POSTBACK_YES:
@@ -158,6 +163,11 @@ export default async function askingArticleSource(params) {
         createAskArticleSubmissionConsentReply(data.sessionId),
       ];
       state = 'ASKING_ARTICLE_SUBMISSION_CONSENT';
+      visitor.event({
+        ec: 'UserInput',
+        ea: 'IsForwarded',
+        el: 'Yes',
+      });
   }
 
   visitor.send();

--- a/src/webhook/handlers/askingArticleSource.js
+++ b/src/webhook/handlers/askingArticleSource.js
@@ -143,6 +143,7 @@ export default async function askingArticleSource(params) {
           },
         },
       ];
+      state = '__INIT__';
       break;
 
     case POSTBACK_IS_FORWARDED:

--- a/src/webhook/handlers/askingArticleSource.js
+++ b/src/webhook/handlers/askingArticleSource.js
@@ -1,0 +1,26 @@
+import { t, msgid, ngettext } from 'ttag';
+import ga from 'src/lib/ga';
+
+import {
+  POSTBACK_IS_FORWARDED,
+  POSTBACK_IS_NOT_FORWARDED,
+  ManipulationError,
+} from './utils';
+
+export default async function askingArticleSource(params) {
+  let { data, state, event, issuedAt, userId, replies, isSkipUser } = params;
+
+  const visitor = ga(userId, state, data.searchedText);
+
+  switch (event.input) {
+    default:
+      throw new ManipulationError(t`Please choose from provided options.`);
+
+    case POSTBACK_IS_FORWARDED:
+    case POSTBACK_IS_NOT_FORWARDED:
+  }
+
+  visitor.send();
+
+  return { data, event, userId, replies, isSkipUser };
+}

--- a/src/webhook/handlers/askingArticleSubmissionConsent.js
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.js
@@ -1,15 +1,14 @@
 import { t } from 'ttag';
 import ga from 'src/lib/ga';
 import gql from 'src/lib/gql';
+import { getArticleURL } from 'src/lib/sharedUtils';
 import {
-  SOURCE_PREFIX_FRIST_SUBMISSION,
-  getArticleURL,
-} from 'src/lib/sharedUtils';
-import {
+  POSTBACK_YES,
+  POSTBACK_NO,
+  ManipulationError,
+  createTextMessage,
+  createCommentBubble,
   createArticleShareBubble,
-  createSuggestOtherFactCheckerReply,
-  getArticleSourceOptionFromLabel,
-  createReasonButtonFooter,
   createNotificationSettingsBubble,
 } from './utils';
 import UserSettings from 'src/database/models/userSettings';
@@ -20,97 +19,67 @@ export default async function askingArticleSubmissionConsent(params) {
 
   const visitor = ga(userId, state, data.searchedText);
 
-  const sourceOption = getArticleSourceOptionFromLabel(
-    event.input.slice(SOURCE_PREFIX_FRIST_SUBMISSION.length)
-  );
+  switch (event.input) {
+    default:
+      throw new ManipulationError(t`Please choose from provided options.`);
 
-  visitor.event({
-    ec: 'UserInput',
-    ea: 'ProvidingSource',
-    el: sourceOption.value,
-  });
+    case POSTBACK_NO:
+      visitor.event({ ec: 'Article', ea: 'Create', el: 'No' });
+      replies = [
+        createTextMessage({
+          text: t`The message has not been reported and won’t be fact-checked. Thanks anyway!`,
+        }),
+      ];
+      state = '__INIT__';
+      break;
 
-  if (!sourceOption.valid) {
-    replies = [
-      {
-        type: 'text',
-        text: t`Thanks for the info.`,
-      },
-      createSuggestOtherFactCheckerReply(),
-    ];
-  } else {
-    visitor.event({ ec: 'Article', ea: 'Create', el: 'Yes' });
+    case POSTBACK_YES: {
+      visitor.event({ ec: 'Article', ea: 'Create', el: 'Yes' });
 
-    const {
-      data: { CreateArticle },
-    } = await gql`
-      mutation($text: String!) {
-        CreateArticle(text: $text, reference: { type: LINE }) {
-          id
+      const {
+        data: { CreateArticle },
+      } = await gql`
+        mutation($text: String!) {
+          CreateArticle(text: $text, reference: { type: LINE }) {
+            id
+          }
         }
-      }
-    `({ text: data.searchedText }, { userId });
+      `({ text: data.searchedText }, { userId });
 
-    await UserArticleLink.createOrUpdateByUserIdAndArticleId(
-      userId,
-      CreateArticle.id
-    );
+      await UserArticleLink.createOrUpdateByUserIdAndArticleId(
+        userId,
+        CreateArticle.id
+      );
 
-    // Create new session, make article submission button expire after submitting
-    data.sessionId = Date.now();
+      // Create new session, make article submission button expire after submission
+      data.sessionId = Date.now();
 
-    const articleUrl = getArticleURL(CreateArticle.id);
-    const articleCreatedMsg = t`Your submission is now recorded at ${articleUrl}`;
-    const { allowNewReplyUpdate } = await UserSettings.findOrInsertByUserId(
-      userId
-    );
+      const articleUrl = getArticleURL(CreateArticle.id);
+      const articleCreatedMsg = t`Your submission is now recorded at ${articleUrl}`;
+      const { allowNewReplyUpdate } = await UserSettings.findOrInsertByUserId(
+        userId
+      );
 
-    // Track the source of the new message.
-    visitor.event({
-      ec: 'Article',
-      ea: 'ProvidingSource',
-      el: `${CreateArticle.id}/${sourceOption.value}`,
-    });
-
-    replies = [
-      {
-        type: 'flex',
-        altText: articleCreatedMsg,
-        contents: {
-          type: 'carousel',
-          contents: [
-            {
-              type: 'bubble',
-              body: {
-                type: 'box',
-                layout: 'vertical',
-                contents: [
-                  {
-                    type: 'text',
-                    wrap: true,
-                    text: articleCreatedMsg,
-                  },
-                ],
-              },
-              footer: createReasonButtonFooter(
-                articleUrl,
-                userId,
-                data.sessionId
-              ),
-            },
-            // Ask user to turn on notification if the user did not turn it on
-            //
-            process.env.NOTIFY_METHOD &&
-              !allowNewReplyUpdate &&
-              createNotificationSettingsBubble(),
-            createArticleShareBubble(articleUrl),
-          ].filter(m => m),
+      replies = [
+        {
+          type: 'flex',
+          altText: articleCreatedMsg,
+          contents: {
+            type: 'carousel',
+            contents: [
+              createCommentBubble(CreateArticle.id),
+              // Ask user to turn on notification if the user did not turn it on
+              //
+              process.env.NOTIFY_METHOD &&
+                !allowNewReplyUpdate &&
+                createNotificationSettingsBubble(),
+              createArticleShareBubble(articleUrl),
+            ].filter(m => m),
+          },
         },
-      },
-    ];
-
-    // Record article ID in context for reason LIFF
-    data.selectedArticleId = CreateArticle.id;
+      ];
+      state = '__INIT__';
+    }
   }
 
   visitor.send();

--- a/src/webhook/handlers/askingArticleSubmissionConsent.js
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.js
@@ -63,6 +63,36 @@ export default async function askingArticleSubmissionConsent(params) {
       replies = [
         {
           type: 'flex',
+          altText: t`The message has now been recorded at Cofacts for volunteers to fact-check. Thank you for submitting!`,
+          contents: {
+            type: 'bubble',
+            body: {
+              type: 'box',
+              layout: 'vertical',
+              contents: [
+                {
+                  type: 'text',
+                  wrap: true,
+                  text: t`The message has now been recorded at Cofacts for volunteers to fact-check. Thank you for submitting!`,
+                },
+                {
+                  type: 'button',
+                  action: {
+                    type: 'uri',
+                    label: t`View reported message`,
+                    uri: articleUrl,
+                  },
+                  margin: 'md',
+                },
+              ],
+            },
+          },
+        },
+        createTextMessage({
+          text: t`In the meantime, you can:`,
+        }),
+        {
+          type: 'flex',
           altText: articleCreatedMsg,
           contents: {
             type: 'carousel',

--- a/src/webhook/handlers/choosingArticle.js
+++ b/src/webhook/handlers/choosingArticle.js
@@ -6,7 +6,7 @@ import {
   createFeedbackWords,
   ellipsis,
   ManipulationError,
-  createAskArticleSubmissionConsentReply,
+  createArticleSourceQuickReplyMessage,
   POSTBACK_NO_ARTICLE_FOUND,
   createTextMessage,
   createCommentBubble,
@@ -56,17 +56,19 @@ export default async function choosingArticle(params) {
     });
     visitor.send();
 
+    const inputSummary = ellipsis(data.searchedText, 12);
     return {
       data,
       event,
       userId,
       replies: [
-        {
-          type: 'text',
-          text: t`I see. Don't trust the message just yet!
-            May I have your help?`,
-        },
-        createAskArticleSubmissionConsentReply(userId, data.sessionId),
+        createTextMessage({
+          text:
+            t`I am sorry you cannot find the information “${inputSummary}” you are looking for. But I would still like to help.` +
+            '\n' +
+            t` May I ask you a quick question?`,
+        }),
+        createArticleSourceQuickReplyMessage(data.sessionId),
       ],
     };
   }

--- a/src/webhook/handlers/choosingArticle.js
+++ b/src/webhook/handlers/choosingArticle.js
@@ -6,7 +6,7 @@ import {
   createFeedbackWords,
   ellipsis,
   ManipulationError,
-  createArticleSourceQuickReplyMessage,
+  createArticleSourceReply,
   POSTBACK_NO_ARTICLE_FOUND,
   createTextMessage,
   createCommentBubble,
@@ -68,7 +68,7 @@ export default async function choosingArticle(params) {
             '\n' +
             t` May I ask you a quick question?`,
         }),
-        createArticleSourceQuickReplyMessage(data.sessionId),
+        createArticleSourceReply(data.sessionId),
       ],
     };
   }

--- a/src/webhook/handlers/initState.js
+++ b/src/webhook/handlers/initState.js
@@ -4,10 +4,11 @@ import gql from 'src/lib/gql';
 import {
   createPostbackAction,
   ellipsis,
-  createAskArticleSubmissionConsentReply,
   createSuggestOtherFactCheckerReply,
   POSTBACK_NO_ARTICLE_FOUND,
   createHighlightContents,
+  createTextMessage,
+  createArticleSourceQuickReplyMessage,
 } from './utils';
 import ga from 'src/lib/ga';
 import detectDialogflowIntent from 'src/lib/detectDialogflowIntent';
@@ -318,13 +319,13 @@ export default async function initState(params) {
       ];
     } else {
       replies = [
-        {
-          type: 'text',
-          text: t`It's good that you don't trust that message just yet. 👍
-
-                  However, I currently don't recognize "${inputSummary}". May I have your help?`,
-        },
-        createAskArticleSubmissionConsentReply(userId, data.sessionId),
+        createTextMessage({
+          text:
+            t`Unfortunately, I currently don’t recognize “${inputSummary}”, but I would still like to help.` +
+            '\n' +
+            t` May I ask you a quick question?`,
+        }),
+        createArticleSourceQuickReplyMessage(data.sessionId),
       ];
     }
   }

--- a/src/webhook/handlers/initState.js
+++ b/src/webhook/handlers/initState.js
@@ -8,7 +8,7 @@ import {
   POSTBACK_NO_ARTICLE_FOUND,
   createHighlightContents,
   createTextMessage,
-  createArticleSourceQuickReplyMessage,
+  createArticleSourceReply,
 } from './utils';
 import ga from 'src/lib/ga';
 import detectDialogflowIntent from 'src/lib/detectDialogflowIntent';
@@ -325,7 +325,7 @@ export default async function initState(params) {
             '\n' +
             t` May I ask you a quick question?`,
         }),
-        createArticleSourceQuickReplyMessage(data.sessionId),
+        createArticleSourceReply(data.sessionId),
       ];
     }
   }

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -726,3 +726,43 @@ export function createTextMessage(textProps) {
     },
   };
 }
+
+export const POSTBACK_IS_FORWARDED = '__POSTBACK_IS_FORWARDED__';
+export const POSTBACK_IS_NOT_FORWARDED = '__POSTBACK_IS_NOT_FORWARDED__';
+
+/**
+ *
+ * @param {string} sessionId - Chatbot session ID
+ * @returns {object} Messaging API message object
+ */
+export function createArticleSourceQuickReplyMessage(sessionId) {
+  return {
+    ...createTextMessage({
+      text: t`Did you forward this message as a whole to me from the LINE app?`,
+    }),
+    quickReply: {
+      items: [
+        {
+          type: 'action',
+          action: createPostbackAction(
+            t`Yes, I forwarded it`,
+            POSTBACK_IS_FORWARDED,
+            t`Yes, I forwarded it as a whole`,
+            sessionId,
+            'ASKING_ARTICLE_SOURCE'
+          ),
+        },
+        {
+          type: 'action',
+          action: createPostbackAction(
+            t`No, typed it myself`,
+            POSTBACK_IS_NOT_FORWARDED,
+            t`No, typed it myself`,
+            sessionId,
+            'ASKING_ARTICLE_SOURCE'
+          ),
+        },
+      ],
+    },
+  };
+}

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -149,6 +149,7 @@ export function createAskArticleSubmissionConsentReply(sessionId) {
       footer: {
         type: 'box',
         layout: 'vertical',
+        spacing: 'sm',
         contents: [
           {
             type: 'button',
@@ -165,7 +166,7 @@ export function createAskArticleSubmissionConsentReply(sessionId) {
           {
             type: 'button',
             style: 'primary',
-            color: '#ffb600',
+            color: '#333333',
             action: createPostbackAction(
               t`Don’t report`,
               POSTBACK_NO,
@@ -751,7 +752,7 @@ export function createArticleSourceReply(sessionId) {
           {
             type: 'button',
             action: createPostbackAction(
-              t`Yes, I forwarded it`,
+              t`Yes, I forwarded it as a whole`,
               POSTBACK_YES,
               t`Yes, I forwarded it as a whole`,
               sessionId,

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -735,34 +735,61 @@ export const POSTBACK_IS_NOT_FORWARDED = '__POSTBACK_IS_NOT_FORWARDED__';
  * @param {string} sessionId - Chatbot session ID
  * @returns {object} Messaging API message object
  */
-export function createArticleSourceQuickReplyMessage(sessionId) {
+export function createArticleSourceReply(sessionId) {
+  const question = t`Did you forward this message as a whole to me from the LINE app?`;
+
   return {
-    ...createTextMessage({
-      text: t`Did you forward this message as a whole to me from the LINE app?`,
-    }),
-    quickReply: {
-      items: [
-        {
-          type: 'action',
-          action: createPostbackAction(
-            t`Yes, I forwarded it`,
-            POSTBACK_IS_FORWARDED,
-            t`Yes, I forwarded it as a whole`,
-            sessionId,
-            'ASKING_ARTICLE_SOURCE'
-          ),
+    type: 'flex',
+    altText: question,
+    contents: {
+      type: 'bubble',
+      body: {
+        type: 'box',
+        layout: 'vertical',
+        contents: [
+          {
+            type: 'text',
+            text: question,
+            wrap: true,
+          },
+        ],
+      },
+      footer: {
+        type: 'box',
+        layout: 'vertical',
+        spacing: 'sm',
+        contents: [
+          {
+            type: 'button',
+            action: createPostbackAction(
+              t`Yes, I forwarded it`,
+              POSTBACK_IS_FORWARDED,
+              t`Yes, I forwarded it as a whole`,
+              sessionId,
+              'ASKING_ARTICLE_SOURCE'
+            ),
+            style: 'primary',
+            color: '#333333',
+          },
+          {
+            type: 'button',
+            action: createPostbackAction(
+              t`No, typed it myself`,
+              POSTBACK_IS_NOT_FORWARDED,
+              t`No, typed it myself`,
+              sessionId,
+              'ASKING_ARTICLE_SOURCE'
+            ),
+            style: 'primary',
+            color: '#333333',
+          },
+        ],
+      },
+      styles: {
+        body: {
+          separator: true,
         },
-        {
-          type: 'action',
-          action: createPostbackAction(
-            t`No, typed it myself`,
-            POSTBACK_IS_NOT_FORWARDED,
-            t`No, typed it myself`,
-            sessionId,
-            'ASKING_ARTICLE_SOURCE'
-          ),
-        },
-      ],
+      },
     },
   };
 }

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -106,17 +106,15 @@ export function getLIFFURL(page, userId, sessionId) {
 }
 
 /**
- * @param {string} userId - LINE user ID
  * @param {string} sessionId - Search session ID
- * @returns {object} reply message object with button that opens source LIFF
+ * @returns {object} reply message object
  */
-export function createAskArticleSubmissionConsentReply(userId, sessionId) {
-  const titleText = `🥇 ${t`Be the first to report the message`}`;
-  const btnText = `🆕 ${t`Submit to database`}`;
+export function createAskArticleSubmissionConsentReply(sessionId) {
+  const btnText = `🆕 ${t`Report to database`}`;
   const spans = [
     {
       type: 'span',
-      text: t`Currently we don't have this message in our database. If you think it is probably a rumor, `,
+      text: t`Currently we don’t have this message in our database. If you think it is most likely a rumor, `,
     },
     {
       type: 'span',
@@ -126,36 +124,15 @@ export function createAskArticleSubmissionConsentReply(userId, sessionId) {
     },
     {
       type: 'span',
-      text: t`for nice volunteers to fact-check. Although you won't receive answers rightaway, you can help the people who receive the same message in the future.`,
+      text: t`and have volunteers fact-check it. This way you can help the people who receive the same message in the future.`,
     },
   ];
 
   return {
     type: 'flex',
-    altText: titleText,
+    altText: t`Be the first to report the message`,
     contents: {
       type: 'bubble',
-      header: {
-        type: 'box',
-        layout: 'horizontal',
-        spacing: 'sm',
-        paddingAll: 'lg',
-        contents: [
-          {
-            type: 'text',
-            text: '🥇',
-            flex: 0,
-            gravity: 'center',
-          },
-          {
-            type: 'text',
-            text: t`Be the first to report the message`,
-            weight: 'bold',
-            color: '#ffb600',
-            wrap: true,
-          },
-        ],
-      },
       body: {
         type: 'box',
         layout: 'vertical',
@@ -177,13 +154,25 @@ export function createAskArticleSubmissionConsentReply(userId, sessionId) {
             type: 'button',
             style: 'primary',
             color: '#ffb600',
-            action: {
-              type: 'uri',
-              label: btnText,
-              uri:
-                getLIFFURL('source', userId, sessionId) +
-                `&article_submission=true`,
-            },
+            action: createPostbackAction(
+              btnText,
+              POSTBACK_YES,
+              btnText,
+              sessionId,
+              'ASKING_ARTICLE_SUBMISSION_CONSENT'
+            ),
+          },
+          {
+            type: 'button',
+            style: 'primary',
+            color: '#ffb600',
+            action: createPostbackAction(
+              t`Don’t report`,
+              POSTBACK_NO,
+              t`Don’t report`,
+              sessionId,
+              'ASKING_ARTICLE_SUBMISSION_CONSENT'
+            ),
           },
         ],
       },
@@ -727,8 +716,8 @@ export function createTextMessage(textProps) {
   };
 }
 
-export const POSTBACK_IS_FORWARDED = '__POSTBACK_IS_FORWARDED__';
-export const POSTBACK_IS_NOT_FORWARDED = '__POSTBACK_IS_NOT_FORWARDED__';
+export const POSTBACK_YES = '__POSTBACK_YES__';
+export const POSTBACK_NO = '__POSTBACK_NO__';
 
 /**
  *
@@ -763,7 +752,7 @@ export function createArticleSourceReply(sessionId) {
             type: 'button',
             action: createPostbackAction(
               t`Yes, I forwarded it`,
-              POSTBACK_IS_FORWARDED,
+              POSTBACK_YES,
               t`Yes, I forwarded it as a whole`,
               sessionId,
               'ASKING_ARTICLE_SOURCE'
@@ -775,7 +764,7 @@ export function createArticleSourceReply(sessionId) {
             type: 'button',
             action: createPostbackAction(
               t`No, typed it myself`,
-              POSTBACK_IS_NOT_FORWARDED,
+              POSTBACK_NO,
               t`No, typed it myself`,
               sessionId,
               'ASKING_ARTICLE_SOURCE'


### PR DESCRIPTION
This PR implements (1) ~ (6) in the following diagram:
![](https://docs.google.com/drawings/d/e/2PACX-1vSjTIcpV0M5UAsmMNWl3Feph3jTgvZ3yykC7r4lUtHWWvSdYwNjpfMkO9jTwTdja7ZaKFf-I4F6xB2N/pub?w=1614&h=1046)

Wording: https://g0v.hackmd.io/eo8NM1VGQ7qxaamBZXRPtA#7-No-replies---Thanks 
> Special thanks to mingyun0d0 for reviewing the English translation!

- Ask if the user forwarded the whole message in `initState` ((1). no search match by chatbot) and `choosingArticle` ((2). user thinks no search match)
- Introduce new state `ASKING_ARTICLE_SOURCE` and its handler `askingArticleSource`
    - Introduce yes & no postback value `POSTBACK_YES` and `POSTBACK_NO`
    - Respond (3) and (4) accordingly
- Rewrite `askingArticleSubmissionConsent` to accept yes & no from postback and respond (5) and (6) accordingly

## Screenshots

### (1) no search match by chatbot
![image](https://user-images.githubusercontent.com/108608/165453600-f79a44b4-8ec1-4362-a594-055480627a91.png)

### (2) user thinks no search match
![image](https://user-images.githubusercontent.com/108608/165457284-f46c09b6-286b-43ff-bb4a-bff504a97606.png)

### (3) typed it myself
![image](https://user-images.githubusercontent.com/108608/165457329-69029781-e87f-43cc-90f7-70fd70994bdc.png)

### (4) is forwarded
![image](https://user-images.githubusercontent.com/108608/165453553-2e794f24-4362-4ebf-b738-223087f89f88.png)

### (5) disagree to publish
![image](https://user-images.githubusercontent.com/108608/165453736-b96cfb99-3aa6-4eb8-a81d-5f62a27e537c.png)

### (6) agree to publish
![image](https://user-images.githubusercontent.com/108608/165453670-d60c8ba1-2115-4a84-b437-a44596097750.png)

