### PR TITLE
fix: `COFACTS_API_URL` is unnecessary

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,9 +19,6 @@ GA_ID=
 # LIFF url with pattern "https://liff.line.me/<liff-id>"
 LIFF_URL=https://liff.line.me/1563196602-X6mLdDkW
 
-# Cofacts API x-app-id for browser apps (LIFF)
-APP_ID=RUMORS_LINE_BOT
-
 # Cofacst API URL
 API_URL=https://dev-api.cofacts.tw/graphql
 

--- a/src/liff/.eslintrc.js
+++ b/src/liff/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
     APP_ID: 'readonly',
     LIFF_ID: 'readonly',
     DEBUG_LIFF: 'readonly',
-    COFACTS_API_URL: 'readonly',
     NOTIFY_METHOD: 'readonly',
   },
 };

--- a/src/liff/.eslintrc.js
+++ b/src/liff/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
     gtag: 'readonly',
 
     // Define plugin
-    APP_ID: 'readonly',
     LIFF_ID: 'readonly',
     DEBUG_LIFF: 'readonly',
     NOTIFY_METHOD: 'readonly',

--- a/src/liff/__tests__/lib.js
+++ b/src/liff/__tests__/lib.js
@@ -153,7 +153,6 @@ describe('getArticlesFromCofacts', () => {
   let getArticlesFromCofacts;
   beforeEach(() => {
     global.location = { search: '?foo=bar' };
-    global.APP_ID = 'mock_app_id';
     global.fetch = jest.fn();
     global.rollbar = { error: jest.fn() };
 
@@ -163,7 +162,6 @@ describe('getArticlesFromCofacts', () => {
 
   afterEach(() => {
     delete global.fetch;
-    delete global.APP_ID;
     delete global.location;
     delete global.rollbar;
   });

--- a/src/liff/__tests__/lib.js
+++ b/src/liff/__tests__/lib.js
@@ -153,7 +153,6 @@ describe('getArticlesFromCofacts', () => {
   let getArticlesFromCofacts;
   beforeEach(() => {
     global.location = { search: '?foo=bar' };
-    global.COFACTS_API_URL = 'http://cofacts.api';
     global.APP_ID = 'mock_app_id';
     global.fetch = jest.fn();
     global.rollbar = { error: jest.fn() };
@@ -163,7 +162,6 @@ describe('getArticlesFromCofacts', () => {
   });
 
   afterEach(() => {
-    delete global.COFACTS_API_URL;
     delete global.fetch;
     delete global.APP_ID;
     delete global.location;

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -118,7 +118,7 @@ export const getArticlesFromCofacts = async articleIds => {
   `;
 
   let status;
-  return fetch(COFACTS_API_URL, {
+  return fetch('/graphql', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -122,7 +122,6 @@ export const getArticlesFromCofacts = async articleIds => {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-app-id': APP_ID,
     },
     body: JSON.stringify({ query, variables }),
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,6 @@ module.exports = {
       LIFF_ID: JSON.stringify(
         (process.env.LIFF_URL || '').replace('https://liff.line.me/', '')
       ),
-      APP_ID: JSON.stringify(process.env.APP_ID),
       DEBUG_LIFF: process.env.DEBUG_LIFF,
       'process.env.SITE_URLS': JSON.stringify(process.env.SITE_URLS),
       'process.env.LOCALE': JSON.stringify(process.env.LOCALE),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,7 +145,6 @@ module.exports = {
       ),
       APP_ID: JSON.stringify(process.env.APP_ID),
       DEBUG_LIFF: process.env.DEBUG_LIFF,
-      COFACTS_API_URL: JSON.stringify(process.env.API_URL),
       'process.env.SITE_URLS': JSON.stringify(process.env.SITE_URLS),
       'process.env.LOCALE': JSON.stringify(process.env.LOCALE),
       NOTIFY_METHOD: JSON.stringify(process.env.NOTIFY_METHOD),


### PR DESCRIPTION
We should replace `COFACTS_API_URL` with `/graphql`, otherwise `getArticlesFromCofacts` will be blocked by CORS.