### PR TITLE
Fix articles page pagination when there is no articles

### DIFF
--- a/src/liff/components/Pagination.stories.svelte
+++ b/src/liff/components/Pagination.stories.svelte
@@ -21,6 +21,17 @@
 />
 
 <Story
+  name="No pages"
+  args={{
+    pageInfo: {
+      firstCursor: null,
+      lastCursor: null,
+    },
+    edges: []
+  }}
+/>
+
+<Story
   name="pageInfo and edges given"
   args={{
     pageInfo: {

--- a/src/liff/components/Pagination.svelte
+++ b/src/liff/components/Pagination.svelte
@@ -29,7 +29,7 @@
   }
 </style>
 
-{#if pageInfo && edges }
+{#if pageInfo && edges && edges.length > 0 }
   <div class="container">
     {#if pageInfo && pageInfo.firstCursor !== edges[0].cursor}
       <Button


### PR DESCRIPTION
Currently empty articles page will trigger error due to 0 elements in `edges`.

After this PR, empty edges will not trigger error. `<Pagination />` should render nothing in this case.

<img width="896" alt="image" src="https://user-images.githubusercontent.com/108608/192158253-f31581dd-9cd8-4d7e-9e60-91e17cac14d7.png">
