### PR TITLE
Detect multiple messages sent at once

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,21 @@ module.exports = {
       files: ['**/*.ts'],
       extends: ['plugin:@typescript-eslint/recommended'],
       plugins: ['@typescript-eslint'],
+      rules: {
+        '@typescript-eslint/no-misused-promises': [
+          'error', // Helps capturing errors like if(someAsyncFunc())
+          {
+            checksVoidReturn: false, // Allow setTimeout(async () => {})
+          },
+        ],
+      },
+
+      // Required by rules that requires type information.
+      // Ref: https://typescript-eslint.io/linting/typed-linting/
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: __dirname,
+      },
     },
   ],
 };

--- a/src/graphql/testUtils.js
+++ b/src/graphql/testUtils.js
@@ -1,5 +1,5 @@
 // ./index.js contains imports to redisClient, which should be mocked in unit tests.
-jest.mock('src/lib/redisClient');
+jest.mock('src/lib/redisClient', () => ({}));
 // Avoid loading src/lib/queue, which really connects to redis
 jest.mock('src/lib/queues', () => ({}));
 

--- a/src/lib/__mocks__/redisClient.js
+++ b/src/lib/__mocks__/redisClient.js
@@ -1,4 +1,0 @@
-export default {
-  get: jest.fn(),
-  set: jest.fn(),
-};

--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -23,6 +23,7 @@ function set(key, value) {
 }
 
 function get(key) {
+  /* istanbul ignore if */
   if (typeof key !== 'string') {
     throw new Error('key of `get(key)` must be a string.');
   }
@@ -34,8 +35,7 @@ function get(key) {
       } else {
         try {
           resolve(JSON.parse(reply));
-          /* istanbul ignore next */
-        } catch (e) {
+        } catch (e) /* istanbul ignore next */ {
           // Gracefully fallback, in case the stuff in redis is a mess
           //
           console.error(e);

--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -6,11 +6,13 @@ const client = redis.createClient(
 );
 
 function set(key, value) {
+  /* istanbul ignore if */
   if (typeof key !== 'string') {
     throw new Error('key of `set(key, value)` must be a string.');
   }
   return new Promise((resolve, reject) => {
     client.set(key, JSON.stringify(value), (err, reply) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
@@ -26,11 +28,13 @@ function get(key) {
   }
   return new Promise((resolve, reject) => {
     client.get(key, (err, reply) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
         try {
           resolve(JSON.parse(reply));
+          /* istanbul ignore next */
         } catch (e) {
           // Gracefully fallback, in case the stuff in redis is a mess
           //
@@ -46,30 +50,7 @@ function get(key) {
 function del(key) {
   return new Promise((resolve, reject) => {
     client.del(key, (err, reply) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(reply);
-      }
-    });
-  });
-}
-
-function incr(key) {
-  return new Promise((resolve, reject) => {
-    client.incr(key, (err, reply) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(reply);
-      }
-    });
-  });
-}
-
-function decr(key) {
-  return new Promise((resolve, reject) => {
-    client.decr(key, (err, reply) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
@@ -83,6 +64,7 @@ function decr(key) {
 function push(key, value) {
   return new Promise((resolve, reject) => {
     client.rpush(key, JSON.stringify(value), (err, reply) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
@@ -96,6 +78,7 @@ function push(key, value) {
 function len(key) {
   return new Promise((resolve, reject) => {
     client.llen(key, (err, reply) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
@@ -109,6 +92,7 @@ function len(key) {
 function getList(key) {
   return new Promise((resolve, reject) => {
     client.lrange(key, 0, -1, (err, reply) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
@@ -121,6 +105,7 @@ function getList(key) {
 function quit() {
   return new Promise((resolve, reject) => {
     client.quit((err) => {
+      /* istanbul ignore if */
       if (err) {
         reject(err);
       } else {
@@ -134,8 +119,6 @@ export default {
   set,
   get,
   del,
-  incr,
-  decr,
   push,
   len,
   getList,

--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -79,6 +79,45 @@ function decr(key) {
   });
 }
 
+/** Push value to the list at the specified key */
+function push(key, value) {
+  return new Promise((resolve, reject) => {
+    client.rpush(key, JSON.stringify(value), (err, reply) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(reply);
+      }
+    });
+  });
+}
+
+/** Get length of the list at the specified key */
+function len(key) {
+  return new Promise((resolve, reject) => {
+    client.llen(key, (err, reply) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(reply);
+      }
+    });
+  });
+}
+
+/** Get the list at the specified key */
+function getList(key) {
+  return new Promise((resolve, reject) => {
+    client.lrange(key, 0, -1, (err, reply) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(reply.map((s) => JSON.parse(s)));
+      }
+    });
+  });
+}
+
 function quit() {
   return new Promise((resolve, reject) => {
     client.quit((err) => {
@@ -97,5 +136,8 @@ export default {
   del,
   incr,
   decr,
+  push,
+  len,
+  getList,
   quit,
 };

--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -74,24 +74,15 @@ function push(key, value) {
   });
 }
 
-/** Get length of the list at the specified key */
-function len(key) {
+/**
+ * Get a sublist out of the list at the specified key
+ * @param {string} key
+ * @param {number} start
+ * @param {number} end
+ */
+function range(key, start, end) {
   return new Promise((resolve, reject) => {
-    client.llen(key, (err, reply) => {
-      /* istanbul ignore if */
-      if (err) {
-        reject(err);
-      } else {
-        resolve(reply);
-      }
-    });
-  });
-}
-
-/** Get the list at the specified key */
-function getList(key) {
-  return new Promise((resolve, reject) => {
-    client.lrange(key, 0, -1, (err, reply) => {
+    client.lrange(key, start, end, (err, reply) => {
       /* istanbul ignore if */
       if (err) {
         reject(err);
@@ -120,7 +111,6 @@ export default {
   get,
   del,
   push,
-  len,
-  getList,
+  range,
   quit,
 };

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -105,5 +105,8 @@ export function gaTitle(title) {
     .join('');
 }
 
-export const sleep = async (ms: number) =>
+/**
+ * @param {number} ms
+ */
+export const sleep = async (ms) =>
   new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -104,3 +104,6 @@ export function gaTitle(title) {
     .slice(0, DOCUMENT_TITLE_LENGTH)
     .join('');
 }
+
+export const sleep = async (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -24,6 +24,21 @@ export type Context = {
     }
 );
 
+/** A single messages in the same co-occurrence */
+export type CooccurredMessage =
+  | {
+      type: Extract<
+        MessageEvent['message']['type'],
+        'audio' | 'video' | 'image'
+      >;
+      id: MessageEvent['message']['id'];
+    }
+  | {
+      type: Extract<MessageEvent['message']['type'], 'text'>;
+      /** Searched text that started this search session */
+      searchedText: string;
+    };
+
 export type ChatbotStateHandlerReturnType = {
   data: Context;
   replies: Message[];

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -25,19 +25,21 @@ export type Context = {
 );
 
 /** A single messages in the same co-occurrence */
-export type CooccurredMessage =
+export type CooccurredMessage = {
+  id: MessageEvent['message']['id'];
+} & (
   | {
       type: Extract<
         MessageEvent['message']['type'],
         'audio' | 'video' | 'image'
       >;
-      id: MessageEvent['message']['id'];
     }
   | {
       type: Extract<MessageEvent['message']['type'], 'text'>;
       /** Searched text that started this search session */
-      searchedText: string;
-    };
+      text: string;
+    }
+);
 
 export type ChatbotStateHandlerReturnType = {
   data: Context;

--- a/src/webhook/__tests__/index.ts
+++ b/src/webhook/__tests__/index.ts
@@ -10,6 +10,7 @@ import Koa from 'koa';
 import request from 'supertest';
 import MockDate from 'mockdate';
 
+import { sleep } from 'src/lib/sharedUtils';
 import webhookRouter from '..';
 import originalSingleUserHandler from '../handlers/singleUserHandler';
 import OriginalGroupHandler from '../handlers/groupHandler';
@@ -30,9 +31,6 @@ const mockedAddJob = groupHandlerInstance.addJob as jest.MockedFunction<
 >;
 
 import { WebhookEvent } from '@line/bot-sdk';
-
-const sleep = async (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 beforeAll(() => {
   MockDate.set(612921600000);

--- a/src/webhook/__tests__/index.ts
+++ b/src/webhook/__tests__/index.ts
@@ -1,6 +1,6 @@
 // Mock unused middlewares and instances that leaves open handles
 jest.mock('src/webhook/checkSignatureAndParse');
-jest.mock('src/lib/redisClient');
+jest.mock('src/lib/redisClient', () => ({}));
 
 // Spied functions
 jest.mock('../handlers/groupHandler');

--- a/src/webhook/handlers/__tests__/groupHandler.test.js
+++ b/src/webhook/handlers/__tests__/groupHandler.test.js
@@ -6,6 +6,7 @@ jest.mock('../processGroupEvent');
 import ga from 'src/lib/ga';
 import gql from 'src/lib/gql';
 import lineClient from 'src/webhook/lineClient';
+import { sleep } from 'src/lib/sharedUtils';
 import MockDate from 'mockdate';
 
 import GroupHandler from '../groupHandler';
@@ -419,5 +420,3 @@ const isQueueIdle = async (q) => {
     return (acc = v === 0 && acc);
   }, true);
 };
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -3,6 +3,7 @@ import UserSettings from 'src/database/models/userSettings';
 import originalLineClient from 'src/webhook/lineClient';
 import originalRedis from 'src/lib/redisClient';
 import originalGa from 'src/lib/ga';
+import { sleep, VIEW_ARTICLE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
 import type { MockedGa } from 'src/lib/__mocks__/ga';
 
 import singleUserHandler from '../singleUserHandler';
@@ -10,7 +11,6 @@ import originalInitState from '../initState';
 import originalHandlePostback from '../handlePostback';
 import { TUTORIAL_STEPS } from '../tutorial';
 
-import { VIEW_ARTICLE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
 import { MessageEvent, PostbackEvent, TextEventMessage } from '@line/bot-sdk';
 import { Context } from 'src/types/chatbotState';
 
@@ -31,9 +31,6 @@ const handlePostback = originalHandlePostback as jest.MockedFunction<
 const lineClient = originalLineClient as jest.Mocked<typeof originalLineClient>;
 const redis = originalRedis as jest.Mocked<typeof originalRedis>;
 const ga = originalGa as MockedGa;
-
-const sleep = async (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 // If session is renewed, sessionId will become this value
 const NOW = 1561982400000;

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -286,7 +286,7 @@ function createTextMessageEvent(
   return {
     type: 'message',
     message: {
-      id: '',
+      id: Buffer.from(input).toString('base64'),
       type: 'text',
       text: input,
     },
@@ -442,7 +442,8 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
   expect(redis.range(REDIS_BATCH_KEY, 0, -1)).resolves.toMatchInlineSnapshot(`
     Array [
       Object {
-        "searchedText": "Newly forwarded message",
+        "id": "TmV3bHkgZm9yd2FyZGVkIG1lc3NhZ2U=",
+        "text": "Newly forwarded message",
         "type": "text",
       },
     ]

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -439,7 +439,7 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
   await sleep(100); // Wait for async redis to be processed
 
   // Expect the message is added to batch
-  expect(redis.getList(REDIS_BATCH_KEY)).resolves.toMatchInlineSnapshot(`
+  expect(redis.range(REDIS_BATCH_KEY, 0, -1)).resolves.toMatchInlineSnapshot(`
     Array [
       Object {
         "searchedText": "Newly forwarded message",
@@ -452,7 +452,7 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
   await processingPromise;
 
   // Expect batch is cleared
-  expect(redis.getList(REDIS_BATCH_KEY)).resolves.toMatchInlineSnapshot(
+  expect(redis.range(REDIS_BATCH_KEY, 0, -1)).resolves.toMatchInlineSnapshot(
     `Array []`
   );
 

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -1,12 +1,12 @@
 import MockDate from 'mockdate';
 import UserSettings from 'src/database/models/userSettings';
 import originalLineClient from 'src/webhook/lineClient';
-import originalRedis from 'src/lib/redisClient';
 import originalGa from 'src/lib/ga';
 import { sleep, VIEW_ARTICLE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
 import type { MockedGa } from 'src/lib/__mocks__/ga';
+import redis from 'src/lib/redisClient';
 
-import singleUserHandler from '../singleUserHandler';
+import singleUserHandler, { getRedisBatchKey } from '../singleUserHandler';
 import originalInitState from '../initState';
 import originalHandlePostback from '../handlePostback';
 import { TUTORIAL_STEPS } from '../tutorial';
@@ -15,11 +15,12 @@ import { MessageEvent, PostbackEvent, TextEventMessage } from '@line/bot-sdk';
 import { Context } from 'src/types/chatbotState';
 
 jest.mock('src/webhook/lineClient');
-jest.mock('src/lib/redisClient');
 jest.mock('src/lib/ga');
 
 jest.mock('../initState');
 jest.mock('../handlePostback');
+
+const redisGet = jest.spyOn(redis, 'get');
 
 const initState = originalInitState as jest.MockedFunction<
   typeof originalInitState
@@ -29,7 +30,6 @@ const handlePostback = originalHandlePostback as jest.MockedFunction<
 >;
 
 const lineClient = originalLineClient as jest.Mocked<typeof originalLineClient>;
-const redis = originalRedis as jest.Mocked<typeof originalRedis>;
 const ga = originalGa as MockedGa;
 
 // If session is renewed, sessionId will become this value
@@ -38,8 +38,7 @@ const NOW = 1561982400000;
 beforeEach(() => {
   initState.mockClear();
   handlePostback.mockClear();
-  redis.get.mockClear();
-  redis.set.mockClear();
+  redisGet.mockClear();
   lineClient.post.mockClear();
   ga.clearAllMocks();
 
@@ -48,6 +47,10 @@ beforeEach(() => {
 
 afterEach(() => {
   MockDate.reset();
+});
+
+afterAll(async () => {
+  await redis.quit();
 });
 
 const userId = 'U4af4980629';
@@ -158,7 +161,7 @@ it('ignores sticker events', async () => {
 it('handles postbacks', async () => {
   const sessionId = 123;
 
-  redis.get.mockImplementationOnce(
+  redisGet.mockImplementationOnce(
     (): Promise<{ data: Context }> =>
       Promise.resolve({
         data: { sessionId, searchedText: '' },
@@ -185,7 +188,12 @@ it('handles postbacks', async () => {
   handlePostback.mockImplementationOnce((data) => {
     return Promise.resolve({
       context: { data },
-      replies: [],
+      replies: [
+        {
+          type: 'text',
+          text: 'Postback results here',
+        },
+      ],
     });
   });
 
@@ -208,11 +216,29 @@ it('handles postbacks', async () => {
       ],
     ]
   `);
+
+  // Expect postback results are sent to LINE
+  expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "/message/reply",
+        Object {
+          "messages": Array [
+            Object {
+              "text": "Postback results here",
+              "type": "text",
+            },
+          ],
+          "replyToken": "",
+        },
+      ],
+    ]
+  `);
 });
 
 it('rejects outdated postback events', async () => {
   // Simulate context removed by Redis
-  redis.get.mockImplementationOnce(() => Promise.resolve(null));
+  redisGet.mockImplementationOnce(() => Promise.resolve(null));
 
   const event: PostbackEvent = {
     type: 'postback',
@@ -282,7 +308,12 @@ it('forwards to CHOOSING_ARTICLE when VIEW_ARTICLE_PREFIX is sent', async () => 
   handlePostback.mockImplementationOnce((data) => {
     return Promise.resolve({
       context: { data },
-      replies: [],
+      replies: [
+        {
+          type: 'text',
+          text: 'Choosing article resp',
+        },
+      ],
     });
   });
 
@@ -290,6 +321,7 @@ it('forwards to CHOOSING_ARTICLE when VIEW_ARTICLE_PREFIX is sent', async () => 
 
   await sleep(500);
 
+  // Expect handlePostback is called with synthetic CHOOSING_ARTICLE postback
   expect(handlePostback).toHaveBeenCalledTimes(1);
   expect(handlePostback.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -304,6 +336,24 @@ it('forwards to CHOOSING_ARTICLE when VIEW_ARTICLE_PREFIX is sent', async () => 
           "state": "CHOOSING_ARTICLE",
         },
         "user-id",
+      ],
+    ]
+  `);
+
+  // Expect replies are sent
+  expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "/message/reply",
+        Object {
+          "messages": Array [
+            Object {
+              "text": "Choosing article resp",
+              "type": "text",
+            },
+          ],
+          "replyToken": "",
+        },
       ],
     ]
   `);
@@ -317,7 +367,12 @@ it('shows reply list when article URL is sent', async () => {
   handlePostback.mockImplementationOnce((data) => {
     return Promise.resolve({
       context: { data },
-      replies: [],
+      replies: [
+        {
+          type: 'text',
+          text: 'Choosing article resp',
+        },
+      ],
     });
   });
 
@@ -325,6 +380,7 @@ it('shows reply list when article URL is sent', async () => {
 
   await sleep(500);
 
+  // Expect handlePostback is called with synthetic CHOOSING_ARTICLE postback
   expect(handlePostback).toHaveBeenCalledTimes(1);
   expect(handlePostback.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -342,6 +398,24 @@ it('shows reply list when article URL is sent', async () => {
       ],
     ]
   `);
+
+  // Expect replies are sent
+  expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "/message/reply",
+        Object {
+          "messages": Array [
+            Object {
+              "text": "Choosing article resp",
+              "type": "text",
+            },
+          ],
+          "replyToken": "",
+        },
+      ],
+    ]
+  `);
 });
 
 it('Resets session on free-form input, triggers fast-forward', async () => {
@@ -351,12 +425,38 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
   initState.mockImplementationOnce(({ data }) => {
     return Promise.resolve({
       data,
-      replies: [],
+      replies: [
+        {
+          type: 'text',
+          text: 'Replies here',
+        },
+      ],
     });
   });
 
-  await singleUserHandler('user-id', event);
+  const REDIS_BATCH_KEY = getRedisBatchKey('user-id');
+  const processingPromise = singleUserHandler('user-id', event);
+  await sleep(100); // Wait for async redis to be processed
 
+  // Expect the message is added to batch
+  expect(redis.getList(REDIS_BATCH_KEY)).resolves.toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "searchedText": "Newly forwarded message",
+        "type": "text",
+      },
+    ]
+  `);
+
+  // Wait for the whole batch process to finish
+  await processingPromise;
+
+  // Expect batch is cleared
+  expect(redis.getList(REDIS_BATCH_KEY)).resolves.toMatchInlineSnapshot(
+    `Array []`
+  );
+
+  // Expect initState is called
   expect(initState).toHaveBeenCalledTimes(1);
   expect(initState.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -371,6 +471,24 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
       ],
     ]
   `);
+
+  // Expect replies are sent
+  expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "/message/reply",
+        Object {
+          "messages": Array [
+            Object {
+              "text": "Replies here",
+              "type": "text",
+            },
+          ],
+          "replyToken": "",
+        },
+      ],
+    ]
+  `);
 });
 
 it('handles tutorial trigger from rich menu', async () => {
@@ -379,13 +497,19 @@ it('handles tutorial trigger from rich menu', async () => {
   handlePostback.mockImplementationOnce((data) => {
     return Promise.resolve({
       context: { data },
-      replies: [],
+      replies: [
+        {
+          type: 'text',
+          text: 'Tutorial here',
+        },
+      ],
     });
   });
 
   await singleUserHandler('user-id', event);
   await sleep(500);
 
+  // Expect handlePostback is called with synthetic TUTORIAL postback
   expect(handlePostback).toHaveBeenCalledTimes(1);
   expect(handlePostback.mock.calls).toMatchInlineSnapshot(`
     Array [
@@ -400,6 +524,24 @@ it('handles tutorial trigger from rich menu', async () => {
           "state": "TUTORIAL",
         },
         "user-id",
+      ],
+    ]
+  `);
+
+  // Expect replies are sent
+  expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "/message/reply",
+        Object {
+          "messages": Array [
+            Object {
+              "text": "Tutorial here",
+              "type": "text",
+            },
+          ],
+          "replyToken": "",
+        },
       ],
     ]
   `);

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -27,7 +27,12 @@ import {
 const CIRCLED_DIGITS = '⓪①②③④⑤⑥⑦⑧⑨⑩⑪';
 const SIMILARITY_THRESHOLD = 0.95;
 
-export default async function (event: MessageEvent, userId: string) {
+export default async function (
+  event: {
+    message: Pick<MessageEvent['message'], 'id' | 'type'>;
+  },
+  userId: string
+) {
   const proxyUrl = getLineContentProxyURL(event.message.id);
   console.log(`Media url: ${proxyUrl}`);
 

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -84,7 +84,7 @@ const singleUserHandler = async (
     data: { sessionId: Date.now() },
   };
 
-  const REDIS_BATCH_KEY = `${userId}:batch`;
+  const REDIS_BATCH_KEY = getRedisBatchKey(userId);
 
   // Helper functions in singleUserHandler that indicates the end of processing
   //
@@ -353,5 +353,9 @@ const singleUserHandler = async (
     }
   }
 };
+
+export function getRedisBatchKey(userId: string) {
+  return `${userId}:batch`;
+}
 
 export default singleUserHandler;

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -186,6 +186,7 @@ const singleUserHandler = async (
     if (messages.length !== 1) {
       // TODO: initiate multi-message processing here
       //
+      await sleep(1000); // Simulate multi-message processing and see if more message in batch.
       return send(
         {
           context,


### PR DESCRIPTION
> Part of article group design: https://g0v.hackmd.io/@cofacts/rd/%2Ff_Ze19PhQuqx_fzOAOkohQ

Implements the batched messages
- Pure text message (not commands) and media messages now are pushed to the batch
- When the batch times out, we process the batch and assign a new search session (already done in existing handlers)
- Under the hood, it is implemented as a [redis list](https://redis.io/docs/data-types/lists/)
    - Each item is in `CooccurredMessage` structure, which contains the same amount of the information in current `Context`

More tests added to `singleUserHandler`
- Remove redis mock to simplify tests; we already have redis set up during tests.
- Test if replies returned by (mocked) handlers are really being sent

## 2 messages
![image](https://github.com/cofacts/rumors-line-bot/assets/108608/619e446f-5dd9-44ab-a61b-f678afcd141f)


## 1 message still works
![image](https://github.com/cofacts/rumors-line-bot/assets/108608/0001bb8e-5f8a-469f-b1dd-73d1dd3d204b)
