### PR TITLE
Build and deploy en and ja bot

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,9 +18,17 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        locales:
+          - locale: en_US
+            postfix: -en
+          - locale: zh_TW
+            postfix: -tw
+          - locale: ja
+            postfix: -ja
     env:
       RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/release') && 'latest' || 'dev' }}
-      LOCALE: zh_TW
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -59,9 +67,11 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: cofacts/rumors-line-bot:${{ env.RELEASE_TAG }}-tw
+          tags: cofacts/rumors-line-bot:${{ env.RELEASE_TAG }}-${{ matrix.locales.postfix }}
           build-args: |
-            "LOCALE=${{ env.LOCALE }}"
+            "LOCALE=${{ matrix.locales.locale }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate production .env file
         run: 'curl $ENV_URL -o .env'
         env:
-          ENV_URL: ${{ secrets.PRODUCTION_ENV_URL }}
+          ENV_URL: ${{ secrets.PRODUCTION_ENV_URL }}${{ matrix.locales.postfix }}
         if: ${{ env.RELEASE_TAG == 'latest' }}
 
       - name: Login to Docker Hub
@@ -67,7 +67,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: cofacts/rumors-line-bot:${{ env.RELEASE_TAG }}-${{ matrix.locales.postfix }}
+          tags: cofacts/rumors-line-bot:${{ env.RELEASE_TAG }}${{ matrix.locales.postfix }}
           build-args: |
             "LOCALE=${{ matrix.locales.locale }}"
           cache-from: type=gha

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,4 @@ client_secret.json
 # Used by mongodb docker & GraphQL
 data/
 
-# Tesseract OCR folder
-tmp_image_process
-
 storybook-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ WORKDIR /srv/www
 EXPOSE 5001
 ENTRYPOINT NODE_ENV=production npm start
 
-RUN apk --no-cache add tesseract-ocr tesseract-ocr-data-chi_tra
-
 COPY package.json package-lock.json ecosystem.config.js ./
 COPY i18n i18n
 COPY static static


### PR DESCRIPTION
This PR adds automation that builds english and japanese chatbot.

- Remove tesseract in docker
- change language settings to a matrix
- run under different .env on production

<img width="690" alt="image" src="https://user-images.githubusercontent.com/108608/199319897-c5aafd38-9bb0-42d4-97ef-e52ef22e1d2e.png">

Note: as we don't setup staging-en and staging-ja build-time args, dev-en and dev-ja package shown above actually have bugs regarding LIFF (which relies on build-time config)
