### PR TITLE
Make LIFF support image

### DIFF
--- a/src/graphql/cofacts-api.graphql
+++ b/src/graphql/cofacts-api.graphql
@@ -119,6 +119,23 @@ type Query {
     """
     before: String
   ): UserConnection!
+  ListAnalytics(
+    filter: ListAnalyticsFilter
+    orderBy: [ListAnalyticsOrderBy]
+
+    """Returns only first <first> results"""
+    first: Int = 10
+
+    """
+    Specify a cursor, returns results after this cursor. cannot be used with "before".
+    """
+    after: String
+
+    """
+    Specify a cursor, returns results before this cursor. cannot be used with "after".
+    """
+    before: String
+  ): AnalyticsConnection!
   ValidateSlug(slug: String!): ValidationResult
 }
 
@@ -143,6 +160,15 @@ type Article implements Node {
 
     """Returns only article replies with the specified statuses"""
     statuses: [ArticleReplyStatusEnum!] = [NORMAL]
+
+    """Show only articleReplies created by a specific app."""
+    appId: String
+
+    """Show only articleReplies created by the specific user."""
+    userId: String
+
+    """Only list the articleReplies created by the currently logged in user"""
+    selfOnly: Boolean
   ): [ArticleReply]
   articleCategories(
     """
@@ -200,8 +226,8 @@ type Article implements Node {
   """Message event type"""
   articleType: ArticleTypeEnum!
 
-  """Attachment of this article"""
-  attachmentUrl: String
+  """Attachment URL for this article."""
+  attachmentUrl(variant: AttachmentVariantEnum): String
 
   """Attachment hash to search or identify files"""
   attachmentHash: String
@@ -513,6 +539,12 @@ type ArticleReplyFeedback implements Node {
   user: User
   userId: String
   appId: String
+
+  """User ID of the reply's author"""
+  replyUserId: String!
+
+  """User ID of the article-reply's author"""
+  articleReplyUserId: String!
   comment: String
   createdAt: String
   updatedAt: String
@@ -727,12 +759,48 @@ input RelatedArticleOrderBy {
   updatedAt: SortOrderEnum
 }
 
-type Analytics {
-  date: String
+type Analytics implements Node {
+  id: ID!
+
+  """The id for the document that this analytic datapoint is for."""
+  docId: ID!
+
+  """Type of document that this analytic datapoint is for."""
+  type: AnalyticsDocTypeEnum!
+
+  """The day this analytic datapoint is represented, in YYYY-MM-DD format"""
+  date: String!
   lineUser: Int
   lineVisit: Int
   webUser: Int
   webVisit: Int
+
+  """Sum of LIFF visitor count from all sources"""
+  liffUser: Int!
+
+  """Sum of LIFF view count from all sources"""
+  liffVisit: Int!
+  liff: [AnalyticsLiffEntry!]!
+
+  """Author of the document that this analytic datapoint measures."""
+  docUserId: ID
+
+  """
+  Authoring app ID of the document that this analytic datapoint measures.
+  """
+  docAppId: ID
+}
+
+enum AnalyticsDocTypeEnum {
+  ARTICLE
+  REPLY
+}
+
+type AnalyticsLiffEntry {
+  """utm_source for this LIFF stat entry. Empty string if not set."""
+  source: String!
+  user: Int!
+  visit: Int!
 }
 
 enum ArticleTypeEnum {
@@ -740,6 +808,19 @@ enum ArticleTypeEnum {
   IMAGE
   VIDEO
   AUDIO
+}
+
+enum AttachmentVariantEnum {
+  """The original file. Only available to logged-in users."""
+  ORIGINAL
+
+  """Downsized file. Fixed-width webp for images; other type TBD."""
+  PREVIEW
+
+  """
+  Tiny, static image representing the attachment. Fixed-height jpeg for images; other types TBD.
+  """
+  THUMBNAIL
 }
 
 input ListArticleFilter {
@@ -778,7 +859,7 @@ input ListArticleFilter {
   replyRequestCount: RangeInput
 
   """
-  List only the articles that were replied between the specific time range.
+  [Deprecated] use articleReply filter instead. List only the articles that were replied between the specific time range.
   """
   repliedAt: TimeRangeInput
 
@@ -799,7 +880,9 @@ input ListArticleFilter {
   """
   hasArticleReplyWithMorePositiveFeedback: Boolean
 
-  """List the articles with replies of certain types"""
+  """
+  [Deprecated] use articleReply filter instead. List the articles with replies of certain types
+  """
   replyTypes: [ReplyTypeEnum]
 
   """List the articles with certain types"""
@@ -807,6 +890,9 @@ input ListArticleFilter {
 
   """Show the media article similar to the input url"""
   mediaUrl: String
+
+  """Show articles with article replies matching this criteria"""
+  articleReply: ArticleReplyFilterInput
 }
 
 """
@@ -836,6 +922,24 @@ input UserAndExistInput {
   exists: Boolean = true
 }
 
+input ArticleReplyFilterInput {
+  """Show only articleReplies created by a specific app."""
+  appId: String
+
+  """Show only articleReplies created by the specific user."""
+  userId: String
+
+  """
+  List only the articleReplies that were created between the specific time range.
+  """
+  createdAt: TimeRangeInput
+
+  """Only list the articleReplies created by the currently logged in user"""
+  selfOnly: Boolean
+  statuses: [ArticleReplyStatusEnum!] = [NORMAL]
+  replyTypes: [ReplyTypeEnum]
+}
+
 """
 An entry of orderBy argument. Specifies field name and the sort order. Only one field name is allowd per entry.
 """
@@ -847,6 +951,7 @@ input ListArticleOrderBy {
   replyCount: SortOrderEnum
   lastRequestedAt: SortOrderEnum
   lastRepliedAt: SortOrderEnum
+  lastMatchingArticleReplyCreatedAt: SortOrderEnum
 }
 
 input ListReplyFilter {
@@ -967,6 +1072,17 @@ input ListArticleReplyFeedbackFilter {
 
   """List only the article reply feedbacks with the selected statuses"""
   statuses: [ArticleReplyFeedbackStatusEnum!] = [NORMAL]
+
+  """List only the feedbacks to the replies created by this user ID"""
+  replyUserId: String
+
+  """List only the feedbacks to the article-replies created by this user ID"""
+  articleReplyUserId: String
+
+  """
+  List only the feedbacks whose `replyUserId` *or* `articleReplyUserId` is this user ID
+  """
+  authorId: String
 }
 
 """
@@ -1066,6 +1182,43 @@ An entry of orderBy argument. Specifies field name and the sort order. Only one 
 """
 input ListBlockedUsersOrderBy {
   createdAt: SortOrderEnum
+}
+
+type AnalyticsConnection implements Connection {
+  """
+  The total count of the entire collection, regardless of "before", "after".
+  """
+  totalCount: Int!
+  edges: [AnalyticsConnectionEdge!]!
+  pageInfo: AnalyticsConnectionPageInfo!
+}
+
+type AnalyticsConnectionEdge implements Edge {
+  node: Analytics!
+  cursor: String!
+  score: Float
+  highlight: Highlights
+}
+
+type AnalyticsConnectionPageInfo implements PageInfo {
+  lastCursor: String
+  firstCursor: String
+}
+
+input ListAnalyticsFilter {
+  """List only the activities between the specific time range."""
+  date: TimeRangeInput
+  type: AnalyticsDocTypeEnum
+  docId: ID
+  docUserId: ID
+  docAppId: ID
+}
+
+"""
+An entry of orderBy argument. Specifies field name and the sort order. Only one field name is allowd per entry.
+"""
+input ListAnalyticsOrderBy {
+  date: SortOrderEnum
 }
 
 type ValidationResult {

--- a/src/liff/__tests__/lib.js
+++ b/src/liff/__tests__/lib.js
@@ -199,10 +199,12 @@ describe('getArticlesFromCofacts', () => {
               a0: {
                 id: 'id1',
                 text: 'text1',
+                articleType: 'TEXT',
               },
               a1: {
                 id: 'id2',
                 text: 'text2',
+                articleType: 'TEXT',
               },
             },
             errors: [{ message: 'Some error loading id3' }],
@@ -212,18 +214,20 @@ describe('getArticlesFromCofacts', () => {
     );
 
     await expect(getArticlesFromCofacts(ids)).resolves.toMatchInlineSnapshot(`
-                  Array [
-                    Object {
-                      "id": "id1",
-                      "text": "text1",
-                    },
-                    Object {
-                      "id": "id2",
-                      "text": "text2",
-                    },
-                    undefined,
-                  ]
-              `);
+            Array [
+              Object {
+                "articleType": "TEXT",
+                "id": "id1",
+                "text": "text1",
+              },
+              Object {
+                "articleType": "TEXT",
+                "id": "id2",
+                "text": "text2",
+              },
+              undefined,
+            ]
+          `);
 
     expect(rollbar.error).toHaveBeenCalledTimes(1);
 

--- a/src/liff/__tests__/lib.js
+++ b/src/liff/__tests__/lib.js
@@ -242,6 +242,8 @@ describe('getArticlesFromCofacts', () => {
                     articleReplies(status: NORMAL) {
                       createdAt
                     }
+                    articleType
+                    attachmentUrl(variant: THUMBNAIL)
                   }
       a1: GetArticle(id: $a1) {
                     id
@@ -249,6 +251,8 @@ describe('getArticlesFromCofacts', () => {
                     articleReplies(status: NORMAL) {
                       createdAt
                     }
+                    articleType
+                    attachmentUrl(variant: THUMBNAIL)
                   }
       a2: GetArticle(id: $a2) {
                     id
@@ -256,6 +260,8 @@ describe('getArticlesFromCofacts', () => {
                     articleReplies(status: NORMAL) {
                       createdAt
                     }
+                    articleType
+                    attachmentUrl(variant: THUMBNAIL)
                   }
           }
         ",

--- a/src/liff/components/ArticleCard.stories.svelte
+++ b/src/liff/components/ArticleCard.stories.svelte
@@ -1,15 +1,21 @@
 <script>
   import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
   import ArticleCard from "./ArticleCard.svelte";
+
+  const DEFAULT_ARGS = {
+    article: {
+      replyRequestCount: 1,
+      createdAt: new Date(new Date() - 86400000).toISOString(),
+      articleType: 'TEXT',
+      text: '',
+    }
+  }
 </script>
 
 <Meta
   title="Card/ArticleCard"
   component={ArticleCard}
-  args={{
-    replyRequestCount: 1,
-    createdAt: new Date(new Date() - 86400000),
-  }}
+  args={DEFAULT_ARGS}
 />
 
 <Template let:args>
@@ -18,15 +24,46 @@
 
 <Story
   name="Short text"
-  args={{text: 'Short text\nwith one line break'}}
+  args={{
+    article: {
+      ...DEFAULT_ARGS.article,
+      text: 'Short text\nwith one line break',
+    },
+  }}
 />
 
 <Story
   name="Long text"
-  args={{text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'}}
+  args={{
+    article: {
+      ...DEFAULT_ARGS.article,
+      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    }
+  }}
 />
 
 <Story
   name="Many line breaks"
-  args={{text: 'So\nmany\n\n\nline\nbreaks'}}
+  args={{
+    article: {
+      ...DEFAULT_ARGS.article,
+      text: 'So\nmany\n\n\nline\nbreaks',
+    }
+  }}
 />
+
+<Story name="Image">
+  Vertical
+  <ArticleCard article={{
+    ...DEFAULT_ARGS.article,
+    articleType: 'IMAGE',
+    attachmentUrl: 'https://placekitten.com/600/900'
+  }} />
+
+  Horizontal
+  <ArticleCard article={{
+    ...DEFAULT_ARGS.article,
+    articleType: 'IMAGE',
+    attachmentUrl: 'https://placekitten.com/600/400'
+  }} />
+</Story>

--- a/src/liff/components/ArticleCard.svelte
+++ b/src/liff/components/ArticleCard.svelte
@@ -5,7 +5,13 @@
   const MAX_TEXT_HEIGHT = 100; // px
 
   export let article;
-  const {createdAt, text, replyRequestCount} = article;
+  const {
+    createdAt,
+    text,
+    replyRequestCount,
+    articleType,
+    attachmentUrl,
+  } = article;
   const createdAtStr = createdAt ? format(new Date(createdAt)) : '';
   const firstReportedStr = t`First reported on ${createdAtStr}`;
 
@@ -57,18 +63,29 @@
     color: var(--blue1);
     text-decoration: none;
   }
+  .img {
+    max-width: 100%;
+    max-height: 640px;
+  }
 </style>
-<div class="measurerContainer">
-  <div class="measurer" bind:clientHeight={textHeight}>
-    {text}
+{#if text}
+  <div class="measurerContainer">
+    <div class="measurer" bind:clientHeight={textHeight}>
+      {text}
+    </div>
   </div>
-</div>
+{/if}
 <Card style="--gap: 8px">
   <aside>{firstReportedStr}｜{reportCountText}</aside>
-  <article
-    class:truncated={isTooLong && !isExpanded}
-  >{text}</article>
-  {#if isTooLong }
+  {#if articleType === 'IMAGE'}
+    <img class="img" src={attachmentUrl} alt={text} />
+  {/if}
+  {#if text}
+    <article class:truncated={isTooLong && !isExpanded}>
+      {text}
+    </article>
+  {/if}
+  {#if text && isTooLong }
     <!-- svelte-ignore a11y-missing-attribute -->
     <a class="expandLink" role="button" on:click={handleExpandClick}>
       {isExpanded ? `${t`Show Less`} ▲` : `${t`Show More`} ▼`}

--- a/src/liff/components/ArticleCard.svelte
+++ b/src/liff/components/ArticleCard.svelte
@@ -4,18 +4,16 @@
   import Card from './Card.svelte';
   const MAX_TEXT_HEIGHT = 100; // px
 
-  export let createdAt;
-  const createdAtStr = createdAt ? format(createdAt) : '';
+  export let article;
+  const {createdAt, text, replyRequestCount} = article;
+  const createdAtStr = createdAt ? format(new Date(createdAt)) : '';
   const firstReportedStr = t`First reported on ${createdAtStr}`;
 
-  export let replyRequestCount;
   const reportCountText = ngettext(
     msgid`${replyRequestCount} person reported`,
     `${replyRequestCount} people reported`,
     replyRequestCount
   );
-
-  export let text = '';
 
   // Measured text height.
   // Default to MAX to trigger collapsed view to avoid too much flicker.

--- a/src/liff/components/ViewedArticle.stories.svelte
+++ b/src/liff/components/ViewedArticle.stories.svelte
@@ -30,7 +30,8 @@
   args={{
     article: {
       text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      articleReplies: []
+      articleReplies: [],
+      articleType: 'TEXT',
     }
   }}
 />
@@ -44,7 +45,8 @@
         createdAt: '2020-06-04T00:00:00Z'
       }, {
         createdAt: '2019-06-04T00:00:00Z'
-      }]
+      }],
+      articleType: 'TEXT',
     }
   }}
 />
@@ -58,7 +60,30 @@
         createdAt: '2021-06-12T00:00:00Z'
       }, {
         createdAt: '2019-06-04T00:00:00Z'
-      }]
+      }],
+      articleType: 'TEXT',
+    }
+  }}
+/>
+
+<Story
+  name="Horizontal image"
+  args={{
+    article: {
+      attachmentUrl: 'https://placekitten.com/400/240',
+      articleReplies: [],
+      articleType: 'IMAGE',
+    }
+  }}
+/>
+
+<Story
+  name="Vertical image"
+  args={{
+    article: {
+      attachmentUrl: 'https://placekitten.com/200/240',
+      articleReplies: [],
+      articleType: 'IMAGE',
     }
   }}
 />

--- a/src/liff/components/ViewedArticle.svelte
+++ b/src/liff/components/ViewedArticle.svelte
@@ -58,6 +58,10 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
   }
+  .img {
+    max-width: 100%;
+    max-height: 120px;
+  }
 </style>
 
 <Card class="ViewedArticle-root" on:click>
@@ -78,6 +82,8 @@
   <main>
     {#if !article}
       {t`Loading`}...
+    {:else if article.articleType === 'IMAGE'}
+      <img class="img" src={article.attachmentUrl} alt={article.text} />
     {:else}
       {article.text}
     {/if}

--- a/src/liff/lib.js
+++ b/src/liff/lib.js
@@ -111,6 +111,8 @@ export const getArticlesFromCofacts = async articleIds => {
               articleReplies(status: NORMAL) {
                 createdAt
               }
+              articleType
+              attachmentUrl(variant: THUMBNAIL)
             }`
         )
         .join('\n')}

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -171,6 +171,7 @@
     {t`Suspicious messages`}
   </Header>
   <ArticleCard
+    article={articleData}
     text={articleData.text}
     replyRequestCount={articleData.replyRequestCount}
     createdAt={createdAt}

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -42,7 +42,7 @@
           requestedForReply
           createdAt
           articleType
-          attachmentUrl(type: PREVIEW)
+          attachmentUrl(variant: PREVIEW)
 
           articleReplies(status: NORMAL) {
             ...ArticleReplyCard_articleReply

--- a/src/liff/pages/Article.svelte
+++ b/src/liff/pages/Article.svelte
@@ -41,6 +41,8 @@
           replyRequestCount
           requestedForReply
           createdAt
+          articleType
+          attachmentUrl(type: PREVIEW)
 
           articleReplies(status: NORMAL) {
             ...ArticleReplyCard_articleReply

--- a/src/liff/pages/Articles.svelte
+++ b/src/liff/pages/Articles.svelte
@@ -56,6 +56,8 @@
               articleId
               createdAt
               lastViewedAt
+              articleType
+              attachmentUrl(type: THUMBNAIL)
             }
           }
         }

--- a/src/liff/pages/Articles.svelte
+++ b/src/liff/pages/Articles.svelte
@@ -56,8 +56,6 @@
               articleId
               createdAt
               lastViewedAt
-              articleType
-              attachmentUrl(type: THUMBNAIL)
             }
           }
         }


### PR DESCRIPTION
- `ArticleCard` (Article LIFF) and `ViewedArticle` (Article list) supports image
- Revamp `ArticleCard` to use article as prop
    - so that it can support more article fields without adding more props

## `ArticleCard` and Article LIFF

### Storybook

<img width="658" alt="image" src="https://user-images.githubusercontent.com/108608/193484005-37b9a8c0-8429-40d3-966d-122ec1eff9c8.png">
<img width="655" alt="image" src="https://user-images.githubusercontent.com/108608/193484023-455f9e97-768a-430e-a1ae-b7b1efe4d5a8.png">

### Actual UI
<img width="662" alt="image" src="https://user-images.githubusercontent.com/108608/193865963-86394695-18f7-4238-a23d-d462a24c87c8.png">


## `ViewedArticle` and Article list

### Storybook
<img width="664" alt="image" src="https://user-images.githubusercontent.com/108608/193483955-d53350f8-0a1d-45ba-9767-2be887f3ed37.png">

<img width="660" alt="image" src="https://user-images.githubusercontent.com/108608/193483962-bcd66b13-4c17-42b9-b98b-faeba2bba241.png">

### Actual UI
![image](https://user-images.githubusercontent.com/108608/193866579-ca65edfb-4091-43a5-b090-0fc19b4e22eb.png)

