### PR TITLE
Remove additional flex alt text

### DIFF
--- a/src/scripts/lib.js
+++ b/src/scripts/lib.js
@@ -3,7 +3,6 @@ import ga from 'src/lib/ga';
 import UserArticleLink from 'src/database/models/userArticleLink';
 import UserSettings from 'src/database/models/userSettings';
 import SendMessage from 'src/lib/sendMessage';
-import { FLEX_MESSAGE_ALT_TEXT } from 'src/webhook/handlers/utils';
 import { t } from 'ttag';
 
 // Async generator that gets a batch of articles with articleReply between `from` and `to`.
@@ -188,7 +187,7 @@ function createNotifyFlexMessage() {
 
   return {
     type: 'flex',
-    altText: message + FLEX_MESSAGE_ALT_TEXT,
+    altText: message,
     contents: {
       type: 'bubble',
       body: {

--- a/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.js.snap
@@ -160,9 +160,7 @@ Somewhere outside LINE",
       "type": "text",
     },
     Object {
-      "altText": "We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.
-
-📱 Please proceed on your mobile phone.",
+      "altText": "We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.",
       "contents": Object {
         "body": Object {
           "contents": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/askingReplyFeedback.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingReplyFeedback.test.js.snap
@@ -89,8 +89,7 @@ Reply is good!",
       "type": "text",
     },
     Object {
-      "altText": "Don't forget to forward the messages above to others and share with them!
-📱 Please proceed on your mobile phone.",
+      "altText": "Don't forget to forward the messages above to others and share with them!",
       "contents": Object {
         "body": Object {
           "contents": Array [
@@ -172,8 +171,7 @@ Reply is good!",
       "type": "text",
     },
     Object {
-      "altText": "Don't forget to forward the messages above to others and share with them!
-📱 Please proceed on your mobile phone.",
+      "altText": "Don't forget to forward the messages above to others and share with them!",
       "contents": Object {
         "body": Object {
           "contents": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.js.snap
@@ -20,8 +20,7 @@ May I have your help?",
       "type": "text",
     },
     Object {
-      "altText": "🥇 Be the first to report the message
-📱 Please proceed on your mobile phone.",
+      "altText": "🥇 Be the first to report the message",
       "contents": Object {
         "body": Object {
           "contents": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
@@ -25,8 +25,7 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
     "type": "text",
   },
   Object {
-    "altText": "Is the reply helpful?
-📱 Please proceed on your mobile phone.",
+    "altText": "Is the reply helpful?",
     "contents": Object {
       "contents": Array [
         Object {
@@ -163,8 +162,7 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
       "type": "text",
     },
     Object {
-      "altText": "Is the reply helpful?
-📱 Please proceed on your mobile phone.",
+      "altText": "Is the reply helpful?",
       "contents": Object {
         "contents": Array [
           Object {
@@ -262,8 +260,7 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
       "type": "text",
     },
     Object {
-      "altText": "Is the reply helpful?
-📱 Please proceed on your mobile phone.",
+      "altText": "Is the reply helpful?",
       "contents": Object {
         "contents": Array [
           Object {

--- a/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/initState.test.js.snap
@@ -388,8 +388,7 @@ Object {
       "type": "text",
     },
     Object {
-      "altText": "🥇 Be the first to report the message
-📱 Please proceed on your mobile phone.",
+      "altText": "🥇 Be the first to report the message",
       "contents": Object {
         "body": Object {
           "contents": Array [
@@ -562,9 +561,7 @@ Object {
       "type": "text",
     },
     Object {
-      "altText": "We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.
-
-📱 Please proceed on your mobile phone.",
+      "altText": "We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.",
       "contents": Object {
         "body": Object {
           "contents": Array [
@@ -952,8 +949,7 @@ Object {
       "type": "text",
     },
     Object {
-      "altText": "🥇 Be the first to report the message
-📱 Please proceed on your mobile phone.",
+      "altText": "🥇 Be the first to report the message",
       "contents": Object {
         "body": Object {
           "contents": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/tutorial.test.js.snap
@@ -2,8 +2,7 @@
 
 exports[`createGreetingMessage() 1`] = `
 Object {
-  "altText": "This is a chatbot that looks up suspicious forwarded messages for you. Here is how to use me:
-📱 Please proceed on your mobile phone.",
+  "altText": "This is a chatbot that looks up suspicious forwarded messages for you. Here is how to use me:",
   "contents": Object {
     "contents": Array [
       Object {
@@ -57,8 +56,7 @@ Object {
   "altText": "1. When receiving a message from elsewhere
 2. Long press and share
 3. Select Cofacts to share
-4. Cofacts replies with a crowd-sourced fact-check or chatbot replies
-📱 Please proceed on your mobile phone.",
+4. Cofacts replies with a crowd-sourced fact-check or chatbot replies",
   "contents": Object {
     "contents": Array [
       Object {
@@ -281,8 +279,7 @@ Object {
       "type": "text",
     },
     Object {
-      "altText": "To wrap up, please finish your permission settings so that I can provide a smoother experience.
-📱 Please proceed on your mobile phone.",
+      "altText": "To wrap up, please finish your permission settings so that I can provide a smoother experience.",
       "contents": Object {
         "body": Object {
           "contents": Array [
@@ -380,8 +377,7 @@ Object {
       "type": "text",
     },
     Object {
-      "altText": "To wrap up, please finish your permission settings so that I can provide a smoother experience.
-📱 Please proceed on your mobile phone.",
+      "altText": "To wrap up, please finish your permission settings so that I can provide a smoother experience.",
       "contents": Object {
         "body": Object {
           "contents": Array [
@@ -477,8 +473,7 @@ Object {
     Object {
       "altText": "When I provide hoax-busting replies to you, I would like to ask you for any feedback on the crowd-sourced reply.
 In order to achieve that, I need to ask for your permission to \\"Send messages to chats\\".
-The permission will be used to send only this one message of yours back to this particular chatr⋯⋯
-📱 Please proceed on your mobile phone.",
+The permission will be used to send only this one message of yours back to this particular chatr⋯⋯",
       "contents": Object {
         "body": Object {
           "contents": Array [
@@ -569,8 +564,7 @@ Object {
       "altText": "1. When receiving a message from elsewhere
 2. Long press and share
 3. Select Cofacts to share
-4. Cofacts replies with a crowd-sourced fact-check or chatbot replies
-📱 Please proceed on your mobile phone.",
+4. Cofacts replies with a crowd-sourced fact-check or chatbot replies",
       "contents": Object {
         "contents": Array [
           Object {
@@ -786,8 +780,7 @@ Object {
   "issuedAt": 1519019735467,
   "replies": Array [
     Object {
-      "altText": "This is the end of the tutorial. Next time when you receive a suspicious message, don't hesitate to forward it to me! 🤗
-📱 Please proceed on your mobile phone.",
+      "altText": "This is the end of the tutorial. Next time when you receive a suspicious message, don't hesitate to forward it to me! 🤗",
       "contents": Object {
         "contents": Array [
           Object {
@@ -857,8 +850,7 @@ Object {
       "type": "text",
     },
     Object {
-      "altText": "This is the end of the tutorial. Next time when you receive a suspicious message, don't hesitate to forward it to me! 🤗
-📱 Please proceed on your mobile phone.",
+      "altText": "This is the end of the tutorial. Next time when you receive a suspicious message, don't hesitate to forward it to me! 🤗",
       "contents": Object {
         "contents": Array [
           Object {

--- a/src/webhook/handlers/askingReplyFeedback.js
+++ b/src/webhook/handlers/askingReplyFeedback.js
@@ -7,7 +7,7 @@ import {
   DOWNVOTE_PREFIX,
   createTypeWords,
 } from 'src/lib/sharedUtils';
-import { ellipsis, ManipulationError, FLEX_MESSAGE_ALT_TEXT } from './utils';
+import { ellipsis, ManipulationError } from './utils';
 
 /**
  * @param {{vote: FeedbackVote, articleId: String, replyId: String, comment: String}} variables
@@ -83,7 +83,7 @@ export default async function askingReplyFeedback(params) {
       },
       {
         type: 'flex',
-        altText: callToAction + '\n' + FLEX_MESSAGE_ALT_TEXT,
+        altText: callToAction,
         contents: {
           type: 'bubble',
           body: {

--- a/src/webhook/handlers/choosingReply.js
+++ b/src/webhook/handlers/choosingReply.js
@@ -3,7 +3,6 @@ import gql from 'src/lib/gql';
 import {
   getLIFFURL,
   ManipulationError,
-  FLEX_MESSAGE_ALT_TEXT,
   createNotificationSettingsBubble,
   createReplyMessages,
 } from './utils';
@@ -23,7 +22,7 @@ async function createAskReplyFeedbackMessage(userId, sessionId) {
 
   return {
     type: 'flex',
-    altText: helpfulTitle + '\n' + FLEX_MESSAGE_ALT_TEXT,
+    altText: helpfulTitle,
     contents: {
       type: 'carousel',
       contents: [

--- a/src/webhook/handlers/tutorial.js
+++ b/src/webhook/handlers/tutorial.js
@@ -1,10 +1,5 @@
 import { t } from 'ttag';
-import {
-  ellipsis,
-  createPostbackAction,
-  createReplyMessages,
-  FLEX_MESSAGE_ALT_TEXT,
-} from './utils';
+import { ellipsis, createPostbackAction, createReplyMessages } from './utils';
 import ga from 'src/lib/ga';
 
 /**
@@ -99,7 +94,7 @@ export function createGreetingMessage() {
 
   return {
     type: 'flex',
-    altText: ellipsis(text, 300) + '\n' + FLEX_MESSAGE_ALT_TEXT,
+    altText: ellipsis(text, 300),
     contents: {
       type: 'carousel',
       contents: [createImageTextBubble(imageUrl, text)],
@@ -137,13 +132,10 @@ export function createTutorialMessage(sessionId) {
 
   return {
     type: 'flex',
-    altText:
-      ellipsis(
-        textStep1 + '\n' + textStep2 + '\n' + textStep3 + '\n' + textStep4,
-        300
-      ) +
-      '\n' +
-      FLEX_MESSAGE_ALT_TEXT,
+    altText: ellipsis(
+      textStep1 + '\n' + textStep2 + '\n' + textStep3 + '\n' + textStep4,
+      300
+    ),
     contents: {
       type: 'carousel',
       contents: [
@@ -201,7 +193,7 @@ function createEndingMessage() {
 
   return {
     type: 'flex',
-    altText: ellipsis(text, 300) + '\n' + FLEX_MESSAGE_ALT_TEXT,
+    altText: ellipsis(text, 300),
     contents: {
       type: 'carousel',
       contents: [createImageTextBubble(imageUrl, text)],
@@ -255,7 +247,7 @@ function createPermissionSetupDialog(message) {
 
   return {
     type: 'flex',
-    altText: ellipsis(message, 300) + '\n' + FLEX_MESSAGE_ALT_TEXT,
+    altText: ellipsis(message, 300),
     contents: {
       type: 'bubble',
       direction: 'ltr',

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -105,10 +105,6 @@ export function getLIFFURL(page, userId, sessionId) {
   return `${process.env.LIFF_URL}?p=${page}&token=${jwt}`;
 }
 
-export const FLEX_MESSAGE_ALT_TEXT = `📱 ${
-  /* t: Flex message alt-text */ t`Please proceed on your mobile phone.`
-}`;
-
 /**
  * @param {string} userId - LINE user ID
  * @param {string} sessionId - Search session ID
@@ -136,7 +132,7 @@ export function createAskArticleSubmissionConsentReply(userId, sessionId) {
 
   return {
     type: 'flex',
-    altText: titleText + '\n' + FLEX_MESSAGE_ALT_TEXT,
+    altText: titleText,
     contents: {
       type: 'bubble',
       header: {
@@ -382,7 +378,7 @@ export function createSuggestOtherFactCheckerReply() {
   const suggestion = t`We suggest forwarding the message to the following fact-checkers instead. They have 💁 1-on-1 Q&A service to respond to your questions.`;
   return {
     type: 'flex',
-    altText: `${suggestion}\n\n${FLEX_MESSAGE_ALT_TEXT}`,
+    altText: suggestion,
     contents: {
       type: 'bubble',
       body: {


### PR DESCRIPTION
const `FLEX_MESSAGE_ALT_TEXT` in `handlers/util` asks the user to proceed action on their mobile phone, if their device does not support flex messages.

At this point of time, all devices, including desktop, supports flex messages. The only chance the user can see the alt text is probably the short quote in the chatroom list, which only displays the first few letters. 
![圖片](https://user-images.githubusercontent.com/108608/164988840-6d84ead9-2296-4ea4-be4e-56cf367642a3.png)

When implementing new submission flow, I removed `FLEX_MESSAGE_ALT_TEXT` and updates each of its occurrences. This is submitted as a separate PR (this PR) in order to make the main PR more focused.