### PR TITLE
Fix image search on chatbot

### DIFF
--- a/src/webhook/handlers/processImage.js
+++ b/src/webhook/handlers/processImage.js
@@ -30,6 +30,7 @@ export default async function({ data = {} }, event, userId) {
     query($mediaUrl: String!) {
       ListArticles(
         filter: { mediaUrl: $mediaUrl }
+        articleTypes: [TEXT, IMAGE, AUDIO, VIDEO]
         orderBy: [{ _score: DESC }]
         first: 4
       ) {

--- a/src/webhook/handlers/processImage.js
+++ b/src/webhook/handlers/processImage.js
@@ -29,8 +29,10 @@ export default async function({ data = {} }, event, userId) {
   } = await gql`
     query($mediaUrl: String!) {
       ListArticles(
-        filter: { mediaUrl: $mediaUrl }
-        articleTypes: [TEXT, IMAGE, AUDIO, VIDEO]
+        filter: {
+          mediaUrl: $mediaUrl
+          articleTypes: [TEXT, IMAGE, AUDIO, VIDEO]
+        }
         orderBy: [{ _score: DESC }]
         first: 4
       ) {


### PR DESCRIPTION
We observed that duplicate images are being submitted to Cofacts.

According to the analysis in https://g0v.hackmd.io/FYQIQOIgQ1evVfzG-33fwg#%E4%B8%8A%E7%B7%9A%E5%BE%8C%E8%BF%BD%E8%B9%A4%EF%BC%9A%E9%87%8D%E8%A4%87%E5%9C%96%E7%89%87 , the root cause is
- Production server does not have `MEDIA_ARTICLE_SUPPORT` turned on
- Chatbot does not specify `articleTypes` so that only text is returned by default
- Therefore, when chatbot user sends a very similar image, API always returns empty image search response

This PR fixes the duplicate image submission problem by specifying all article types so that no matter what API's `MEDIA_ARTICLE_SUPPORT` is, chatbot can get all media results.