### PR TITLE
Support transport layer batching for gql()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ajv": "^6.12.2",
         "apollo-server-koa": "^2.21.0",
         "bull": "^3.20.0",
+        "dataloader": "^2.1.0",
         "date-fns": "^2.14.0",
         "googleapis": "^75.0.0",
         "grapheme-splitter": "^1.0.4",
@@ -2271,6 +2272,11 @@
         "tslib": "~2.1.0"
       }
     },
+    "node_modules/@graphql-tools/batch-delegate/node_modules/dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "node_modules/@graphql-tools/batch-delegate/node_modules/tslib": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -2286,6 +2292,11 @@
         "is-promise": "4.0.0",
         "tslib": "~2.1.0"
       }
+    },
+    "node_modules/@graphql-tools/batch-execute/node_modules/dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
       "version": "2.1.0",
@@ -2305,6 +2316,11 @@
         "is-promise": "4.0.0",
         "tslib": "~2.2.0"
       }
+    },
+    "node_modules/@graphql-tools/delegate/node_modules/dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "node_modules/@graphql-tools/delegate/node_modules/tslib": {
       "version": "2.2.0",
@@ -12778,9 +12794,9 @@
       }
     },
     "node_modules/dataloader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
-      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "node_modules/date-fns": {
       "version": "2.14.0",
@@ -32598,6 +32614,11 @@
         "tslib": "~2.1.0"
       },
       "dependencies": {
+        "dataloader": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+          "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+        },
         "tslib": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -32616,6 +32637,11 @@
         "tslib": "~2.1.0"
       },
       "dependencies": {
+        "dataloader": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+          "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+        },
         "tslib": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -32637,6 +32663,11 @@
         "tslib": "~2.2.0"
       },
       "dependencies": {
+        "dataloader": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+          "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
@@ -40882,9 +40913,9 @@
       }
     },
     "dataloader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
-      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "date-fns": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ajv": "^6.12.2",
     "apollo-server-koa": "^2.21.0",
     "bull": "^3.20.0",
+    "dataloader": "^2.1.0",
     "date-fns": "^2.14.0",
     "googleapis": "^75.0.0",
     "grapheme-splitter": "^1.0.4",

--- a/src/graphql/cofacts-api.graphql
+++ b/src/graphql/cofacts-api.graphql
@@ -196,6 +196,15 @@ type Article implements Node {
     """List only the activities between the specific time range."""
     dateRange: TimeRangeInput
   ): [Analytics]
+
+  """Message event type"""
+  articleType: ArticleTypeEnum!
+
+  """Attachment of this article"""
+  attachmentUrl: String
+
+  """Attachment hash to search or identify files"""
+  attachmentHash: String
 }
 
 """Basic entity. Modeled after Relay's GraphQL Server Specification."""
@@ -726,6 +735,13 @@ type Analytics {
   webVisit: Int
 }
 
+enum ArticleTypeEnum {
+  TEXT
+  IMAGE
+  VIDEO
+  AUDIO
+}
+
 input ListArticleFilter {
   """Show only articles created by a specific app."""
   appId: String
@@ -785,6 +801,12 @@ input ListArticleFilter {
 
   """List the articles with replies of certain types"""
   replyTypes: [ReplyTypeEnum]
+
+  """List the articles with certain types"""
+  articleTypes: [ArticleTypeEnum]
+
+  """Show the media article similar to the input url"""
+  mediaUrl: String
 }
 
 """
@@ -1070,6 +1092,18 @@ type Mutation {
   """Create an article and/or a replyRequest"""
   CreateArticle(
     text: String!
+    reference: ArticleReferenceInput!
+
+    """
+    The reason why the user want to submit this article. Mandatory for 1st sender
+    """
+    reason: String
+  ): MutationResult
+
+  """Create a media article and/or a replyRequest"""
+  CreateMediaArticle(
+    mediaUrl: String!
+    articleType: ArticleTypeEnum!
     reference: ArticleReferenceInput!
 
     """

--- a/src/lib/__tests__/gql.js
+++ b/src/lib/__tests__/gql.js
@@ -1,20 +1,20 @@
-jest.mock("node-fetch");
-jest.mock("../rollbar");
+jest.mock('node-fetch');
+jest.mock('../rollbar');
 
-import fetch from "node-fetch";
-import rollbar from "../rollbar";
-import gql, { loaders } from "../gql";
+import fetch from 'node-fetch';
+import rollbar from '../rollbar';
+import gql, { loaders } from '../gql';
 
 beforeEach(() => {
   fetch.mockClear();
   rollbar.error.mockClear();
 });
 
-it("invokes fetch and returns result", async () => {
+it('invokes fetch and returns result', async () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({ json: () => Promise.resolve([{ data: { foo: 1 } }]) })
   );
-  const result = await gql`(bar: String){foo}`({ bar: "bar" });
+  const result = await gql`(bar: String){foo}`({ bar: 'bar' });
 
   expect(fetch.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -42,15 +42,15 @@ it("invokes fetch and returns result", async () => {
   `);
 });
 
-it("handles syntax error", async () => {
+it('handles syntax error', async () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
       status: 200, // Apollo Server always return 200 when transport layer batch is used.
       json: () =>
         Promise.resolve([
           // Apollo Server do not send `data` when there is syntax error
-          { errors: [{ message: "Syntax error" }] }
-        ])
+          { errors: [{ message: 'Syntax error' }] },
+        ]),
     })
   );
   const result = await gql`
@@ -62,15 +62,15 @@ it("handles syntax error", async () => {
   expect(result).toMatchInlineSnapshot(`[Error: GraphQL Error: Syntax error]`);
 });
 
-it("handles runtime error", async () => {
+it('handles runtime error', async () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       json: () =>
         Promise.resolve([
           // No fields resolved successfully, but data is still an object
-          { data: {}, errors: [{ message: "Runtime error" }] }
-        ])
+          { data: {}, errors: [{ message: 'Runtime error' }] },
+        ]),
     })
   );
   const result = await gql`
@@ -112,17 +112,17 @@ it("handles runtime error", async () => {
   `);
 });
 
-it("batches consecutive requests by URL", async () => {
+it('batches consecutive requests by URL', async () => {
   fetch
     .mockImplementationOnce(() =>
       Promise.resolve({
         json: () =>
-          Promise.resolve([{ data: { foo: 1 } }, { data: { bar: 2 } }])
+          Promise.resolve([{ data: { foo: 1 } }, { data: { bar: 2 } }]),
       })
     )
     .mockImplementationOnce(() =>
       Promise.resolve({
-        json: () => Promise.resolve([{ data: { foobar: 3 } }])
+        json: () => Promise.resolve([{ data: { foobar: 3 } }]),
       })
     );
 
@@ -141,7 +141,7 @@ it("batches consecutive requests by URL", async () => {
       {
         foobar
       }
-    `({}, { userId: "another-user" })
+    `({}, { userId: 'another-user' }),
   ]);
 
   // Expect called 2 times

--- a/src/lib/__tests__/gql.js
+++ b/src/lib/__tests__/gql.js
@@ -1,20 +1,20 @@
-jest.mock('node-fetch');
-jest.mock('../rollbar');
+jest.mock("node-fetch");
+jest.mock("../rollbar");
 
-import fetch from 'node-fetch';
-import rollbar from '../rollbar';
-import gql from '../gql';
+import fetch from "node-fetch";
+import rollbar from "../rollbar";
+import gql, { loaders } from "../gql";
 
 beforeEach(() => {
   fetch.mockClear();
   rollbar.error.mockClear();
 });
 
-it('invokes fetch and returns result', async () => {
+it("invokes fetch and returns result", async () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({ json: () => Promise.resolve([{ data: { foo: 1 } }]) })
   );
-  const result = await gql`(bar: String){foo}`({ bar: 'bar' });
+  const result = await gql`(bar: String){foo}`({ bar: "bar" });
 
   expect(fetch.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -42,15 +42,15 @@ it('invokes fetch and returns result', async () => {
   `);
 });
 
-it('handles syntax error', async () => {
+it("handles syntax error", async () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
       status: 200, // Apollo Server always return 200 when transport layer batch is used.
       json: () =>
         Promise.resolve([
           // Apollo Server do not send `data` when there is syntax error
-          { errors: [{ message: 'Syntax error' }] },
-        ]),
+          { errors: [{ message: "Syntax error" }] }
+        ])
     })
   );
   const result = await gql`
@@ -62,15 +62,15 @@ it('handles syntax error', async () => {
   expect(result).toMatchInlineSnapshot(`[Error: GraphQL Error: Syntax error]`);
 });
 
-it('handles runtime error', async () => {
+it("handles runtime error", async () => {
   fetch.mockImplementationOnce(() =>
     Promise.resolve({
       status: 200,
       json: () =>
         Promise.resolve([
           // No fields resolved successfully, but data is still an object
-          { data: {}, errors: [{ message: 'Runtime error' }] },
-        ]),
+          { data: {}, errors: [{ message: "Runtime error" }] }
+        ])
     })
   );
   const result = await gql`
@@ -110,4 +110,91 @@ it('handles runtime error', async () => {
       ],
     ]
   `);
+});
+
+it("batches consecutive requests by URL", async () => {
+  fetch
+    .mockImplementationOnce(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([{ data: { foo: 1 } }, { data: { bar: 2 } }])
+      })
+    )
+    .mockImplementationOnce(() =>
+      Promise.resolve({
+        json: () => Promise.resolve([{ data: { foobar: 3 } }])
+      })
+    );
+
+  const results = await Promise.all([
+    gql`
+      {
+        foo
+      }
+    `(),
+    gql`
+      {
+        bar
+      }
+    `(),
+    gql`
+      {
+        foobar
+      }
+    `({}, { userId: "another-user" })
+  ]);
+
+  // Expect called 2 times
+  expect(fetch.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "https://dev-api.cofacts.tw/graphql",
+        Object {
+          "body": "[{\\"query\\":\\"\\\\n      {\\\\n        foo\\\\n      }\\\\n    \\"},{\\"query\\":\\"\\\\n      {\\\\n        bar\\\\n      }\\\\n    \\"}]",
+          "credentials": "include",
+          "headers": Object {
+            "Content-Type": "application/json",
+            "x-app-secret": "CHANGE_ME",
+          },
+          "method": "POST",
+        },
+      ],
+      Array [
+        "https://dev-api.cofacts.tw/graphql?userId=another-user",
+        Object {
+          "body": "[{\\"query\\":\\"\\\\n      {\\\\n        foobar\\\\n      }\\\\n    \\",\\"variables\\":{}}]",
+          "credentials": "include",
+          "headers": Object {
+            "Content-Type": "application/json",
+            "x-app-secret": "CHANGE_ME",
+          },
+          "method": "POST",
+        },
+      ],
+    ]
+  `);
+
+  // Expect foo, bar and foobar all returned
+  expect(results).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "data": Object {
+          "foo": 1,
+        },
+      },
+      Object {
+        "data": Object {
+          "bar": 2,
+        },
+      },
+      Object {
+        "data": Object {
+          "foobar": 3,
+        },
+      },
+    ]
+  `);
+
+  // Expect loaders to be empty
+  expect(loaders).toMatchInlineSnapshot(`Object {}`);
 });

--- a/src/lib/gql.js
+++ b/src/lib/gql.js
@@ -1,9 +1,60 @@
 import fetch from 'node-fetch';
 import rollbar from './rollbar';
-import url from 'url';
+import { format } from 'url';
+import Dataloader from 'dataloader';
 
 const API_URL =
   process.env.API_URL || 'https://cofacts-api.hacktabl.org/graphql';
+
+// Maps URL to dataloader. Cleared after batched request is fired.
+const loaders = {};
+
+/**
+ * Returns a dataloader instance that can send query & variable to the GraphQL endpoint specified by `url`.
+ *
+ * The dataloader instance is automatically created when not exist for the specified `url`, and is
+ * cleared automatically when the batch request fires.
+ *
+ * @param {string} url - GraphQL endpoint URL
+ * @returns {Dataloader} A dataloader instance that loads response of the given {query, variable}
+ */
+function getGraphQLRespLoader(url) {
+  if (loaders[url]) return loaders[url];
+
+  return (loaders[url] = new Dataloader(async queryAndVariables => {
+    // Clear dataloader so that next batch will get a fresh dataloader
+    delete loaders[url];
+
+    // Implements Apollo's transport layer batching
+    // https://www.apollographql.com/blog/apollo-client/performance/query-batching/#1bce
+    //
+    const responses = await (await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-app-secret': process.env.APP_SECRET,
+      },
+      credentials: 'include',
+      body: JSON.stringify(queryAndVariables),
+    })).json();
+
+    responses.forEach((resp, i) => {
+      if (resp.errors) {
+        console.error('GraphQL operation contains error:', resp.errors);
+        rollbar.error(
+          'GraphQL error',
+          {
+            body: JSON.stringify(queryAndVariables[i]),
+            url,
+          },
+          { resp }
+        );
+      }
+    });
+
+    return responses;
+  }));
+}
 
 // Usage:
 //
@@ -15,8 +66,6 @@ const API_URL =
 // We use template string here so that Atom's language-babel does syntax highlight
 // for us.
 //
-// GraphQL Protocol: http://dev.apollodata.com/tools/graphql-server/requests.html
-//
 export default (query, ...substitutions) => (variables, search) => {
   const queryAndVariable = {
     query: String.raw(query, ...substitutions),
@@ -24,42 +73,7 @@ export default (query, ...substitutions) => (variables, search) => {
 
   if (variables) queryAndVariable.variables = variables;
 
-  let status;
-  const URL = `${API_URL}${url.format({ query: search })}`;
-
-  return fetch(URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-app-secret': process.env.APP_SECRET,
-    },
-    credentials: 'include',
-    body: JSON.stringify(queryAndVariable),
-  })
-    .then(r => {
-      status = r.status;
-      return r.json();
-    })
-    .then(resp => {
-      if (status === 400) {
-        throw new Error(
-          `GraphQL Error: ${resp.errors
-            .map(({ message }) => message)
-            .join('\n')}`
-        );
-      }
-      if (resp.errors) {
-        // When status is 200 but have error, just print them out.
-        console.error('GraphQL operation contains error:', resp.errors);
-        rollbar.error(
-          'GraphQL error',
-          {
-            body: JSON.stringify(queryAndVariable),
-            url: URL,
-          },
-          { resp }
-        );
-      }
-      return resp;
-    });
+  return getGraphQLRespLoader(`${API_URL}${format({ query: search })}`).load(
+    queryAndVariable
+  );
 };

--- a/src/lib/gql.js
+++ b/src/lib/gql.js
@@ -28,7 +28,7 @@ function getGraphQLRespLoader(url) {
     // Implements Apollo's transport layer batching
     // https://www.apollographql.com/blog/apollo-client/performance/query-batching/#1bce
     //
-    const responses = await (await fetch(url, {
+    return (await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -37,22 +37,6 @@ function getGraphQLRespLoader(url) {
       credentials: 'include',
       body: JSON.stringify(queryAndVariables),
     })).json();
-
-    responses.forEach((resp, i) => {
-      if (resp.errors) {
-        console.error('GraphQL operation contains error:', resp.errors);
-        rollbar.error(
-          'GraphQL error',
-          {
-            body: JSON.stringify(queryAndVariables[i]),
-            url,
-          },
-          { resp }
-        );
-      }
-    });
-
-    return responses;
   }));
 }
 
@@ -73,7 +57,34 @@ export default (query, ...substitutions) => (variables, search) => {
 
   if (variables) queryAndVariable.variables = variables;
 
-  return getGraphQLRespLoader(`${API_URL}${format({ query: search })}`).load(
-    queryAndVariable
-  );
+  const URL = `${API_URL}${format({ query: search })}`;
+
+  return getGraphQLRespLoader(URL)
+    .load(queryAndVariable)
+    .then(resp => {
+      // We cannot get status code in transport layer batching.
+      // but we can guess that it's not 2xx if `data` is null or does not exist.
+      // Ref: https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#status-codes
+      //
+      if (!resp.data) {
+        throw new Error(
+          `GraphQL Error: ${resp.errors
+            .map(({ message }) => message)
+            .join('\n')}`
+        );
+      }
+
+      if (resp.errors) {
+        console.error('GraphQL operation contains error:', resp.errors);
+        rollbar.error(
+          'GraphQL error',
+          {
+            body: JSON.stringify(queryAndVariable),
+            url: URL,
+          },
+          { resp }
+        );
+      }
+      return resp;
+    });
 };

--- a/src/lib/gql.js
+++ b/src/lib/gql.js
@@ -7,7 +7,8 @@ const API_URL =
   process.env.API_URL || 'https://cofacts-api.hacktabl.org/graphql';
 
 // Maps URL to dataloader. Cleared after batched request is fired.
-const loaders = {};
+// Exported just for unit test.
+export const loaders = {};
 
 /**
  * Returns a dataloader instance that can send query & variable to the GraphQL endpoint specified by `url`.


### PR DESCRIPTION
- The schema stitching mechanism will cause query fields in a query being sent as several operations in separate requests. 
    - Even [the following operation](https://github.com/cofacts/rumors-line-bot/pull/312/files#diff-a4377695c351076549611444f305edd46ead9de7f1de3752ccd4b0e2cbb9082eR28-R45) will be split into 2 operations when calling BE API server
       ```graphql
       query GetCurrentUserFeedbackInLIFF($articleId: String!, $replyId: String!) {
         ListArticleReplyFeedbacks(
           filter: {
             articleId: $articleId
             replyId: $replyId
             selfOnly: true
           }
         ) {
           edges {
             node {
               id
               comment
             }
           }
         }
         GetArticle(id: $articleId) {
           text
         }
       }
       ```
- rumors-api is having issues handling concurrent requests (due to version conflict to `users` collection).
- We implement [Apollo's transport layer batching](https://www.apollographql.com/blog/apollo-client/performance/query-batching/#1bce) so that consecutive queries are sent as 1 HTTP request, which will only trigger 1 context generation in rumors-api server, thus avoids the problem above.

This PR changes the internal behavior of `gql` but does not change the API and the signature of the function.

Also update Cofacts API schema.