### PR TITLE
Revamp feedback sending mechanism

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,7 +30,7 @@ API_URL=https://dev-api.cofacts.tw/graphql
 SITE_URLS=https://dev.cofacts.tw
 
 # LINE_NOTIFY or PUSH_MESSAGE
-NOTIFY_METHOD=PUSH_MESSAGE
+NOTIFY_METHOD=
 
 # Uncomment this to bypass in-client check in LIFF, enable debugging on extenral browsers
 # DEBUG_LIFF=1

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -99,17 +99,18 @@ msgid "If you have different thoughts, you may have your say here:"
 msgstr "如果你對這則訊息有不同看法，歡迎到下面這裡寫入新的回應："
 
 #: src/liff/components/FeedbackForm.svelte:23
-#: src/webhook/handlers/choosingReply.js:18
+#: src/webhook/handlers/choosingReply.js:29
+#: src/webhook/handlers/choosingReply.js:161
 msgid "Is the reply helpful?"
 msgstr "請問上面回應是否有幫助？"
 
 #: src/liff/components/FeedbackForm.svelte:27
-#: src/webhook/handlers/choosingReply.js:54
+#: src/webhook/handlers/choosingReply.js:44
 msgid "Yes"
 msgstr "是"
 
 #: src/liff/components/FeedbackForm.svelte:30
-#: src/webhook/handlers/choosingReply.js:64
+#: src/webhook/handlers/choosingReply.js:56
 msgid "No"
 msgstr "否"
 
@@ -173,11 +174,13 @@ msgstr "抱歉，chatbot 出錯了。我們已經重設您目前的搜尋狀態�
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "您回報的訊息已經被收錄至 ${ articleUrl }"
 
+#: src/liff/pages/Feedback.svelte:81
 #: src/webhook/handlers/askingReplyFeedback.js:41
 msgid "Cannot record your feedback. Try again later?"
 msgstr "無法記錄您的評價，請稍後再試。"
 
 #: src/webhook/handlers/askingReplyFeedback.js:71
+#: src/webhook/handlers/choosingReply.js:77
 #, javascript-format
 msgid ""
 "Someone says the message “${ articleText }” ${ replyType }.\n"
@@ -190,22 +193,26 @@ msgstr ""
 "請至 ${ articleUrl } 觀看完整的訊息內容、其他鄉親的回應以及出處。"
 
 #: src/webhook/handlers/askingReplyFeedback.js:74
+#: src/webhook/handlers/choosingReply.js:89
 msgid "Don't forget to forward the messages above to others and share with them!"
 msgstr "別忘了把上面的回應轉傳回您的聊天室，給其他人也看看！"
 
 #: src/liff/components/FeedbackSummary.svelte:14
+#: src/liff/pages/Feedback.svelte:88
 #: src/webhook/handlers/askingReplyFeedback.js:81
 #, javascript-format
 msgid "We've received feedback from you and ${ otherFeedbackCount } other users!"
 msgstr "感謝您與其他 ${otherFeedbackCount} 人的評價。"
 
 #: src/liff/components/FeedbackSummary.svelte:15
+#: src/liff/pages/Feedback.svelte:89
 #: src/webhook/handlers/askingReplyFeedback.js:82
 #: src/webhook/handlers/askingReplyFeedback.js:154
 msgid "Thanks. You're the first one who gave feedback on this reply!"
 msgstr "感謝您的回饋，您是第一個評價這個回應的人 :)"
 
 #: src/webhook/handlers/askingReplyFeedback.js:113
+#: src/webhook/handlers/choosingReply.js:104
 msgid "Share to friends"
 msgstr "分享給朋友"
 
@@ -221,7 +228,7 @@ msgstr "感謝您與其他 ${_otherFeedbackCount} 人的評價。"
 #: src/webhook/handlers/askingArticleSource.js:23
 #: src/webhook/handlers/askingArticleSubmissionConsent.js:24
 #: src/webhook/handlers/choosingArticle.js:47
-#: src/webhook/handlers/choosingReply.js:85
+#: src/webhook/handlers/choosingReply.js:127
 msgid "Please choose from provided options."
 msgstr "請從上面的選項中做選擇。"
 
@@ -255,7 +262,7 @@ msgstr "我要選「${displayTextWhenChosen}」"
 msgid "Provide more info"
 msgstr "提供更多資訊"
 
-#: src/webhook/handlers/choosingReply.js:106
+#: src/webhook/handlers/choosingReply.js:148
 msgid ""
 "We have problem retrieving message and reply data, please forward the "
 "message again"
@@ -698,10 +705,12 @@ msgstr "請在上面輸入寶貴建議"
 msgid "Close"
 msgstr "關閉"
 
+#: src/liff/pages/Feedback.svelte:125
 #: src/liff/pages/NegativeFeedback.svelte:41
 msgid "Report not helpful"
 msgstr "表示回應沒幫助"
 
+#: src/liff/pages/Feedback.svelte:124
 #: src/liff/pages/PositiveFeedback.svelte:42
 msgid "Report reply helpful"
 msgstr "表示回應有幫助"
@@ -1033,3 +1042,7 @@ msgstr "否，我自行打字輸入的"
 #: src/webhook/handlers/initState.js:326
 msgid "May I ask you a quick question?"
 msgstr "想先請教您一個問題："
+
+#: src/webhook/handlers/choosingReply.js:114
+msgid "Provide better reply"
+msgstr "提供更好的回應"

--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -7,6 +7,7 @@
   import UserSetting from './pages/UserSetting.svelte';
   import PositiveFeedback from './pages/PositiveFeedback.svelte';
   import NegativeFeedback from './pages/NegativeFeedback.svelte';
+  import Feedback from './pages/Feedback.svelte';
 
   const routes = {
     article: Article,
@@ -15,6 +16,7 @@
     'feedback/no': NegativeFeedback,
     setting: UserSetting,
     comment: Comment,
+    feedback: Feedback,
   };
 
   // Send pageview with correct path on each page change.

--- a/src/liff/pages/Feedback.svelte
+++ b/src/liff/pages/Feedback.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { t, ngettext, msgid } from 'ttag';
+  import { t } from 'ttag';
   import { gaTitle } from 'src/lib/sharedUtils';
   import { gql } from '../lib';
   import FeedbackForm from '../components/FeedbackForm.svelte' ;

--- a/src/liff/pages/Feedback.svelte
+++ b/src/liff/pages/Feedback.svelte
@@ -1,0 +1,146 @@
+<script>
+  import { onMount } from 'svelte';
+  import { t, ngettext, msgid } from 'ttag';
+  import { gaTitle } from 'src/lib/sharedUtils';
+  import { gql } from '../lib';
+  import FeedbackForm from '../components/FeedbackForm.svelte' ;
+
+  const params = new URLSearchParams(location.search);
+
+  // Feedback parameters
+  //
+  const articleId = params.get('articleId');
+  const replyId = params.get('replyId');
+  let vote = params.get('vote'); // 'UPVOTE' | 'DOWNVOTE'. User may change vote.
+  let comment = '';
+
+  // Loading states
+  //
+  let isInitializing = true;
+  let isSubmitting = false;
+
+  // Submitting feedback with existing comment first
+  //
+  onMount(async () => {
+    // Load searchedText and previous comment
+    const { data, errors } = await gql`
+      query GetCurrentUserFeedbackInLIFF($articleId: String!, $replyId: String!) {
+        ListArticleReplyFeedbacks(
+          filter: {
+            articleId: $articleId
+            replyId: $replyId
+            selfOnly: true
+          }
+        ) {
+          edges {
+            node {
+              id
+              comment
+            }
+          }
+        }
+        GetArticle(id: $articleId) {
+          text
+        }
+      }
+    `({articleId, replyId});
+
+    isInitializing = false;
+
+    if(errors) {
+      alert(errors[0].message);
+      return;
+    }
+
+    if(!data.GetArticle) {
+      alert('Article not found');
+      return;
+    }
+
+    // Loads previous comment
+    // (previous vote will be overwritten by current vote)
+    comment = data.ListArticleReplyFeedbacks.edges[0]?.node.comment ?? '';
+
+    gtag('set', { page_title: gaTitle(data.GetArticle.text) });
+    await submitFeedback();
+  });
+
+  const handleVote = (e) => {
+    vote = e.detail;
+    submitFeedback();
+  }
+
+  const handleComment = async (e) => {
+    comment = (e.detail || '').trim();
+    isSubmitting = true;
+
+    const { data, errors } = await submitFeedback();
+    isSubmitting = false;
+
+    if(errors) {
+      alert(t`Cannot record your feedback. Try again later?`);
+      return;
+    }
+
+    const otherFeedbackCount = data.CreateOrUpdateArticleReplyFeedback.feedbackCount - 1;
+    alert(
+      otherFeedbackCount > 0
+        ? t`We've received feedback from you and ${otherFeedbackCount} other users!`
+        : t`Thanks. You're the first one who gave feedback on this reply!`
+    );
+
+    liff.closeWindow();
+  }
+
+  /**
+   * Submit feedback with current parameters
+   */
+  function submitFeedback() {
+    // Use UserInput category for data consistency
+    gtag('event', 'Feedback-Vote', {
+      event_category: 'UserInput',
+      event_label: `${articleId}/${replyId}`,
+    });
+
+    return gql`
+      mutation SubmitFeedbackInLIFF(
+        $articleId: String!
+        $replyId: String!
+        $vote: CofactsAPIFeedbackVote!
+        $comment: String!
+      ) {
+        CreateOrUpdateArticleReplyFeedback(
+          articleId: $articleId
+          replyId: $replyId
+          vote: $vote
+          comment: $comment
+        ) {
+          feedbackCount
+        }
+      }
+    `({ articleId, replyId, vote, comment });
+  }
+</script>
+
+<svelte:head>
+  {#if vote === 'UPVOTE'}
+    <title>{t`Report reply helpful`}</title>
+  {:else}
+  <title>{t`Report not helpful`}</title>
+  {/if}
+</svelte:head>
+
+<style>
+  :global(.form) {
+    flex: 1;
+  }
+</style>
+
+<FeedbackForm
+  class="form"
+  vote={vote}
+  comment={comment}
+  disabled={isInitializing || isSubmitting}
+  on:vote={handleVote}
+  on:comment={handleComment}
+/>

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
@@ -1,29 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should select reply by replyId should ask user to turn on notification settings if they did not turn it on 1`] = `
+exports[`should select reply by replyId should ask user to turn on notification settings if and only if they did not turn it on: Not allowing notification yet 1`] = `
 Array [
   Object {
-    "text": "💡 Someone on the internet replies to the message:",
-    "type": "text",
+    "altText": "Is the reply helpful?",
+    "contents": Object {
+      "contents": Array [
+        Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "Is the reply helpful?",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "paddingAll": "xl",
+            "type": "box",
+          },
+          "footer": Object {
+            "contents": Array [
+              Object {
+                "action": Object {
+                  "label": "👍 Yes",
+                  "type": "uri",
+                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=UPVOTE",
+                },
+                "color": "#00B172",
+                "style": "primary",
+                "type": "button",
+              },
+              Object {
+                "action": Object {
+                  "label": "😕 No",
+                  "type": "uri",
+                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=DOWNVOTE",
+                },
+                "color": "#FB5959",
+                "style": "primary",
+                "type": "button",
+              },
+            ],
+            "layout": "vertical",
+            "spacing": "sm",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+        Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "You can turn on notifications if you want Cofacts to notify you when someone replies to this message.",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "type": "box",
+          },
+          "footer": Object {
+            "contents": Array [
+              Object {
+                "action": Object {
+                  "label": "Go to settings",
+                  "type": "uri",
+                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=setting&utm_source=rumors-line-bot&utm_medium=reply-request",
+                },
+                "color": "#00B172",
+                "style": "primary",
+                "type": "button",
+              },
+            ],
+            "layout": "vertical",
+            "spacing": "sm",
+            "type": "box",
+          },
+          "header": Object {
+            "contents": Array [
+              Object {
+                "text": "🔔  Receive updates",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "paddingBottom": "none",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+        Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "text": "Don't forget to forward the messages above to others and share with them!",
+                "type": "text",
+                "wrap": true,
+              },
+            ],
+            "layout": "vertical",
+            "paddingAll": "lg",
+            "spacing": "md",
+            "type": "box",
+          },
+          "footer": Object {
+            "contents": Array [
+              Object {
+                "action": Object {
+                  "label": "Share to friends",
+                  "type": "uri",
+                  "uri": "https://line.me/R/msg/text/?Someone%20says%20the%20message%20%E2%80%9C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E2%80%9D%20invalid%20request.%0A%0APlease%20refer%20to%20https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz%20for%20more%20information,%20replies%20and%20references.",
+                },
+                "color": "#ffb600",
+                "style": "primary",
+                "type": "button",
+              },
+              Object {
+                "action": Object {
+                  "label": "Provide better reply",
+                  "type": "uri",
+                  "uri": "https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
+                },
+                "color": "#ffb600",
+                "style": "link",
+                "type": "button",
+              },
+            ],
+            "layout": "vertical",
+            "spacing": "sm",
+            "type": "box",
+          },
+          "type": "bubble",
+        },
+      ],
+      "type": "carousel",
+    },
+    "type": "flex",
   },
-  Object {
-    "text": "這是商業活動廣告01 這是商業活動廣告02 這是商業活動廣告03 這是商業活動廣告04 這是商業活動廣告05 這是商業活動廣告06 這是商業活動廣告07 這是商業活動廣告08 這是商業活動廣告09 這是商業活動廣告10 這是商業活動廣告11 這是商業活動廣告12 這是商業活動廣告13 這是商業活動廣告14 這是商業活動廣告15 這是商業活動廣告16 這是商業活動廣告17 這是商業活動廣告18 這是商業活動廣告19 這是商業活動廣告20",
-    "type": "text",
-  },
-  Object {
-    "text": "􀂅 ⚠️️ This reply has no references and it may be biased ⚠️️  􀂅",
-    "type": "text",
-  },
-  Object {
-    "text": "⬆️ Therefore, the author think the message invalid request.
+]
+`;
 
-💁 This content is provided by Cofact message reporting chatbot and crowd-sourced fact-checking community under CC BY-SA 4.0 license. Please refer to their references and make judgements on your own.
-
-
-⁉️ If you have different thoughts, you may have your say here:
-https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
-    "type": "text",
-  },
+exports[`should select reply by replyId should ask user to turn on notification settings if and only if they did not turn it on: Notification already allowed 1`] = `
+Array [
   Object {
     "altText": "Is the reply helpful?",
     "contents": Object {

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.js.snap
@@ -45,26 +45,26 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
             "contents": Array [
               Object {
                 "action": Object {
-                  "label": "Yes",
+                  "label": "👍 Yes",
                   "type": "uri",
-                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback/yes&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYWRkYzc0ZGY4YTNhMTc2YjkwMWQ5ZDY0OGIwZmM0ZmUiLCJleHAiOjE1Nzc5MjMyMDB9.rVpljRKoxb65cvss9Rtuup-N9vF0y2n46pQ9SXNRufw",
+                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=UPVOTE",
                 },
-                "color": "#ffb600",
+                "color": "#00B172",
                 "style": "primary",
                 "type": "button",
               },
               Object {
                 "action": Object {
-                  "label": "No",
+                  "label": "😕 No",
                   "type": "uri",
-                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback/no&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYWRkYzc0ZGY4YTNhMTc2YjkwMWQ5ZDY0OGIwZmM0ZmUiLCJleHAiOjE1Nzc5MjMyMDB9.rVpljRKoxb65cvss9Rtuup-N9vF0y2n46pQ9SXNRufw",
+                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=DOWNVOTE",
                 },
-                "color": "#ffb600",
+                "color": "#FB5959",
                 "style": "primary",
                 "type": "button",
               },
             ],
-            "layout": "horizontal",
+            "layout": "vertical",
             "spacing": "sm",
             "type": "box",
           },
@@ -74,41 +74,41 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
           "body": Object {
             "contents": Array [
               Object {
-                "text": "You can turn on notifications if you want Cofacts to notify you when someone replies to this message.",
+                "text": "Don't forget to forward the messages above to others and share with them!",
                 "type": "text",
                 "wrap": true,
               },
             ],
             "layout": "vertical",
+            "paddingAll": "lg",
+            "spacing": "md",
             "type": "box",
           },
           "footer": Object {
             "contents": Array [
               Object {
                 "action": Object {
-                  "label": "Go to settings",
+                  "label": "Share to friends",
                   "type": "uri",
-                  "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=setting&utm_source=rumors-line-bot&utm_medium=reply-request",
+                  "uri": "https://line.me/R/msg/text/?Someone%20says%20the%20message%20%E2%80%9C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E2%80%9D%20invalid%20request.%0A%0APlease%20refer%20to%20https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz%20for%20more%20information,%20replies%20and%20references.",
                 },
-                "color": "#00B172",
+                "color": "#ffb600",
                 "style": "primary",
+                "type": "button",
+              },
+              Object {
+                "action": Object {
+                  "label": "Provide better reply",
+                  "type": "uri",
+                  "uri": "https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
+                },
+                "color": "#ffb600",
+                "style": "link",
                 "type": "button",
               },
             ],
             "layout": "vertical",
             "spacing": "sm",
-            "type": "box",
-          },
-          "header": Object {
-            "contents": Array [
-              Object {
-                "text": "🔔  Receive updates",
-                "type": "text",
-                "wrap": true,
-              },
-            ],
-            "layout": "vertical",
-            "paddingBottom": "none",
             "type": "box",
           },
           "type": "bubble",
@@ -126,6 +126,9 @@ Object {
   "data": Object {
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
+    "selectedArticleText": "(0)(1)(/)(0)(9)(line)免費貼圖
+「[全螢幕貼圖]生活市集x生活小黑熊」
+ https://line.me/S/sticker/",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
   },
   "event": Object {
@@ -182,9 +185,52 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
               "contents": Array [
                 Object {
                   "action": Object {
-                    "label": "Yes",
+                    "label": "👍 Yes",
                     "type": "uri",
-                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback/yes&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYWRkYzc0ZGY4YTNhMTc2YjkwMWQ5ZDY0OGIwZmM0ZmUiLCJleHAiOjE1Nzc5MjMyMDB9.rVpljRKoxb65cvss9Rtuup-N9vF0y2n46pQ9SXNRufw",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=UPVOTE",
+                  },
+                  "color": "#00B172",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "😕 No",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=DOWNVOTE",
+                  },
+                  "color": "#FB5959",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
+            },
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Don't forget to forward the messages above to others and share with them!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "paddingAll": "lg",
+              "spacing": "md",
+              "type": "box",
+            },
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share to friends",
+                    "type": "uri",
+                    "uri": "https://line.me/R/msg/text/?Someone%20says%20the%20message%20%E2%80%9C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E2%80%9D%20invalid%20request.%0A%0APlease%20refer%20to%20https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz%20for%20more%20information,%20replies%20and%20references.",
                   },
                   "color": "#ffb600",
                   "style": "primary",
@@ -192,16 +238,16 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
                 },
                 Object {
                   "action": Object {
-                    "label": "No",
+                    "label": "Provide better reply",
                     "type": "uri",
-                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback/no&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYWRkYzc0ZGY4YTNhMTc2YjkwMWQ5ZDY0OGIwZmM0ZmUiLCJleHAiOjE1Nzc5MjMyMDB9.rVpljRKoxb65cvss9Rtuup-N9vF0y2n46pQ9SXNRufw",
+                    "uri": "https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
                   },
                   "color": "#ffb600",
-                  "style": "primary",
+                  "style": "link",
                   "type": "button",
                 },
               ],
-              "layout": "horizontal",
+              "layout": "vertical",
               "spacing": "sm",
               "type": "box",
             },
@@ -222,6 +268,9 @@ Object {
   "data": Object {
     "searchedText": "貼圖",
     "selectedArticleId": "AWDZYXxAyCdS-nWhumlz",
+    "selectedArticleText": "(0)(1)(/)(0)(9)(line)免費貼圖
+「[全螢幕貼圖]生活市集x生活小黑熊」
+ https://line.me/S/sticker/",
     "selectedReplyId": "AWDZeeV0yCdS-nWhuml8",
   },
   "event": Object {
@@ -280,9 +329,52 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
               "contents": Array [
                 Object {
                   "action": Object {
-                    "label": "Yes",
+                    "label": "👍 Yes",
                     "type": "uri",
-                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback/yes&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYWRkYzc0ZGY4YTNhMTc2YjkwMWQ5ZDY0OGIwZmM0ZmUiLCJleHAiOjE1Nzc5MjMyMDB9.rVpljRKoxb65cvss9Rtuup-N9vF0y2n46pQ9SXNRufw",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=UPVOTE",
+                  },
+                  "color": "#00B172",
+                  "style": "primary",
+                  "type": "button",
+                },
+                Object {
+                  "action": Object {
+                    "label": "😕 No",
+                    "type": "uri",
+                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback&articleId=AWDZYXxAyCdS-nWhumlz&replyId=AWDZeeV0yCdS-nWhuml8&vote=DOWNVOTE",
+                  },
+                  "color": "#FB5959",
+                  "style": "primary",
+                  "type": "button",
+                },
+              ],
+              "layout": "vertical",
+              "spacing": "sm",
+              "type": "box",
+            },
+            "type": "bubble",
+          },
+          Object {
+            "body": Object {
+              "contents": Array [
+                Object {
+                  "text": "Don't forget to forward the messages above to others and share with them!",
+                  "type": "text",
+                  "wrap": true,
+                },
+              ],
+              "layout": "vertical",
+              "paddingAll": "lg",
+              "spacing": "md",
+              "type": "box",
+            },
+            "footer": Object {
+              "contents": Array [
+                Object {
+                  "action": Object {
+                    "label": "Share to friends",
+                    "type": "uri",
+                    "uri": "https://line.me/R/msg/text/?Someone%20says%20the%20message%20%E2%80%9C(0)(1)(/)(0)(%E2%8B%AF%E2%8B%AF%E2%80%9D%20invalid%20request.%0A%0APlease%20refer%20to%20https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz%20for%20more%20information,%20replies%20and%20references.",
                   },
                   "color": "#ffb600",
                   "style": "primary",
@@ -290,16 +382,16 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
                 },
                 Object {
                   "action": Object {
-                    "label": "No",
+                    "label": "Provide better reply",
                     "type": "uri",
-                    "uri": "https://liff.line.me/1563196602-X6mLdDkW?p=feedback/no&token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVYWRkYzc0ZGY4YTNhMTc2YjkwMWQ5ZDY0OGIwZmM0ZmUiLCJleHAiOjE1Nzc5MjMyMDB9.rVpljRKoxb65cvss9Rtuup-N9vF0y2n46pQ9SXNRufw",
+                    "uri": "https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
                   },
                   "color": "#ffb600",
-                  "style": "primary",
+                  "style": "link",
                   "type": "button",
                 },
               ],
-              "layout": "horizontal",
+              "layout": "vertical",
               "spacing": "sm",
               "type": "box",
             },

--- a/src/webhook/handlers/__tests__/choosingReply.test.js
+++ b/src/webhook/handlers/__tests__/choosingReply.test.js
@@ -23,13 +23,13 @@ afterAll(async () => {
   await (await Client.getInstance()).close();
 });
 
-// Note: all commented to make unit test pass on other PRs.
-
 describe('should select reply by replyId', () => {
   const params = {
     data: {
       searchedText: '貼圖',
       selectedArticleId: 'AWDZYXxAyCdS-nWhumlz',
+      selectedArticleText:
+        '(0)(1)(/)(0)(9)(line)免費貼圖\n「[全螢幕貼圖]生活市集x生活小黑熊」\n https://line.me/S/sticker/',
     },
     event: {
       type: 'postback',

--- a/src/webhook/handlers/__tests__/choosingReply.test.js
+++ b/src/webhook/handlers/__tests__/choosingReply.test.js
@@ -71,15 +71,26 @@ describe('should select reply by replyId', () => {
     expect(ga.sendMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should ask user to turn on notification settings if they did not turn it on', async () => {
-    gql.__push(apiResult.oneReply);
-    process.env.NOTIFY_METHOD == 'LINE_NOTIFY';
-    await UserSettings.setAllowNewReplyUpdate(params.userId, false);
+  it('should ask user to turn on notification settings if and only if they did not turn it on', async () => {
+    process.env.NOTIFY_METHOD = 'LINE_NOTIFY';
 
-    expect((await choosingReply(params)).replies).toMatchSnapshot();
+    // Not allowing notification yet, expect notification bubble to show
+    //
+    await UserSettings.setAllowNewReplyUpdate(params.userId, false);
+    gql.__push(apiResult.oneReply);
+    expect((await choosingReply(params)).replies.slice(-1)).toMatchSnapshot(
+      'Not allowing notification yet'
+    );
+
+    // The user already allowed notification, expect notification bubble to not show
+    //
+    await UserSettings.setAllowNewReplyUpdate(params.userId, true);
+    gql.__push(apiResult.oneReply);
+    expect((await choosingReply(params)).replies.slice(-1)).toMatchSnapshot(
+      'Notification already allowed'
+    );
 
     // Reset
-    await UserSettings.setAllowNewReplyUpdate(params.userId, true);
     delete process.env.NOTIFY_METHOD;
   });
 

--- a/src/webhook/handlers/choosingReply.js
+++ b/src/webhook/handlers/choosingReply.js
@@ -139,7 +139,6 @@ export default async function choosingReply(params) {
       }
       GetArticle(id: $articleId) {
         replyCount
-        text
       }
     }
   `({ id: selectedReplyId, articleId: data.selectedArticleId });
@@ -172,7 +171,7 @@ export default async function choosingReply(params) {
 
           createShareBubble(
             data.selectedArticleId,
-            GetArticle.text,
+            data.selectedArticleText,
             GetReply.type
           ),
         ].filter(m => m),

--- a/src/webhook/handlers/choosingReply.js
+++ b/src/webhook/handlers/choosingReply.js
@@ -1,79 +1,121 @@
 import { t } from 'ttag';
 import gql from 'src/lib/gql';
 import {
-  getLIFFURL,
   ManipulationError,
   createNotificationSettingsBubble,
   createReplyMessages,
+  ellipsis,
 } from './utils';
+import { getArticleURL, createTypeWords } from 'src/lib/sharedUtils';
 import ga from 'src/lib/ga';
 import UserSettings from 'src/database/models/userSettings';
 
 /**
- * @param {string} userId LINE user ID that does the input
- * @param {string} sessionId Search session ID
- * @returns {object} Flex message object
+ * @param {string} articleId - Article ID of the article-reply to feedback
+ * @param {string} replyId - Reply ID of the article-reply to feedback
+ * @returns {object} Flex message bubble object that asks the user if reply is helpful
  */
-async function createAskReplyFeedbackMessage(userId, sessionId) {
-  const helpfulTitle = t`Is the reply helpful?`;
-  const { allowNewReplyUpdate } = await UserSettings.findOrInsertByUserId(
-    userId
-  );
-
+function createAskReplyFeedbackBubble(articleId, replyId) {
   return {
-    type: 'flex',
-    altText: helpfulTitle,
-    contents: {
-      type: 'carousel',
+    type: 'bubble',
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      paddingAll: 'xl',
       contents: [
         {
-          type: 'bubble',
-          body: {
-            type: 'box',
-            layout: 'vertical',
-            paddingAll: 'xl',
-            contents: [
-              {
-                type: 'text',
-                wrap: true,
-                text: helpfulTitle,
-              },
-            ],
-          },
-          footer: {
-            type: 'box',
-            layout: 'horizontal',
-            spacing: 'sm',
-            contents: [
-              {
-                type: 'button',
-                style: 'primary',
-                color: '#ffb600',
-                action: {
-                  type: 'uri',
-                  label: t`Yes`,
-                  uri: getLIFFURL('feedback/yes', userId, sessionId),
-                },
-              },
-              {
-                type: 'button',
-                style: 'primary',
-                color: '#ffb600',
-                action: {
-                  type: 'uri',
-                  label: t`No`,
-                  uri: getLIFFURL('feedback/no', userId, sessionId),
-                },
-              },
-            ],
+          type: 'text',
+          wrap: true,
+          text: t`Is the reply helpful?`,
+        },
+      ],
+    },
+    footer: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'sm',
+      contents: [
+        {
+          type: 'button',
+          style: 'primary',
+          color: '#00B172',
+          action: {
+            type: 'uri',
+            label: '👍 ' + t`Yes`,
+            uri: `${
+              process.env.LIFF_URL
+            }?p=feedback&articleId=${articleId}&replyId=${replyId}&vote=UPVOTE`,
           },
         },
-        // Ask user to turn on notification if the user did not turn it on
-        //
-        process.env.NOTIFY_METHOD &&
-          !allowNewReplyUpdate &&
-          createNotificationSettingsBubble(),
-      ].filter(m => m),
+        {
+          type: 'button',
+          style: 'primary',
+          color: '#FB5959',
+          action: {
+            type: 'uri',
+            label: '😕 ' + t`No`,
+            uri: `${
+              process.env.LIFF_URL
+            }?p=feedback&articleId=${articleId}&replyId=${replyId}&vote=DOWNVOTE`,
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * @param {string} articleId - article ID to share
+ * @param {string} fullArticleText - article text
+ * @param {ReplyTypeEnum} replyTypeEnumValue - reply's type enum
+ * @returns Flex message bubble object that asks user to share
+ */
+function createShareBubble(articleId, fullArticleText, replyTypeEnumValue) {
+  const articleUrl = getArticleURL(articleId);
+  const articleText = ellipsis(fullArticleText, 15);
+  const replyType = createTypeWords(replyTypeEnumValue).toLowerCase();
+  const sharedText = t`Someone says the message “${articleText}” ${replyType}.\n\nPlease refer to ${articleUrl} for more information, replies and references.`;
+  return {
+    type: 'bubble',
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'md',
+      paddingAll: 'lg',
+      contents: [
+        {
+          type: 'text',
+          wrap: true,
+          text: t`Don't forget to forward the messages above to others and share with them!`,
+        },
+      ],
+    },
+    footer: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'sm',
+      contents: [
+        {
+          type: 'button',
+          style: 'primary',
+          color: '#ffb600',
+          action: {
+            type: 'uri',
+            label: t`Share to friends`,
+            uri: `https://line.me/R/msg/text/?${encodeURI(sharedText)}`,
+          },
+        },
+        {
+          type: 'button',
+          style: 'link',
+          color: '#ffb600',
+          action: {
+            type: 'uri',
+            label: t`Provide better reply`,
+            uri: getArticleURL(articleId),
+          },
+        },
+      ],
     },
   };
 }
@@ -97,6 +139,7 @@ export default async function choosingReply(params) {
       }
       GetArticle(id: $articleId) {
         replyCount
+        text
       }
     }
   `({ id: selectedReplyId, articleId: data.selectedArticleId });
@@ -108,12 +151,34 @@ export default async function choosingReply(params) {
   }
 
   const { GetReply, GetArticle } = getReplyData;
+  const { allowNewReplyUpdate } = await UserSettings.findOrInsertByUserId(
+    userId
+  );
 
-  replies = createReplyMessages(
-    GetReply,
-    GetArticle,
-    data.selectedArticleId
-  ).concat(await createAskReplyFeedbackMessage(userId, data.sessionId));
+  replies = [
+    ...createReplyMessages(GetReply, GetArticle, data.selectedArticleId),
+    {
+      type: 'flex',
+      altText: t`Is the reply helpful?`,
+      contents: {
+        type: 'carousel',
+        contents: [
+          createAskReplyFeedbackBubble(data.selectedArticleId, selectedReplyId),
+
+          // Ask user to turn on notification if the user did not turn it on
+          process.env.NOTIFY_METHOD &&
+            !allowNewReplyUpdate &&
+            createNotificationSettingsBubble(),
+
+          createShareBubble(
+            data.selectedArticleId,
+            GetArticle.text,
+            GetReply.type
+          ),
+        ].filter(m => m),
+      },
+    },
+  ];
 
   const visitor = ga(userId, state, data.selectedArticleText);
   // Track when user select a reply.

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -1,6 +1,5 @@
 import { t, msgid, ngettext } from 'ttag';
 import GraphemeSplitter from 'grapheme-splitter';
-import { sign } from 'src/lib/jwt';
 import { getArticleURL, createTypeWords } from 'src/lib/sharedUtils';
 
 const splitter = new GraphemeSplitter();

--- a/src/webhook/handlers/utils.js
+++ b/src/webhook/handlers/utils.js
@@ -83,24 +83,6 @@ export function createReferenceWords({ reference, type }) {
   return `\uDBC0\uDC85 ⚠️️ ${t`This reply has no ${prompt} and it may be biased`} ⚠️️  \uDBC0\uDC85`;
 }
 
-const LIFF_EXP_SEC = 86400; // LIFF JWT is only valid for 1 day
-
-/**
- * @param {'feedback'} page - The page to display
- * @param {string} userId - LINE user ID
- * @param {string} sessionId - The current session ID
- * @returns {string}
- */
-export function getLIFFURL(page, userId, sessionId) {
-  const jwt = sign({
-    sessionId,
-    sub: userId,
-    exp: Math.round(Date.now() / 1000) + LIFF_EXP_SEC,
-  });
-
-  return `${process.env.LIFF_URL}?p=${page}&token=${jwt}`;
-}
-
 /**
  * @param {string} sessionId - Search session ID
  * @returns {object} reply message object


### PR DESCRIPTION
Fixes #310

- Implements `p=feedback` LIFF to replace the original `p=feedback/yes` and `p=feedback/no`
    - Will cleanup old LIFF in next PR
    - Does not rely on live context information, but solely relying on URL params
    - Thanks the user in the same way as in `askingArticleReplyFeedback` handler
- `choosingReply` state handler put all data needed by feedback LIFF in URL
- Revamp reply bubbles as discussed in https://g0v.hackmd.io/_MhN2CdMQJu8RrNAqY5FaA#Chatbot-feedback-bug
    - Adjust button orientation to match actions of feedback card & share card in the carousel
    - Adjust button background color to match the color of LIFF background
- Test both the user has allowed / not allowed notification for the case when `NOTIFY_METHOD` is set
    - Remove `NOTIFY_METHOD` in `.env.sample` so that empty `NOTIFY_METHOD` can be covered in ordinary tests as well


### Conversation
![1656095796107](https://user-images.githubusercontent.com/108608/175645556-e83d9c46-8895-46c2-9293-b62b3031bc8f.jpg)

The new carousel after displaying feedback
<img width="625" alt="image" src="https://user-images.githubusercontent.com/108608/175645720-e5d11383-f826-494c-8b0d-8e193996fefb.png">


### Upvote the reply in the center
The feedback is attached to the correct reply
![image](https://user-images.githubusercontent.com/108608/175645643-9ce8f752-d3e9-4a50-926e-da14debcbea5.png)
![image](https://user-images.githubusercontent.com/108608/175645656-086fbcd6-2535-4b62-b182-ef7a47ca264a.png)

