### PR TITLE
Add userid in bq analytics

### DIFF
--- a/src/lib/__tests__/ga.js
+++ b/src/lib/__tests__/ga.js
@@ -71,6 +71,7 @@ it('returns visitor', () => {
           "extra": "{}",
           "messageSource": "user",
           "text": "",
+          "userId": "userId",
         },
       ],
     ]
@@ -109,6 +110,7 @@ it('sets title when title is given', () => {
       "events": Array [],
       "extra": "{}",
       "messageSource": "room",
+      "userId": "userId",
     }
   `);
   // Expect title is sent to BigQuery
@@ -160,6 +162,7 @@ it('sets events', () => {
           "extra": "{}",
           "messageSource": "user",
           "text": "",
+          "userId": "userId",
         },
       ],
     ]

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -52,8 +52,10 @@ export default function ga(
       });
       return visitor.event(evt);
     },
+
     send() {
       insertEventBatch({
+        userId: uuid,
         text: documentTitle,
         messageSource,
         events,

--- a/src/lineContent.ts
+++ b/src/lineContent.ts
@@ -31,6 +31,7 @@ lineContentRouter.get('/', async (ctx) => {
   visitor.send();
 
   insertEventBatch({
+    userId: null,
     createdAt: new Date(),
     text: null,
     messageSource: null,


### PR DESCRIPTION
Related to https://github.com/cofacts/rumors-db/pull/63

This PR sends `userId` to big query. The ID can also be group ID when in group.