### PR TITLE
Fix choosing reply action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run i18n:validate
-      - run: npm run test --ignore-scripts -- --coverage
+      - run: npm run test --ignore-scripts -- --coverage --runInBand
       - name: Update coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -31,8 +31,6 @@ export type ChatbotStateHandlerReturnType = {
 
 /**
  * The data that postback action stores as JSON.
- *
- * @FIXME Replace input: string with something that is more structured
  */
 export type PostbackActionData<T> = {
   input: T;

--- a/src/webhook/__tests__/handlePostback.test.ts
+++ b/src/webhook/__tests__/handlePostback.test.ts
@@ -206,11 +206,6 @@ it('handles ManipulationError fired in handlers', async () => {
 
 it('throws on unknown error', async () => {
   const data: Context = { sessionId: FIXED_DATE, searchedText: '' };
-  const event = {
-    type: 'postback',
-    input: `article-id`,
-  };
-
   choosingArticle.mockImplementationOnce(() =>
     Promise.reject(new Error('Unknown error'))
   );

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.ts.snap
@@ -388,7 +388,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “老榮民有住所，有月退俸，也不需要特別的醫療護理⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -466,7 +466,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV8fXikZyCdS-nWhuhfN\\",\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV8fXikZyCdS-nWhuhfN\\"},\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “慈濟自來有褒有貶，每人有各自的看法。”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -545,7 +545,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--LRZYyCdS-nWhujL9\\",\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--LRZYyCdS-nWhujL9\\"},\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “整個基督教徒的打手，自己不努力去牧人、募款，利⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -623,7 +623,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV8jkRlByCdS-nWhuhiY\\",\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV8jkRlByCdS-nWhuhiY\\"},\\"sessionId\\":1497994017447,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “文章是假的 照片也是盜用我方家人的照片,嚴重影⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -734,7 +734,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應1”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -812,7 +812,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應2”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -890,7 +890,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應3”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -968,7 +968,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應4”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1046,7 +1046,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應5”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1124,7 +1124,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應6”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1202,7 +1202,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV8fXikZyCdS-nWhuhfN\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV8fXikZyCdS-nWhuhfN\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應9”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1280,7 +1280,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應10”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1358,7 +1358,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--O3nfyCdS-nWhujMD\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--O3nfyCdS-nWhujMD\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應11”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1437,7 +1437,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AV--LRZYyCdS-nWhujL9\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AV--LRZYyCdS-nWhujL9\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “回應7。
 ”",
                     "label": "👀 Take a look",
@@ -1557,7 +1557,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AVygFA0RyCdS-nWhuaXY\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AVygFA0RyCdS-nWhuaXY\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “查證這則謠言的過程中，約翰走鹿也發現其實網路早⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -1635,7 +1635,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AVy6LkWIyCdS-nWhuaqu\\",\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"article-id\\",\\"r\\":\\"AVy6LkWIyCdS-nWhuaqu\\"},\\"sessionId\\":0,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “過去台灣只有一個海獸胃腺蟲鑽入胃壁的病例，而且⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",

--- a/src/webhook/handlers/__tests__/__snapshots__/processMedia.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/processMedia.test.js.snap
@@ -197,7 +197,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AVygFA0RyCdS-nWhuaXY\\",\\"sessionId\\":1577836800000,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"image-article-1\\",\\"r\\":\\"AVygFA0RyCdS-nWhuaXY\\"},\\"sessionId\\":1577836800000,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “查證這則謠言的過程中，約翰走鹿也發現其實網路早⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",
@@ -275,7 +275,7 @@ Object {
               "contents": Array [
                 Object {
                   "action": Object {
-                    "data": "{\\"input\\":\\"AVy6LkWIyCdS-nWhuaqu\\",\\"sessionId\\":1577836800000,\\"state\\":\\"CHOOSING_REPLY\\"}",
+                    "data": "{\\"input\\":{\\"a\\":\\"image-article-1\\",\\"r\\":\\"AVy6LkWIyCdS-nWhuaqu\\"},\\"sessionId\\":1577836800000,\\"state\\":\\"CHOOSING_REPLY\\"}",
                     "displayText": "I choose “過去台灣只有一個海獸胃腺蟲鑽入胃壁的病例，而且⋯⋯”",
                     "label": "👀 Take a look",
                     "type": "postback",

--- a/src/webhook/handlers/askingArticleSource.ts
+++ b/src/webhook/handlers/askingArticleSource.ts
@@ -16,7 +16,6 @@ import {
 
 import { TUTORIAL_STEPS } from './tutorial';
 
-
 const inputSchema = z.enum([POSTBACK_NO, POSTBACK_YES]);
 
 /** Postback input type for ASKING_ARTICLE_SOURCE state handler */

--- a/src/webhook/handlers/choosingArticle.ts
+++ b/src/webhook/handlers/choosingArticle.ts
@@ -315,7 +315,7 @@ const choosingArticle: ChatbotPostbackHandler = async (params) => {
                   type: 'button',
                   action: createPostbackAction(
                     `👀 ${t`Take a look`}`,
-                    reply.id,
+                    { a: selectedArticleId, r: reply.id },
                     t`I choose “${displayTextWhenChosen}”`,
                     data.sessionId,
                     'CHOOSING_REPLY'

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -11,7 +11,11 @@ import type {
 } from '@line/bot-sdk';
 import { t, msgid, ngettext } from 'ttag';
 import GraphemeSplitter from 'grapheme-splitter';
+
 import gql from 'src/lib/gql';
+import { getArticleURL, createTypeWords } from 'src/lib/sharedUtils';
+import { sign } from 'src/lib/jwt';
+import { ChatbotState, PostbackActionData } from 'src/types/chatbotState';
 
 import type {
   CreateHighlightContentsHighlightFragment,
@@ -21,26 +25,31 @@ import type {
   CreateAiReplyMutation,
   CreateAiReplyMutationVariables,
 } from 'typegen/graphql';
-import { getArticleURL, createTypeWords } from 'src/lib/sharedUtils';
-import { sign } from 'src/lib/jwt';
-import { ChatbotState, PostbackActionData } from 'src/types/chatbotState';
+
 import type { Input as ChoosingReplyInput } from './choosingReply';
+import type { Input as AskingArticleSourceInput } from './askingArticleSource';
+import type { Input as AskingArticleSubmissionConsentInput } from './askingArticleSubmissionConsent';
 
 const splitter = new GraphemeSplitter();
 
+/**
+ * Maps ChatbotState to the postback action data
+ */
 type StateInputMap = {
   __INIT__: string;
   TUTORIAL: string;
   CHOOSING_ARTICLE: string;
   CHOOSING_REPLY: ChoosingReplyInput;
-  ASKING_ARTICLE_SOURCE: string;
-  ASKING_ARTICLE_SUBMISSION_CONSENT: string;
+  ASKING_ARTICLE_SOURCE: AskingArticleSourceInput;
+  ASKING_ARTICLE_SUBMISSION_CONSENT: AskingArticleSubmissionConsentInput;
   Error: unknown;
 };
 
 /**
+ * Generate a postback action with a payload that the state handler can process properly.
+ *
  * @param label - Postback action button text, max 20 words
- * @param input - Input when pressed
+ * @param input - Input when pressed. The format must match the postback data type for that state.
  * @param displayText - Text to display in chat window.
  * @param sessionId - Current session ID
  * @param state - the state that processes the postback

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -24,8 +24,19 @@ import type {
 import { getArticleURL, createTypeWords } from 'src/lib/sharedUtils';
 import { sign } from 'src/lib/jwt';
 import { ChatbotState, PostbackActionData } from 'src/types/chatbotState';
+import type { Input as ChoosingReplyInput } from './choosingReply';
 
 const splitter = new GraphemeSplitter();
+
+type StateInputMap = {
+  __INIT__: string;
+  TUTORIAL: string;
+  CHOOSING_ARTICLE: string;
+  CHOOSING_REPLY: ChoosingReplyInput;
+  ASKING_ARTICLE_SOURCE: string;
+  ASKING_ARTICLE_SUBMISSION_CONSENT: string;
+  Error: unknown;
+};
 
 /**
  * @param label - Postback action button text, max 20 words
@@ -34,15 +45,15 @@ const splitter = new GraphemeSplitter();
  * @param sessionId - Current session ID
  * @param state - the state that processes the postback
  */
-export function createPostbackAction<INPUT = string>(
+export function createPostbackAction<S extends ChatbotState>(
   label: string,
-  input: INPUT,
+  input: StateInputMap[S],
   displayText: string,
   sessionId: number,
-  state: ChatbotState
+  state: S
 ): Action {
   // Ensure the data type before stringification
-  const data: PostbackActionData<INPUT> = {
+  const data: PostbackActionData<StateInputMap[S]> = {
     input,
     sessionId,
     state,

--- a/src/webhook/index.ts
+++ b/src/webhook/index.ts
@@ -20,7 +20,7 @@ import UserSettings from '../database/models/userSettings';
 import { Request } from 'koa';
 import { MessageEvent, TextEventMessage, WebhookEvent } from '@line/bot-sdk';
 import { Result } from 'src/types/result';
-import { Context, PostbackActionData } from 'src/types/chatbotState';
+import { PostbackActionData } from 'src/types/chatbotState';
 
 const userIdBlacklist = (process.env.USERID_BLACKLIST || '').split(',');
 


### PR DESCRIPTION
This PR fixes [the release blocker found in 20231115 release test](https://g0v.hackmd.io/vAUg0WtvTAi0rzJ7E1spnQ#%E2%9B%94%EF%B8%8F-Release-Blockers).

refactor(webhook): map state and payload in createPostbackAction
- we don't touch PostbackActionData in chatbotState because we don't want to change ChatbotPostbackHandlerParams; which makes calling postback more difficult

refactor(webhook): type yes/no postback handlers
- `return input satisfies never` is to ensure all input enum has its own `case` in switch statement.
- It's called exhaustive switch. Ref: https://stackoverflow.com/a/75217377/1582110

## Screenshot
1. Choose 1st article, list replies for 1st article
2. Choose 2nd article, list replies for 2nd article
3. Choose a reply for 1st article, show link to 1st article
4. Choose a reply for 2nd article, show link to 2nd article

![1700542535241](https://github.com/cofacts/rumors-line-bot/assets/108608/69aeabce-6674-48c9-8360-2acd2c03b766)
![1700542535700](https://github.com/cofacts/rumors-line-bot/assets/108608/bd41ded9-b7ab-4094-a787-8553d2d3413d)

