### PR TITLE
docs: fix hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Developing rumors-line-bot requires you to finish the following settings.
 
 ### LINE channels & Developer accounts
 
-Please follow all the steps in [LINE official tutorial](https://developers.line.me/messaging-api/getting-started).
+Please follow all the steps in [LINE official tutorial](https://developers.line.biz/en/docs/messaging-api/getting-started/).
 
 ### Environment variables
 


### PR DESCRIPTION
The `LINE official tutorial` link at `README.md` isn't valid anymore.