### PR TITLE
Fix group message cannot read properties of undefined (reading 'timestamp')

### DIFF
--- a/src/webhook/handlers/__fixtures__/groupHandler.js
+++ b/src/webhook/handlers/__fixtures__/groupHandler.js
@@ -2,7 +2,7 @@ const joinGroup = {
   replyToken: 'nHuyWiB7yP5Zw52FIkcQobQuGDXCTA',
   type: 'join',
   groupId: 'C4a1',
-  otherFields: {
+  webhookEvent: {
     mode: 'active',
     timestamp: 1462629479859,
     source: {
@@ -16,7 +16,7 @@ const textMessage = {
   replyToken: 'nHuyWiB7yP5Zw52FIkcQobQuGDXCTA',
   type: 'message',
   groupId: 'C4a1',
-  otherFields: {
+  webhookEvent: {
     mode: 'active',
     timestamp: 1462629479859,
     message: {
@@ -33,7 +33,7 @@ const expiredTextMessage = {
   replyToken: 'nHuyWiB7yP5Zw52FIkcQobQuGDXCTA',
   type: 'message',
   groupId: 'C4a1',
-  otherFields: {
+  webhookEvent: {
     mode: 'active',
     timestamp: 612921600000,
     message: {

--- a/src/webhook/handlers/__tests__/processGroupEvent.test.js
+++ b/src/webhook/handlers/__tests__/processGroupEvent.test.js
@@ -34,12 +34,12 @@ afterAll(async () => {
 
 describe('processGroupEvent', () => {
   it('should handle join event', async () => {
-    const { type, replyToken, ...otherFields } = messageEvent.joinGroup;
+    const { type, replyToken, ...webhookEvent } = messageEvent.joinGroup;
     const param = {
       replyToken,
       type,
-      groupId: otherFields.source.groupId,
-      otherFields: { ...otherFields },
+      groupId: webhookEvent.source.groupId,
+      webhookEvent: { ...webhookEvent },
     };
     lineClient.get.mockImplementationOnce(() => ({
       count: 55987,
@@ -81,12 +81,12 @@ describe('processGroupEvent', () => {
   });
 
   it('should handle leave event', async () => {
-    const { type, replyToken, ...otherFields } = messageEvent.leaveGroup;
+    const { type, replyToken, ...webhookEvent } = messageEvent.leaveGroup;
     const param = {
       replyToken,
       type,
-      groupId: otherFields.source.groupId,
-      otherFields: { ...otherFields },
+      groupId: webhookEvent.source.groupId,
+      webhookEvent: { ...webhookEvent },
     };
     lineClient.get.mockImplementationOnce(() => ({
       count: 55987,
@@ -121,12 +121,12 @@ describe('processGroupEvent', () => {
   });
 
   it('should handle text message event', async () => {
-    const { type, replyToken, ...otherFields } = messageEvent.textMessage;
+    const { type, replyToken, ...webhookEvent } = messageEvent.textMessage;
     const param = {
       replyToken,
       type,
-      groupId: otherFields.source.groupId,
-      otherFields: { ...otherFields },
+      groupId: webhookEvent.source.groupId,
+      webhookEvent: { ...webhookEvent },
     };
     groupMessage.mockImplementationOnce(() => ({
       groupMessageResult: 'groupMessage result',
@@ -156,13 +156,13 @@ describe('processGroupEvent', () => {
   });
 
   it('should reject expired text message event', async () => {
-    const { type, replyToken, ...otherFields } =
+    const { type, replyToken, ...webhookEvent } =
       messageEvent.expiredTextMessage;
     const param = {
       replyToken,
       type,
-      groupId: otherFields.source.groupId,
-      otherFields: { ...otherFields },
+      groupId: webhookEvent.source.groupId,
+      webhookEvent: { ...webhookEvent },
     };
     groupMessage.mockImplementationOnce(() => ({
       groupMessageResult: 'groupMessage result',
@@ -194,12 +194,12 @@ describe('processGroupEvent', () => {
   });
 
   it('should handle groupMessage error', async () => {
-    const { type, replyToken, ...otherFields } = messageEvent.textMessage;
+    const { type, replyToken, ...webhookEvent } = messageEvent.textMessage;
     const param = {
       replyToken,
       type,
-      groupId: otherFields.source.groupId,
-      otherFields: { ...otherFields },
+      groupId: webhookEvent.source.groupId,
+      webhookEvent: { ...webhookEvent },
     };
     groupMessage.mockImplementationOnce(() =>
       Promise.reject(new Error('Foo error'))

--- a/src/webhook/handlers/groupHandler.js
+++ b/src/webhook/handlers/groupHandler.js
@@ -50,7 +50,7 @@ export default class {
       // Check and exit here because currently we cannot
       // kill or stop a running job outside the jobFunction.
       // see https://github.com/OptimalBits/bull/issues/1950
-      if (isEventExpired(job.data.otherFields.timestamp)) {
+      if (isEventExpired(job.data.webhookEvent.timestamp)) {
         // move job to expired queue and exit
         this.expiredJobQueue.add(job.data, { jobId: job.id });
         return Promise.reject(new TimeoutError('Event expired'));


### PR DESCRIPTION
It's caused by this [commit](https://github.com/cofacts/rumors-line-bot/pull/361/commits/0fb06d6ddca6e366424966384ba1e9a12ddaf2dd#diff-9261e8336ee484199b9b0cc596b54cca0cc3d6eac7dd2eba77042eb4d3d19380R292), `groupHandler.addJob` with a `webhookEvent`.
