### PR TITLE
Revamp chatbot context to support multiple messages (cooccurrences)

### DIFF
--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -10,19 +10,24 @@ export type ChatbotState =
   | 'Error';
 
 export type LegacyContext = {
-  /** Used to differientiate different search sessions (searched text or media) */
-  sessionId: number;
-} & (
-  | {
-      /** Searched multi-media message that started this search session */
-      messageId: MessageEvent['message']['id'];
-      messageType: MessageEvent['message']['type'];
-    }
-  | {
-      /** Searched text that started this search session */
-      searchedText: string;
-    }
-);
+  data: {
+    /** Used to differientiate different search sessions (searched text or media) */
+    sessionId: number;
+  } & (
+    | {
+        /** Searched multi-media message that started this search session */
+        messageId: MessageEvent['message']['id'];
+        messageType: Extract<
+          MessageEvent['message']['type'],
+          'audio' | 'video' | 'image'
+        >;
+      }
+    | {
+        /** Searched text that started this search session */
+        searchedText: string;
+      }
+  );
+};
 
 export type Context = {
   /** Used to differientiate different search sessions (searched text or media) */

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -9,7 +9,7 @@ export type ChatbotState =
   | 'ASKING_ARTICLE_SUBMISSION_CONSENT'
   | 'Error';
 
-export type Context = {
+export type LegacyContext = {
   /** Used to differientiate different search sessions (searched text or media) */
   sessionId: number;
 } & (
@@ -23,6 +23,12 @@ export type Context = {
       searchedText: string;
     }
 );
+
+export type Context = {
+  /** Used to differientiate different search sessions (searched text or media) */
+  sessionId: number;
+  msgs: ReadonlyArray<CooccurredMessage>;
+};
 
 /** A single messages in the same co-occurrence */
 export type CooccurredMessage = {
@@ -41,8 +47,12 @@ export type CooccurredMessage = {
     }
 );
 
-export type ChatbotStateHandlerReturnType = {
-  data: Context;
+/** Result of handler or processors */
+export type Result = {
+  /** The new context to set after processing the event */
+  context: Context;
+
+  /** The messages to send to the user as reply */
   replies: Message[];
 };
 
@@ -56,8 +66,8 @@ export type PostbackActionData<T> = {
 };
 
 export type ChatbotPostbackHandlerParams<T = unknown> = {
-  /** Data stored in Chatbot context */
-  data: Context;
+  /** Chatbot context */
+  context: Context;
   /** Data in postback payload */
   postbackData: PostbackActionData<T>;
   userId: string;
@@ -68,4 +78,4 @@ export type ChatbotPostbackHandlerParams<T = unknown> = {
  */
 export type ChatbotPostbackHandler<T = unknown> = (
   params: ChatbotPostbackHandlerParams<T>
-) => Promise<ChatbotStateHandlerReturnType>;
+) => Promise<Result>;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,9 +1,0 @@
-import { Message } from '@line/bot-sdk';
-import { Context } from './chatbotState';
-
-export declare type Result = {
-  context: {
-    data: Partial<Context>;
-  };
-  replies: Message[];
-};

--- a/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.ts.snap
@@ -147,8 +147,14 @@ Array [
 
 exports[`should submit article if user agrees to submit: has AI reply 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "Some text forwarded by the user",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "Some text forwarded by the user",
+        "type": "text",
+      },
+    ],
     "sessionId": 1577923200000,
   },
   "replies": Array [
@@ -325,8 +331,14 @@ Object {
 
 exports[`should submit article if user agrees to submit: has no AI reply 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "Some text forwarded by the user",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "Some text forwarded by the user",
+        "type": "text",
+      },
+    ],
     "sessionId": 1577923200000,
   },
   "replies": Array [
@@ -475,10 +487,13 @@ Object {
 
 exports[`should submit image article if user agrees to submit 1`] = `
 Object {
-  "data": Object {
-    "messageId": "6530038889933",
-    "messageType": "image",
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "6530038889933",
+        "type": "image",
+      },
+    ],
     "sessionId": 1577923200000,
   },
   "replies": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.ts.snap
@@ -2,8 +2,14 @@
 
 exports[`should ask users if they want to submit article when user say not found 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "這一篇文章確實是一個轉傳文章，他夠長，看起來很轉傳，但是使用者覺得資料庫裡沒有。",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "這一篇文章確實是一個轉傳文章，他夠長，看起來很轉傳，但是使用者覺得資料庫裡沒有。",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -85,9 +91,13 @@ May I ask you a quick question?",
 
 exports[`should ask users if they want to submit image article when user say not found 1`] = `
 Object {
-  "data": Object {
-    "messageId": "6530038889933",
-    "messageType": "image",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "6530038889933",
+        "type": "image",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -198,8 +208,14 @@ Array [
 
 exports[`should select article and choose the only one reply for user 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -325,8 +341,14 @@ https://dev.cofacts.tw/article/article-id",
 
 exports[`should select article and have OPINIONATED and NOT_ARTICLE replies 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -671,8 +693,14 @@ Object {
 
 exports[`should select article and slice replies when over 10 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -1490,13 +1518,19 @@ Object {
 
 exports[`should select article by articleId 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "《緊急通知》
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "《緊急通知》
 台北馬偕醫院傳來訊息：
 資深醫生（林清風）傳來：「請大家以後千萬不要再吃生魚片了！」
 因為最近已經發現- 好多病人因為吃了生魚片，胃壁附著《海獸胃腺蟲》，大小隻不一定，有的病人甚至胃壁上滿滿都是無法夾出來，驅蟲藥也很難根治，罹患機率每個國家的人都一樣。
 尤其；鮭魚的含蟲量最高、最可怕！
 請傳給朋友，讓他們有所警惕!",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -1683,8 +1717,14 @@ Object {
 
 exports[`should select article with no replies: has AI reply 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "老司機車裡總備一塊香皂，知道內情的新手默默也準備了一塊",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "老司機車裡總備一塊香皂，知道內情的新手默默也準備了一塊",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -1862,8 +1902,14 @@ Don’t trust the message just yet!",
 
 exports[`should select article with no replies: has no AI reply 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "老司機車裡總備一塊香皂，知道內情的新手默默也準備了一塊",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "老司機車裡總備一塊香皂，知道內情的新手默默也準備了一塊",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingReply.test.ts.snap
@@ -243,8 +243,14 @@ Array [
 
 exports[`should select reply by replyId should handle the case with just one reply 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "貼圖",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "貼圖",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [
@@ -370,8 +376,14 @@ https://dev.cofacts.tw/article/AWDZYXxAyCdS-nWhumlz",
 
 exports[`should select reply by replyId should handle the case with multiple replies 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "貼圖",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "foo",
+        "text": "貼圖",
+        "type": "text",
+      },
+    ],
     "sessionId": 0,
   },
   "replies": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/initState.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/initState.test.ts.snap
@@ -2,8 +2,14 @@
 
 exports[`article found 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "計程車上有裝悠遊卡感應器，老人悠悠卡可以享受優惠部分由政府補助，不影響司機收入",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "計程車上有裝悠遊卡感應器，老人悠悠卡可以享受優惠部分由政府補助，不影響司機收入",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -161,8 +167,14 @@ Please choose the version that looks the most similar👇",
 
 exports[`articles found with high similarity 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "YouTube · 寻找健康人生",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "YouTube · 寻找健康人生",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -348,8 +360,14 @@ Please choose the version that looks the most similar👇",
 
 exports[`input matches dialogflow intent search article when input length > 10 and intentDetectionConfidence != 1 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "零一二三四五六七八九十",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "零一二三四五六七八九十",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -431,8 +449,14 @@ May I ask you a quick question?",
 
 exports[`input matches dialogflow intent uses dialogflow response when input length < 10 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "你好",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "你好",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -446,8 +470,14 @@ Object {
 
 exports[`input matches dialogflow intent uses dialogflow response when input length > 10 and intentDetectionConfidence = 1 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "零一二三四五六七八九十",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "零一二三四五六七八九十",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -461,8 +491,14 @@ Object {
 
 exports[`only one article found with high similarity and choose for user 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "YouTube · 寻找健康人生",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "YouTube · 寻找健康人生",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -613,8 +649,14 @@ Don’t trust the message just yet!",
 
 exports[`should handle message matches only hyperlinks 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "YouTube · 寻找健康人生",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "YouTube · 寻找健康人生",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -920,8 +962,14 @@ title2 title2 title2 ",
 
 exports[`should handle text not found 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "YouTube · 寻找健康人生 驚！大批香蕉受到愛滋血污染！這種香蕉千萬不要吃！吃到可能會被 ...",
+  "context": Object {
+    "msgs": Array [
+      Object {
+        "id": "abc",
+        "text": "YouTube · 寻找健康人生 驚！大批香蕉受到愛滋血污染！這種香蕉千萬不要吃！吃到可能會被 ...",
+        "type": "text",
+      },
+    ],
     "sessionId": 1497994017447,
   },
   "replies": Array [

--- a/src/webhook/handlers/__tests__/__snapshots__/processMedia.test.js.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/processMedia.test.js.snap
@@ -3,12 +3,13 @@
 exports[`one article found (not identical) 1`] = `
 Object {
   "context": Object {
-    "data": Object {
-      "messageId": "6270464463537",
-      "messageType": "image",
-      "searchedText": "",
-      "sessionId": 1577836800000,
-    },
+    "msgs": Array [
+      Object {
+        "id": "6270464463537",
+        "type": "image",
+      },
+    ],
+    "sessionId": 1577836800000,
   },
   "replies": Array [
     Object {
@@ -132,12 +133,13 @@ Please choose the version that looks the most similar👇",
 exports[`one identical article found and choose for user 1`] = `
 Object {
   "context": Object {
-    "data": Object {
-      "messageId": "6270464463537",
-      "messageType": "image",
-      "searchedText": "",
-      "sessionId": 1577836800000,
-    },
+    "msgs": Array [
+      Object {
+        "id": "6270464463537",
+        "type": "image",
+      },
+    ],
+    "sessionId": 1577836800000,
   },
   "replies": Array [
     Object {
@@ -324,12 +326,13 @@ Object {
 exports[`one identical image and similar text found 1`] = `
 Object {
   "context": Object {
-    "data": Object {
-      "messageId": "6270464463537",
-      "messageType": "image",
-      "searchedText": "",
-      "sessionId": 1577836800000,
-    },
+    "msgs": Array [
+      Object {
+        "id": "6270464463537",
+        "type": "image",
+      },
+    ],
+    "sessionId": 1577836800000,
   },
   "replies": Array [
     Object {
@@ -466,12 +469,13 @@ Please choose the version that looks the most similar👇",
 exports[`should handle image not found 1`] = `
 Object {
   "context": Object {
-    "data": Object {
-      "messageId": "6530038889933",
-      "messageType": "image",
-      "searchedText": "",
-      "sessionId": 1577836800000,
-    },
+    "msgs": Array [
+      Object {
+        "id": "6530038889933",
+        "type": "image",
+      },
+    ],
+    "sessionId": 1577836800000,
   },
   "replies": Array [
     Object {
@@ -570,12 +574,13 @@ Do you want someone to fact-check this message?",
 exports[`twelve articles found 1`] = `
 Object {
   "context": Object {
-    "data": Object {
-      "messageId": "6530038889933",
-      "messageType": "image",
-      "searchedText": "",
-      "sessionId": 1577836800000,
-    },
+    "msgs": Array [
+      Object {
+        "id": "6530038889933",
+        "type": "image",
+      },
+    ],
+    "sessionId": 1577836800000,
   },
   "replies": Array [
     Object {

--- a/src/webhook/handlers/__tests__/__snapshots__/tutorial.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/tutorial.test.ts.snap
@@ -257,8 +257,8 @@ Object {
 
 exports[`should handle EXPLAN_CHATBOT_FLOW_AND_PROVIDE_PERMISSION_SETUP 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -354,8 +354,8 @@ Object {
 
 exports[`should handle PROVIDE_PERMISSION_SETUP 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -445,8 +445,8 @@ Object {
 
 exports[`should handle PROVIDE_PERMISSION_SETUP_WITH_EXPLANATION 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -528,8 +528,8 @@ You can still use Cofacts without granting me this permission. When we ask for f
 
 exports[`should handle RICH_MENU 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -740,8 +740,8 @@ Object {
 
 exports[`should handle SETUP_DONE 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -799,8 +799,8 @@ Object {
 
 exports[`should handle SETUP_LATER 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [
@@ -862,8 +862,8 @@ Object {
 
 exports[`should handle SIMULATE_FORWARDING_MESSAGE 1`] = `
 Object {
-  "data": Object {
-    "searchedText": "",
+  "context": Object {
+    "msgs": Array [],
     "sessionId": 1497994017447,
   },
   "replies": Array [

--- a/src/webhook/handlers/__tests__/askingArticleSource.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSource.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 it('throws on incorrect input', async () => {
   const incorrectParam: ChatbotPostbackHandlerParams = {
-    data: { sessionId: 0, searchedText: 'foo' },
+    context: { sessionId: 0, msgs: [{ id: 'foo', type: 'text', text: 'foo' }] },
     postbackData: {
       sessionId: 0,
       state: 'ASKING_ARTICLE_SOURCE',
@@ -30,7 +30,7 @@ it('throws on incorrect input', async () => {
 
 it('returns instructions if user did not forward the whole message', async () => {
   const didNotForwardParam: ChatbotPostbackHandlerParams = {
-    data: { searchedText: 'foo', sessionId: 0 },
+    context: { sessionId: 0, msgs: [{ id: 'foo', type: 'text', text: 'foo' }] },
     postbackData: {
       sessionId: 0,
       state: 'ASKING_ARTICLE_SOURCE',
@@ -212,7 +212,7 @@ it('returns instructions if user did not forward the whole message', async () =>
 
 it('sends user submission consent if user forwarded the whole message', async () => {
   const didForwardParam: ChatbotPostbackHandlerParams = {
-    data: { searchedText: 'foo', sessionId: 0 },
+    context: { sessionId: 0, msgs: [{ id: 'foo', type: 'text', text: 'foo' }] },
     postbackData: {
       sessionId: 0,
       state: 'ASKING_ARTICLE_SOURCE',

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 
 it('throws on incorrect input', async () => {
   const incorrectParam: ChatbotPostbackHandlerParams = {
-    data: { sessionId: 0, searchedText: 'foo' },
+    context: { sessionId: 0, msgs: [] },
     postbackData: {
       sessionId: 0,
       state: 'ASKING_ARTICLE_SUBMISSION_CONSENT',
@@ -47,9 +47,11 @@ it('throws on incorrect input', async () => {
 it('should thank the user if user does not agree to submit', async () => {
   const inputSession = new Date('2020-01-01T18:10:18.314Z').getTime();
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: inputSession,
-      searchedText: 'Some text forwarded by the user',
+      msgs: [
+        { id: 'foo', type: 'text', text: 'Some text forwarded by the user' },
+      ],
     },
     postbackData: {
       sessionId: inputSession,
@@ -87,9 +89,11 @@ it('should thank the user if user does not agree to submit', async () => {
 it('should submit article if user agrees to submit', async () => {
   const inputSession = new Date('2020-01-01T18:10:18.314Z').getTime();
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: inputSession,
-      searchedText: 'Some text forwarded by the user',
+      msgs: [
+        { id: 'foo', type: 'text', text: 'Some text forwarded by the user' },
+      ],
     },
     postbackData: {
       sessionId: inputSession,
@@ -108,7 +112,7 @@ it('should submit article if user agrees to submit', async () => {
   expect(gql.__finished()).toBe(true);
 
   expect(result).toMatchSnapshot('has AI reply');
-  expect(result.data.sessionId).not.toEqual(inputSession);
+  expect(result.context.sessionId).not.toEqual(inputSession);
   expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
@@ -137,11 +141,9 @@ it('should submit article if user agrees to submit', async () => {
 it('should submit image article if user agrees to submit', async () => {
   const inputSession = new Date('2020-01-01T18:10:18.314Z').getTime();
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: inputSession,
-      searchedText: '',
-      messageId: '6530038889933',
-      messageType: 'image',
+      msgs: [{ id: '6530038889933', type: 'image' }],
     },
     postbackData: {
       sessionId: inputSession,
@@ -158,7 +160,7 @@ it('should submit image article if user agrees to submit', async () => {
   expect(gql.__finished()).toBe(true);
 
   expect(result).toMatchSnapshot();
-  expect(result.data.sessionId).not.toEqual(inputSession);
+  expect(result.context.sessionId).not.toEqual(inputSession);
   expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
@@ -176,9 +178,11 @@ it('should submit image article if user agrees to submit', async () => {
 it('should create a UserArticleLink when creating a Article', async () => {
   const userId = 'user-id-0';
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: 'Some text forwarded by the user',
+      msgs: [
+        { id: 'foo', type: 'text', text: 'Some text forwarded by the user' },
+      ],
     },
     postbackData: {
       sessionId: 0,
@@ -201,9 +205,11 @@ it('should create a UserArticleLink when creating a Article', async () => {
 it('should ask user to turn on notification settings if they did not turn it on after creating an Article', async () => {
   const userId = 'user-id-0';
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: 'Some text forwarded by the user',
+      msgs: [
+        { id: 'foo', type: 'text', text: 'Some text forwarded by the user' },
+      ],
     },
     postbackData: {
       sessionId: 0,

--- a/src/webhook/handlers/__tests__/choosingArticle.test.ts
+++ b/src/webhook/handlers/__tests__/choosingArticle.test.ts
@@ -32,10 +32,15 @@ it('should select article by articleId', async () => {
   gql.__push(apiGetArticleResult.selectedArticleId);
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText:
-        '《緊急通知》\n台北馬偕醫院傳來訊息：\n資深醫生（林清風）傳來：「請大家以後千萬不要再吃生魚片了！」\n因為最近已經發現- 好多病人因為吃了生魚片，胃壁附著《海獸胃腺蟲》，大小隻不一定，有的病人甚至胃壁上滿滿都是無法夾出來，驅蟲藥也很難根治，罹患機率每個國家的人都一樣。\n尤其；鮭魚的含蟲量最高、最可怕！\n請傳給朋友，讓他們有所警惕!',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: '《緊急通知》\n台北馬偕醫院傳來訊息：\n資深醫生（林清風）傳來：「請大家以後千萬不要再吃生魚片了！」\n因為最近已經發現- 好多病人因為吃了生魚片，胃壁附著《海獸胃腺蟲》，大小隻不一定，有的病人甚至胃壁上滿滿都是無法夾出來，驅蟲藥也很難根治，罹患機率每個國家的人都一樣。\n尤其；鮭魚的含蟲量最高、最可怕！\n請傳給朋友，讓他們有所警惕!',
+        },
+      ],
     },
     postbackData: {
       sessionId: 0,
@@ -81,7 +86,7 @@ it('throws ManipulationError when articleId is not valid', async () => {
   gql.__push({ data: { GetArticle: null } });
 
   const params: ChatbotPostbackHandlerParams = {
-    data: { sessionId: 0, searchedText: '' },
+    context: { sessionId: 0, msgs: [] },
     postbackData: {
       sessionId: 0,
       state: 'CHOOSING_ARTICLE',
@@ -100,10 +105,15 @@ it('should select article and have OPINIONATED and NOT_ARTICLE replies', async (
   gql.__push(apiGetArticleResult.multipleReplies);
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 1497994017447,
-      searchedText:
-        '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',
+        },
+      ],
     },
     postbackData: {
       input: 'article-id',
@@ -168,9 +178,15 @@ it('should select article with no replies', async () => {
   gql.__push(apiGetArticleResult.createOrUpdateReplyRequest);
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: '老司機車裡總備一塊香皂，知道內情的新手默默也準備了一塊',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: '老司機車裡總備一塊香皂，知道內情的新手默默也準備了一塊',
+        },
+      ],
     },
     postbackData: {
       input: 'article-id',
@@ -223,10 +239,15 @@ it('should select article and choose the only one reply for user', async () => {
   gql.__push(apiGetReplyResult.oneReply2);
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText:
-        'Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: 'Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply',
+        },
+      ],
     },
     postbackData: {
       input: 'article-id',
@@ -269,10 +290,15 @@ it('should select article and choose the only one reply for user', async () => {
 
 it('should block incorrect interactions', async () => {
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText:
-        'Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: 'Just One Reply Just One Reply Just One Reply Just One Reply Just One Reply',
+        },
+      ],
     },
     postbackData: {
       sessionId: 0,
@@ -291,10 +317,15 @@ it('should select article and slice replies when over 10', async () => {
   gql.__push(apiGetArticleResult.elevenReplies);
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText:
-        '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: '老榮民九成存款全部捐給慈濟，如今窮了卻得不到慈濟醫院社工的幫忙，竟翻臉不認人',
+        },
+      ],
     },
     postbackData: {
       input: 'article-id',
@@ -310,10 +341,15 @@ it('should select article and slice replies when over 10', async () => {
 
 it('should ask users if they want to submit article when user say not found', async () => {
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText:
-        '這一篇文章確實是一個轉傳文章，他夠長，看起來很轉傳，但是使用者覺得資料庫裡沒有。',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: '這一篇文章確實是一個轉傳文章，他夠長，看起來很轉傳，但是使用者覺得資料庫裡沒有。',
+        },
+      ],
     },
     postbackData: {
       input: POSTBACK_NO_ARTICLE_FOUND,
@@ -344,10 +380,14 @@ it('should ask users if they want to submit article when user say not found', as
 
 it('should ask users if they want to submit image article when user say not found', async () => {
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      messageType: 'image',
-      messageId: '6530038889933',
+      msgs: [
+        {
+          id: '6530038889933',
+          type: 'image',
+        },
+      ],
     },
     postbackData: {
       input: POSTBACK_NO_ARTICLE_FOUND,
@@ -379,9 +419,15 @@ it('should ask users if they want to submit image article when user say not foun
 it('should create a UserArticleLink when selecting a article', async () => {
   const userId = 'user-id-0';
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: '《緊急通知》',
+      msgs: [
+        {
+          id: 'foo',
+          type: 'text',
+          text: '《緊急通知》',
+        },
+      ],
     },
     postbackData: {
       input: 'article-id',

--- a/src/webhook/handlers/__tests__/choosingArticle.test.ts
+++ b/src/webhook/handlers/__tests__/choosingArticle.test.ts
@@ -86,7 +86,7 @@ it('throws ManipulationError when articleId is not valid', async () => {
   gql.__push({ data: { GetArticle: null } });
 
   const params: ChatbotPostbackHandlerParams = {
-    context: { sessionId: 0, msgs: [] },
+    context: { sessionId: 0, msgs: [{ type: 'text', text: 'foo', id: 'id' }] },
     postbackData: {
       sessionId: 0,
       state: 'CHOOSING_ARTICLE',

--- a/src/webhook/handlers/__tests__/choosingReply.test.ts
+++ b/src/webhook/handlers/__tests__/choosingReply.test.ts
@@ -31,9 +31,9 @@ describe('should select reply by replyId', () => {
   };
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: '貼圖',
+      msgs: [{ id: 'foo', type: 'text', text: '貼圖' }],
     },
     postbackData: {
       sessionId: 0,
@@ -101,9 +101,9 @@ describe('should select reply by replyId', () => {
 
 it('should block invalid postback input', async () => {
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: '貼圖',
+      msgs: [{ id: 'foo', type: 'text', text: '貼圖' }],
     },
     postbackData: {
       sessionId: 0,
@@ -126,9 +126,9 @@ it('should handle graphql error gracefully', async () => {
   };
 
   const params: ChatbotPostbackHandlerParams = {
-    data: {
+    context: {
       sessionId: 0,
-      searchedText: '貼圖',
+      msgs: [{ id: 'foo', type: 'text', text: '貼圖' }],
     },
     postbackData: {
       sessionId: 0,

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -228,7 +228,7 @@ describe('tutorial', () => {
 
     tutorial.mockImplementationOnce(() => {
       return {
-        data: { sessionId: 0, searchedText: '' },
+        context: { sessionId: 0, msgs: [] },
         replies: [],
       };
     });

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -126,10 +126,8 @@ describe('defaultState', () => {
     ).resolves.toMatchInlineSnapshot(`
       Object {
         "context": Object {
-          "data": Object {
-            "searchedText": "",
-            "sessionId": 0,
-          },
+          "msgs": Array [],
+          "sessionId": 0,
         },
         "replies": Array [],
       }
@@ -158,10 +156,8 @@ it('handles ManipulationError fired in handlers', async () => {
   ).resolves.toMatchInlineSnapshot(`
     Object {
       "context": Object {
-        "data": Object {
-          "searchedText": "",
-          "sessionId": 612964800000,
-        },
+        "msgs": Array [],
+        "sessionId": 612964800000,
       },
       "replies": Array [
         Object {
@@ -242,10 +238,8 @@ describe('tutorial', () => {
     ).resolves.toMatchInlineSnapshot(`
       Object {
         "context": Object {
-          "data": Object {
-            "searchedText": "",
-            "sessionId": 0,
-          },
+          "msgs": Array [],
+          "sessionId": 0,
         },
         "replies": Array [],
       }

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -7,7 +7,7 @@ import originalAskingArticleSource from '../askingArticleSource';
 import originalAskingArticleSubmissionConsent from '../askingArticleSubmissionConsent';
 import originalTutorial from '../tutorial';
 import originalDefaultState from '../defaultState';
-import { ChatbotStateHandlerReturnType, Context } from 'src/types/chatbotState';
+import { Result, Context } from 'src/types/chatbotState';
 
 jest.mock('../choosingArticle');
 jest.mock('../choosingReply');
@@ -56,9 +56,9 @@ afterEach(() => {
 });
 
 it('invokes state handler specified by event.postbackHandlerState', async () => {
-  const data: Context = {
+  const context: Context = {
     sessionId: FIXED_DATE,
-    searchedText: '',
+    msgs: [],
   };
 
   for (const { postbackState, expectedHandler } of [
@@ -82,13 +82,13 @@ it('invokes state handler specified by event.postbackHandlerState', async () => 
   ] as const) {
     expectedHandler.mockImplementationOnce(() => {
       return Promise.resolve({
-        data: { sessionId: 0, searchedText: '' },
+        context: { sessionId: 0, msgs: [] },
         replies: [],
-      } as ChatbotStateHandlerReturnType);
+      } as Result);
     });
 
     await handlePostback(
-      data,
+      context,
       {
         sessionId: FIXED_DATE,
         state: postbackState,
@@ -105,17 +105,17 @@ it('invokes state handler specified by event.postbackHandlerState', async () => 
 
 describe('defaultState', () => {
   it('handles unimplemented state', async () => {
-    const data: Context = { sessionId: FIXED_DATE, searchedText: '' };
+    const context: Context = { sessionId: FIXED_DATE, msgs: [] };
     defaultState.mockImplementationOnce(() => {
       return {
-        data: { sessionId: 0, searchedText: '' },
+        context: { sessionId: 0, msgs: [] },
         replies: [],
       };
     });
 
     await expect(
       handlePostback(
-        data,
+        context,
         {
           sessionId: FIXED_DATE,
           input: 'foo',
@@ -139,7 +139,7 @@ describe('defaultState', () => {
 });
 
 it('handles ManipulationError fired in handlers', async () => {
-  const data: Context = { sessionId: FIXED_DATE, searchedText: '' };
+  const context: Context = { sessionId: FIXED_DATE, msgs: [] };
 
   choosingArticle.mockImplementationOnce(() =>
     Promise.reject(new ManipulationError('Foo error'))
@@ -147,7 +147,7 @@ it('handles ManipulationError fired in handlers', async () => {
 
   await expect(
     handlePostback(
-      data,
+      context,
       {
         sessionId: FIXED_DATE,
         state: 'CHOOSING_ARTICLE',
@@ -205,14 +205,14 @@ it('handles ManipulationError fired in handlers', async () => {
 });
 
 it('throws on unknown error', async () => {
-  const data: Context = { sessionId: FIXED_DATE, searchedText: '' };
+  const context: Context = { sessionId: FIXED_DATE, msgs: [] };
   choosingArticle.mockImplementationOnce(() =>
     Promise.reject(new Error('Unknown error'))
   );
 
   await expect(
     handlePostback(
-      data,
+      context,
       { sessionId: FIXED_DATE, state: 'CHOOSING_ARTICLE', input: '' },
       'user-id'
     )
@@ -223,7 +223,7 @@ describe('tutorial', () => {
   it('handles TUTORIAL postbackHandlerState', async () => {
     const context: Context = {
       sessionId: FIXED_DATE,
-      searchedText: '',
+      msgs: [],
     };
 
     tutorial.mockImplementationOnce(() => {

--- a/src/webhook/handlers/__tests__/initState.test.ts
+++ b/src/webhook/handlers/__tests__/initState.test.ts
@@ -31,10 +31,15 @@ it('article found', async () => {
 
   expect(
     await initState({
-      data: {
+      context: {
         sessionId: 1497994017447,
-        searchedText:
-          '計程車上有裝悠遊卡感應器，老人悠悠卡可以享受優惠部分由政府補助，不影響司機收入',
+        msgs: [
+          {
+            type: 'text',
+            id: 'abc',
+            text: '計程車上有裝悠遊卡感應器，老人悠悠卡可以享受優惠部分由政府補助，不影響司機收入',
+          },
+        ],
       },
       userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
     })
@@ -73,10 +78,15 @@ it('long article replies still below flex message limit', async () => {
   gql.__push(apiListArticleResult.twelveLongArticles);
 
   const result = await initState({
-    data: {
+    context: {
       sessionId: 1502477506267,
-      searchedText:
-        '這樣的大事國內媒體竟然不敢報導！\n我國駐日代表將原「中華民國」申請更名為「台灣」結果被日本裁罰，須繳納7000萬日圓（合約台幣2100萬元）高額稅賦(轉載中時電子報）\n\n我駐日代表謝長廷將原「中華民國」申請更名為「台灣」，自認得意之時，結果遭自認友好日本國給出賣了，必須繳納7000萬日圓（合約台幣2100萬元）高額稅賦...民進黨沒想到如此更名竟然是這樣的下場：被他最信任也最友好的日本政府給坑了。\n果然錯誤的政策比貪污可怕，2100萬就這樣打水漂了，還要資助九州水患，核四停建違約賠償金.......夠全國軍公教退休2次.........\n\nhttp://www.chinatimes.com/newspapers/20170617000318-260118',
+      msgs: [
+        {
+          type: 'text',
+          id: 'abc',
+          text: '這樣的大事國內媒體竟然不敢報導！\n我國駐日代表將原「中華民國」申請更名為「台灣」結果被日本裁罰，須繳納7000萬日圓（合約台幣2100萬元）高額稅賦(轉載中時電子報）\n\n我駐日代表謝長廷將原「中華民國」申請更名為「台灣」，自認得意之時，結果遭自認友好日本國給出賣了，必須繳納7000萬日圓（合約台幣2100萬元）高額稅賦...民進黨沒想到如此更名竟然是這樣的下場：被他最信任也最友好的日本政府給坑了。\n果然錯誤的政策比貪污可怕，2100萬就這樣打水漂了，還要資助九州水患，核四停建違約賠償金.......夠全國軍公教退休2次.........\n\nhttp://www.chinatimes.com/newspapers/20170617000318-260118',
+        },
+      ],
     },
     userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
   });
@@ -106,9 +116,9 @@ it('articles found with high similarity', async () => {
 
   expect(
     await initState({
-      data: {
+      context: {
         sessionId: 1497994017447,
-        searchedText: 'YouTube · 寻找健康人生',
+        msgs: [{ type: 'text', id: 'abc', text: 'YouTube · 寻找健康人生' }],
       },
       userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
     })
@@ -157,9 +167,9 @@ it('only one article found with high similarity and choose for user', async () =
 
   expect(
     await initState({
-      data: {
+      context: {
         sessionId: 1497994017447,
-        searchedText: 'YouTube · 寻找健康人生',
+        msgs: [{ type: 'text', id: 'abc', text: 'YouTube · 寻找健康人生' }],
       },
       userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
     })
@@ -214,9 +224,9 @@ it('should handle message matches only hyperlinks', async () => {
 
   expect(
     await initState({
-      data: {
+      context: {
         sessionId: 1497994017447,
-        searchedText: 'YouTube · 寻找健康人生',
+        msgs: [{ type: 'text', id: 'abc', text: 'YouTube · 寻找健康人生' }],
       },
       userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
     })
@@ -265,10 +275,15 @@ it('should handle text not found', async () => {
   MockDate.set('2020-01-01');
   expect(
     await initState({
-      data: {
+      context: {
         sessionId: 1497994017447,
-        searchedText:
-          'YouTube · 寻找健康人生 驚！大批香蕉受到愛滋血污染！這種香蕉千萬不要吃！吃到可能會被 ...',
+        msgs: [
+          {
+            type: 'text',
+            id: 'abc',
+            text: 'YouTube · 寻找健康人生 驚！大批香蕉受到愛滋血污染！這種香蕉千萬不要吃！吃到可能會被 ...',
+          },
+        ],
       },
       userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
     })
@@ -313,9 +328,9 @@ describe('input matches dialogflow intent', () => {
 
     expect(
       await initState({
-        data: {
+        context: {
           sessionId: 1497994017447,
-          searchedText: '你好',
+          msgs: [{ type: 'text', id: 'abc', text: '你好' }],
         },
         userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
       })
@@ -360,9 +375,9 @@ describe('input matches dialogflow intent', () => {
 
     expect(
       await initState({
-        data: {
+        context: {
           sessionId: 1497994017447,
-          searchedText: '零一二三四五六七八九十',
+          msgs: [{ type: 'text', id: 'abc', text: '零一二三四五六七八九十' }],
         },
         userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
       })
@@ -408,9 +423,9 @@ describe('input matches dialogflow intent', () => {
     MockDate.set('2020-01-01');
     expect(
       await initState({
-        data: {
+        context: {
           sessionId: 1497994017447,
-          searchedText: '零一二三四五六七八九十',
+          msgs: [{ type: 'text', id: 'abc', text: '零一二三四五六七八九十' }],
         },
         userId: 'Uc76d8ae9ccd1ada4f06c4e1515d46466',
       })

--- a/src/webhook/handlers/__tests__/processMedia.test.js
+++ b/src/webhook/handlers/__tests__/processMedia.test.js
@@ -18,17 +18,13 @@ it('one identical article found and choose for user', async () => {
   gql.__push(apiListArticlesResult.oneIdenticalImageArticle);
   gql.__push(apiGetArticleResult.oneImageArticle);
 
-  const event = {
-    type: 'message',
-    timestamp: 1497994016356,
-    message: {
-      type: 'image',
-      id: '6270464463537',
-    },
+  const msg = {
+    type: 'image',
+    id: '6270464463537',
   };
   const userId = 'Uc76d8ae9ccd1ada4f06c4e1515d46466';
   MockDate.set('2020-01-01');
-  expect(await processMedia(event, userId)).toMatchSnapshot();
+  expect(await processMedia(msg, userId)).toMatchSnapshot();
   MockDate.reset();
   expect(gql.__finished()).toBe(true);
   expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
@@ -86,17 +82,13 @@ it('one identical article found and choose for user', async () => {
 it('one identical image and similar text found', async () => {
   gql.__push(apiListArticlesResult.identicalImageAndTextFound);
 
-  const event = {
-    type: 'message',
-    timestamp: 1497994016356,
-    message: {
-      type: 'image',
-      id: '6270464463537',
-    },
+  const msg = {
+    type: 'image',
+    id: '6270464463537',
   };
   const userId = 'Uc76d8ae9ccd1ada4f06c4e1515d46466';
   MockDate.set('2020-01-01');
-  expect(await processMedia(event, userId)).toMatchSnapshot();
+  expect(await processMedia(msg, userId)).toMatchSnapshot();
   MockDate.reset();
   expect(gql.__finished()).toBe(true);
 });
@@ -104,17 +96,13 @@ it('one identical image and similar text found', async () => {
 it('one article found (not identical)', async () => {
   gql.__push(apiListArticlesResult.oneImageArticle);
 
-  const event = {
-    type: 'message',
-    timestamp: 1497994016356,
-    message: {
-      type: 'image',
-      id: '6270464463537',
-    },
+  const msg = {
+    type: 'image',
+    id: '6270464463537',
   };
   const userId = 'Uc76d8ae9ccd1ada4f06c4e1515d46466';
   MockDate.set('2020-01-01');
-  expect(await processMedia(event, userId)).toMatchSnapshot();
+  expect(await processMedia(msg, userId)).toMatchSnapshot();
   MockDate.reset();
   expect(gql.__finished()).toBe(true);
   expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`
@@ -149,18 +137,14 @@ it('one article found (not identical)', async () => {
 it('twelve articles found', async () => {
   gql.__push(apiListArticlesResult.twelveImageArticles);
 
-  const event = {
-    type: 'message',
-    timestamp: 1497994016356,
-    message: {
-      type: 'image',
-      id: '6530038889933',
-    },
+  const msg = {
+    type: 'image',
+    id: '6530038889933',
   };
   const userId = 'Uc76d8ae9ccd1ada4f06c4e1515d46466';
 
   MockDate.set('2020-01-01');
-  const result = await processMedia(event, userId);
+  const result = await processMedia(msg, userId);
   MockDate.reset();
   expect(result).toMatchSnapshot();
   expect(gql.__finished()).toBe(true);
@@ -173,17 +157,13 @@ it('twelve articles found', async () => {
 
 it('should handle image not found', async () => {
   gql.__push(apiListArticlesResult.notFound);
-  const event = {
-    type: 'message',
-    timestamp: 1497994016356,
-    message: {
-      type: 'image',
-      id: '6530038889933',
-    },
+  const msg = {
+    type: 'image',
+    id: '6530038889933',
   };
   const userId = 'Uc76d8ae9ccd1ada4f06c4e1515d46466';
   MockDate.set('2020-01-01');
-  expect(await processMedia(event, userId)).toMatchSnapshot();
+  expect(await processMedia(msg, userId)).toMatchSnapshot();
   MockDate.reset();
   expect(gql.__finished()).toBe(true);
   expect(ga.eventMock.mock.calls).toMatchInlineSnapshot(`

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -205,7 +205,13 @@ it('handles postbacks w/ LegacyContext', async () => {
     Array [
       Array [
         Object {
-          "searchedText": "",
+          "msgs": Array [
+            Object {
+              "id": "123",
+              "text": "",
+              "type": "text",
+            },
+          ],
           "sessionId": 123,
         },
         Object {
@@ -327,7 +333,7 @@ it('forwards to CHOOSING_ARTICLE when VIEW_ARTICLE_PREFIX is sent', async () => 
     Array [
       Array [
         Object {
-          "searchedText": "",
+          "msgs": Array [],
           "sessionId": 1561982400000,
         },
         Object {
@@ -386,7 +392,7 @@ it('shows reply list when article URL is sent', async () => {
     Array [
       Array [
         Object {
-          "searchedText": "",
+          "msgs": Array [],
           "sessionId": 1561982400000,
         },
         Object {
@@ -463,8 +469,14 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
     Array [
       Array [
         Object {
-          "data": Object {
-            "searchedText": "Newly forwarded message",
+          "context": Object {
+            "msgs": Array [
+              Object {
+                "id": "TmV3bHkgZm9yd2FyZGVkIG1lc3NhZ2U=",
+                "text": "Newly forwarded message",
+                "type": "text",
+              },
+            ],
             "sessionId": 1561982400000,
           },
           "userId": "user-id",
@@ -516,7 +528,7 @@ it('handles tutorial trigger from rich menu', async () => {
     Array [
       Array [
         Object {
-          "searchedText": "",
+          "msgs": Array [],
           "sessionId": 1561982400000,
         },
         Object {

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -12,7 +12,7 @@ import originalHandlePostback from '../handlePostback';
 import { TUTORIAL_STEPS } from '../tutorial';
 
 import { MessageEvent, PostbackEvent, TextEventMessage } from '@line/bot-sdk';
-import { Context } from 'src/types/chatbotState';
+import { LegacyContext } from 'src/types/chatbotState';
 
 jest.mock('src/webhook/lineClient');
 jest.mock('src/lib/ga');
@@ -162,7 +162,7 @@ it('handles postbacks', async () => {
   const sessionId = 123;
 
   redisGet.mockImplementationOnce(
-    (): Promise<{ data: Context }> =>
+    (): Promise<{ data: LegacyContext }> =>
       Promise.resolve({
         data: { sessionId, searchedText: '' },
       })
@@ -185,9 +185,9 @@ it('handles postbacks', async () => {
     replyToken: '',
   };
 
-  handlePostback.mockImplementationOnce((data) => {
+  handlePostback.mockImplementationOnce((context) => {
     return Promise.resolve({
-      context: { data },
+      context,
       replies: [
         {
           type: 'text',
@@ -305,9 +305,9 @@ it('forwards to CHOOSING_ARTICLE when VIEW_ARTICLE_PREFIX is sent', async () => 
     `${VIEW_ARTICLE_PREFIX}${getArticleURL('article-id')}`
   );
 
-  handlePostback.mockImplementationOnce((data) => {
+  handlePostback.mockImplementationOnce((context) => {
     return Promise.resolve({
-      context: { data },
+      context,
       replies: [
         {
           type: 'text',
@@ -364,9 +364,9 @@ it('shows reply list when article URL is sent', async () => {
     getArticleURL('article-id') + '  \n  ' /* simulate manual input */
   );
 
-  handlePostback.mockImplementationOnce((data) => {
+  handlePostback.mockImplementationOnce((context) => {
     return Promise.resolve({
-      context: { data },
+      context,
       replies: [
         {
           type: 'text',
@@ -495,9 +495,9 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
 it('handles tutorial trigger from rich menu', async () => {
   const event = createTextMessageEvent(TUTORIAL_STEPS['RICH_MENU']);
 
-  handlePostback.mockImplementationOnce((data) => {
+  handlePostback.mockImplementationOnce((context) => {
     return Promise.resolve({
-      context: { data },
+      context,
       replies: [
         {
           type: 'text',

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -158,11 +158,11 @@ it('ignores sticker events', async () => {
   expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`Array []`);
 });
 
-it('handles postbacks', async () => {
+it('handles postbacks w/ LegacyContext', async () => {
   const sessionId = 123;
 
   redisGet.mockImplementationOnce(
-    (): Promise<{ data: LegacyContext }> =>
+    (): Promise<LegacyContext> =>
       Promise.resolve({
         data: { sessionId, searchedText: '' },
       })

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -422,9 +422,9 @@ it('Resets session on free-form input, triggers fast-forward', async () => {
   const input = 'Newly forwarded message';
   const event = createTextMessageEvent(input);
 
-  initState.mockImplementationOnce(({ data }) => {
+  initState.mockImplementationOnce(({ context }) => {
     return Promise.resolve({
-      data,
+      context,
       replies: [
         {
           type: 'text',

--- a/src/webhook/handlers/__tests__/tutorial.test.ts
+++ b/src/webhook/handlers/__tests__/tutorial.test.ts
@@ -12,9 +12,9 @@ import { ChatbotPostbackHandlerParams } from 'src/types/chatbotState';
 const ga = originalGa as MockedGa;
 
 const param: ChatbotPostbackHandlerParams = {
-  data: {
+  context: {
     sessionId: 1497994017447,
-    searchedText: '',
+    msgs: [],
   },
   postbackData: {
     sessionId: 1497994017447,
@@ -242,6 +242,6 @@ it('createGreetingMessage()', () => {
 });
 
 it('createTutorialMessage()', () => {
-  const result = createTutorialMessage(param.data.sessionId);
+  const result = createTutorialMessage(param.context.sessionId);
   expect(result).toMatchSnapshot();
 });

--- a/src/webhook/handlers/choosingReply.ts
+++ b/src/webhook/handlers/choosingReply.ts
@@ -140,7 +140,7 @@ function createShareBubble(
 }
 
 const choosingReply: ChatbotPostbackHandler = async ({
-  data,
+  context,
   userId,
   postbackData: { input: postbackInput, state },
 }) => {
@@ -221,7 +221,7 @@ const choosingReply: ChatbotPostbackHandler = async ({
   visitor.event({ ec: 'Reply', ea: 'Type', el: GetReply.type, ni: true });
   visitor.send();
 
-  return { data, replies };
+  return { context, replies };
 };
 
 export default choosingReply;

--- a/src/webhook/handlers/defaultState.ts
+++ b/src/webhook/handlers/defaultState.ts
@@ -1,12 +1,9 @@
 import { Message } from '@line/bot-sdk';
-import {
-  ChatbotPostbackHandlerParams,
-  ChatbotStateHandlerReturnType,
-} from 'src/types/chatbotState';
+import { ChatbotPostbackHandlerParams, Result } from 'src/types/chatbotState';
 
 export default function defaultState(
   params: ChatbotPostbackHandlerParams
-): ChatbotStateHandlerReturnType {
+): Result {
   const replies: Message[] = [
     {
       type: 'text',

--- a/src/webhook/handlers/handlePostback.ts
+++ b/src/webhook/handlers/handlePostback.ts
@@ -8,7 +8,7 @@ import { ManipulationError } from './utils';
 import tutorial from './tutorial';
 import {
   ChatbotPostbackHandlerParams,
-  ChatbotStateHandlerReturnType,
+  Result,
   Context,
   PostbackActionData,
 } from 'src/types/chatbotState';
@@ -21,17 +21,17 @@ import {
  * @param userId LINE user ID that does the input
  */
 export default async function handlePostback(
-  data: Context,
+  context: Context,
   postbackData: PostbackActionData<unknown>,
   userId: string
 ) {
   const params: ChatbotPostbackHandlerParams = {
-    data,
+    context,
     postbackData,
     userId,
   };
 
-  let result: ChatbotStateHandlerReturnType;
+  let result: Result;
 
   // Sets data and replies
   //
@@ -65,7 +65,7 @@ export default async function handlePostback(
   } catch (e) {
     if (e instanceof ManipulationError) {
       result = {
-        ...params,
+        context,
         replies: [
           {
             type: 'flex',
@@ -109,8 +109,5 @@ export default async function handlePostback(
     }
   }
 
-  return {
-    context: { data: result.data },
-    replies: result.replies,
-  };
+  return result;
 }

--- a/src/webhook/handlers/initState.ts
+++ b/src/webhook/handlers/initState.ts
@@ -7,7 +7,11 @@ import {
   Message,
   TextMessage,
 } from '@line/bot-sdk';
-import type { Result, Context } from 'src/types/chatbotState';
+import type {
+  Result,
+  Context,
+  CooccurredMessage,
+} from 'src/types/chatbotState';
 import gql from 'src/lib/gql';
 import {
   createPostbackAction,
@@ -32,13 +36,15 @@ const initState = async ({
   userId,
 }: {
   // Context initiated by text search
-  context: Context;
+  context: Context & {
+    msgs: ReadonlyArray<CooccurredMessage & { type: 'text' }>;
+  };
   userId: string;
 }): Promise<Result> => {
   const state = '__INIT__';
   let replies: Message[] = [];
 
-  const input = context.msgs[0].;
+  const input = context.msgs[0].text;
 
   // Track text message type send by user
   const visitor = ga(userId, state, input);
@@ -51,12 +57,12 @@ const initState = async ({
   // send input to dialogflow before doing search
   // uses dialogflowResponse as reply only when there's a intent matched and
   // input.length <= 10 or input.length > 10 but intentDetectionConfidence == 1
-  const dialogflowResponse = await detectDialogflowIntent(data.searchedText);
+  const dialogflowResponse = await detectDialogflowIntent(input);
   if (
     dialogflowResponse &&
     dialogflowResponse.queryResult &&
     dialogflowResponse.queryResult.intent &&
-    (data.searchedText.length <= 10 ||
+    (input.length <= 10 ||
       dialogflowResponse.queryResult.intentDetectionConfidence == 1)
   ) {
     replies = [
@@ -101,10 +107,10 @@ const initState = async ({
       }
     }
   `<ListArticlesInInitStateQuery, ListArticlesInInitStateQueryVariables>({
-    text: data.searchedText,
+    text: input,
   });
 
-  const inputSummary = ellipsis(data.searchedText, 12);
+  const inputSummary = ellipsis(input, 12);
 
   if (ListArticles?.edges.length) {
     // Track if find similar Articles in DB.
@@ -127,7 +133,7 @@ const initState = async ({
           // Remove spaces so that we count word's similarities only
           //
           (edge.node.text ?? '').replace(/\s/g, ''),
-          data.searchedText.replace(/\s/g, '')
+          input.replace(/\s/g, '')
         ),
       }))
       .sort((edge1, edge2) => edge2.similarity - edge1.similarity)
@@ -143,7 +149,7 @@ const initState = async ({
         context,
         // choose for user
         postbackData: {
-          sessionId: data.sessionId,
+          sessionId: context.sessionId,
           state: 'CHOOSING_ARTICLE',
           input: edgesSortedWithSimilarity[0].node.id,
         },
@@ -236,7 +242,7 @@ const initState = async ({
                   t`Choose this one`,
                   id,
                   t`I choose “${displayTextWhenChosen}”`,
-                  data.sessionId,
+                  context.sessionId,
                   'CHOOSING_ARTICLE'
                 ),
                 style: 'primary',
@@ -295,7 +301,7 @@ const initState = async ({
                 t`Tell us more`,
                 POSTBACK_NO_ARTICLE_FOUND,
                 t`None of these messages matches mine :(`,
-                data.sessionId,
+                context.sessionId,
                 'CHOOSING_ARTICLE'
               ),
               style: 'primary',
@@ -347,7 +353,7 @@ const initState = async ({
           '\n' +
           t`May I ask you a quick question?`,
       }),
-      createArticleSourceReply(data.sessionId),
+      createArticleSourceReply(context.sessionId),
     ];
   }
   visitor.send();

--- a/src/webhook/handlers/initState.ts
+++ b/src/webhook/handlers/initState.ts
@@ -7,10 +7,7 @@ import {
   Message,
   TextMessage,
 } from '@line/bot-sdk';
-import type {
-  ChatbotStateHandlerReturnType,
-  Context,
-} from 'src/types/chatbotState';
+import type { Result, Context } from 'src/types/chatbotState';
 import gql from 'src/lib/gql';
 import {
   createPostbackAction,
@@ -31,17 +28,17 @@ import {
 const SIMILARITY_THRESHOLD = 0.95;
 
 const initState = async ({
-  data,
+  context,
   userId,
 }: {
   // Context initiated by text search
-  data: Context & { searchedText: string };
+  context: Context;
   userId: string;
-}): Promise<ChatbotStateHandlerReturnType> => {
+}): Promise<Result> => {
   const state = '__INIT__';
   let replies: Message[] = [];
 
-  const input = data.searchedText;
+  const input = context.msgs[0].;
 
   // Track text message type send by user
   const visitor = ga(userId, state, input);
@@ -74,7 +71,7 @@ const initState = async ({
       el: dialogflowResponse.queryResult.intent.displayName ?? undefined,
     });
     visitor.send();
-    return { data, replies };
+    return { context, replies };
   }
 
   // Search for articles
@@ -143,7 +140,7 @@ const initState = async ({
       visitor.send();
 
       return await choosingArticle({
-        data,
+        context,
         // choose for user
         postbackData: {
           sessionId: data.sessionId,
@@ -354,7 +351,7 @@ const initState = async ({
     ];
   }
   visitor.send();
-  return { data, replies };
+  return { context, replies };
 };
 
 export default initState;

--- a/src/webhook/handlers/processBatch.ts
+++ b/src/webhook/handlers/processBatch.ts
@@ -5,7 +5,7 @@ import { Message } from '@line/bot-sdk';
 async function processBatch(messages: CooccurredMessage[]) {
   const context: Context = {
     sessionId: Date.now(),
-    searchedText: '',
+    msgs: [],
   };
 
   const replies: Message[] = [

--- a/src/webhook/handlers/processBatch.ts
+++ b/src/webhook/handlers/processBatch.ts
@@ -1,0 +1,25 @@
+import { Context, CooccurredMessage } from 'src/types/chatbotState';
+import { createTextMessage } from './utils';
+import { Message } from '@line/bot-sdk';
+
+async function processBatch(messages: CooccurredMessage[]) {
+  const context: Context = {
+    sessionId: Date.now(),
+    searchedText: '',
+  };
+
+  const replies: Message[] = [
+    createTextMessage({
+      text: `目前我還沒辦法一次處理 ${messages.length} 則訊息，請一則一則傳進來唷！`,
+    }),
+  ];
+
+  return {
+    context: {
+      data: context,
+    },
+    replies,
+  };
+}
+
+export default processBatch;

--- a/src/webhook/handlers/processBatch.ts
+++ b/src/webhook/handlers/processBatch.ts
@@ -1,6 +1,9 @@
-import { Context, CooccurredMessage } from 'src/types/chatbotState';
-import { createTextMessage } from './utils';
 import { Message } from '@line/bot-sdk';
+
+import { Context, CooccurredMessage } from 'src/types/chatbotState';
+import { sleep } from 'src/lib/sharedUtils';
+
+import { createTextMessage } from './utils';
 
 async function processBatch(messages: CooccurredMessage[]) {
   const context: Context = {
@@ -14,12 +17,11 @@ async function processBatch(messages: CooccurredMessage[]) {
     }),
   ];
 
-  return {
-    context: {
-      data: context,
-    },
-    replies,
-  };
+  // TODO: initiate multi-message processing here
+  //
+  await sleep(1000); // Simulate multi-message processing and see if more message in batch.
+
+  return { context, replies };
 }
 
 export default processBatch;

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -355,5 +355,5 @@ export default async function (
     ];
   }
   visitor.send();
-  return { context: { data: context }, replies };
+  return { context, replies };
 }

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -1,12 +1,11 @@
 import { t } from 'ttag';
 import type {
-  MessageEvent,
   FlexBubble,
   Message,
   FlexMessage,
   FlexComponent,
 } from '@line/bot-sdk';
-import { Context } from 'src/types/chatbotState';
+import { Context, CooccurredMessage } from 'src/types/chatbotState';
 
 import {
   getLineContentProxyURL,
@@ -27,19 +26,14 @@ import {
 const CIRCLED_DIGITS = '⓪①②③④⑤⑥⑦⑧⑨⑩⑪';
 const SIMILARITY_THRESHOLD = 0.95;
 
-export default async function (
-  event: {
-    message: Pick<MessageEvent['message'], 'id' | 'type'>;
-  },
-  userId: string
-) {
-  const proxyUrl = getLineContentProxyURL(event.message.id);
+export default async function (message: CooccurredMessage, userId: string) {
+  const proxyUrl = getLineContentProxyURL(message.id);
   console.log(`Media url: ${proxyUrl}`);
 
   const visitor = ga(userId, '__PROCESS_MEDIA__', proxyUrl);
 
   // Track media message type send by user
-  visitor.event({ ec: 'UserInput', ea: 'MessageType', el: event.message.type });
+  visitor.event({ ec: 'UserInput', ea: 'MessageType', el: message.type });
 
   let replies;
   const context: Context = {
@@ -47,12 +41,7 @@ export default async function (
     sessionId: Date.now(),
 
     // Store user messageId into context, which will use for submit new image article
-    msgs: [
-      {
-        type: event.message.type,
-        messageId: event.message.id,
-      },
-    ],
+    msgs: [message],
   };
 
   const {

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -191,15 +191,7 @@ const singleUserHandler = async (
     // messages[0] should be identical to msg.
     //
     if (msg.type !== 'text') {
-      return send(
-        await processMedia(
-          {
-            message: msg,
-          },
-          userId
-        ),
-        msg
-      );
+      return send(await processMedia(msg, userId), msg);
     }
 
     return send(

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -16,8 +16,8 @@ import {
   createTutorialMessage,
 } from './tutorial';
 import processMedia from './processMedia';
+import processBatch from './processBatch';
 import initState from './initState';
-import { createTextMessage } from './utils';
 
 const userIdBlacklist = (process.env.USERID_BLACKLIST || '').split(',');
 
@@ -184,20 +184,7 @@ const singleUserHandler = async (
     );
 
     if (messages.length !== 1) {
-      // TODO: initiate multi-message processing here
-      //
-      await sleep(1000); // Simulate multi-message processing and see if more message in batch.
-      return send(
-        {
-          context,
-          replies: [
-            createTextMessage({
-              text: `目前我還沒辦法一次處理 ${messages.length} 則訊息，請一則一則傳進來唷！`,
-            }),
-          ],
-        },
-        msg
-      );
+      return send(await processBatch(messages), msg);
     }
 
     const firstMsg = messages[0];

--- a/src/webhook/handlers/tutorial.ts
+++ b/src/webhook/handlers/tutorial.ts
@@ -11,7 +11,7 @@ import { CreateReplyMessagesReplyFragment } from 'typegen/graphql';
 import {
   ChatbotPostbackHandlerParams,
   ChatbotState,
-  ChatbotStateHandlerReturnType,
+  Result,
 } from 'src/types/chatbotState';
 
 /**
@@ -295,10 +295,10 @@ function createPermissionSetupDialog(message: string): FlexMessage {
 }
 
 export default function tutorial({
-  data,
+  context,
   postbackData,
   userId,
-}: ChatbotPostbackHandlerParams): ChatbotStateHandlerReturnType {
+}: ChatbotPostbackHandlerParams): Result {
   let replies: Message[] = [];
 
   const replyProvidePermissionSetup = `${t`You are smart`} 😊`;
@@ -317,11 +317,11 @@ export default function tutorial({
   if (!process.env.RUMORS_LINE_BOT_URL) {
     throw new Error('RUMORS_LINE_BOT_URL undefined');
   } else if (postbackData.input === TUTORIAL_STEPS['RICH_MENU']) {
-    replies = [createTutorialMessage(data.sessionId)];
+    replies = [createTutorialMessage(context.sessionId)];
   } else if (
     postbackData.input === TUTORIAL_STEPS['SIMULATE_FORWARDING_MESSAGE']
   ) {
-    replies = createMockReplyMessages(data.sessionId);
+    replies = createMockReplyMessages(context.sessionId);
   } else if (
     postbackData.input === TUTORIAL_STEPS['PROVIDE_PERMISSION_SETUP']
   ) {
@@ -336,17 +336,17 @@ export default function tutorial({
           items: [
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['SETUP_DONE'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['SETUP_LATER'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['PROVIDE_PERMISSION_SETUP_WITH_EXPLANATION'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
           ],
@@ -368,17 +368,17 @@ export default function tutorial({
           items: [
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['SETUP_DONE'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['SETUP_LATER'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['PROVIDE_PERMISSION_SETUP_WITH_EXPLANATION'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
           ],
@@ -396,12 +396,12 @@ export default function tutorial({
           items: [
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['SETUP_DONE'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
             createQuickReplyPostbackItem(
               TUTORIAL_STEPS['SETUP_LATER'],
-              data.sessionId,
+              context.sessionId,
               'TUTORIAL'
             ),
           ],
@@ -432,5 +432,5 @@ export default function tutorial({
   });
   visitor.send();
 
-  return { data, replies };
+  return { context, replies };
 }


### PR DESCRIPTION
As discussed in [20231206 meeting](https://g0v.hackmd.io/DSht8xFqRN-XXbhwE64k9Q#comm-Cooccurrence), we will first file a PR for revamping context:

- Replace `searchedText` / `messageId` with `msgs`, an array of cooccurrence messages
- Simplify context structure: remove `data` level, just `sessionId` and the `msgs`
- Refactors:
    - `getNewContext` to collect context creation logic.
    - `getContextForUser` is not reused many times, but is somewhat complex, thus extract these logic and name it as a function.
        - It also handles backward compatibility of the legacy context, converting it to the new format before sending it to the webhook event handlers.
    - `processBatch` moves the multi-message handling logic to a separate file, which is expected to grow in the next PR

The revamp touched all of the [event handlers](https://g0v.hackmd.io/f_Ze19PhQuqx_fzOAOkohQ#LINE-bot)
- `choosingArticle`, `choosingReply`: only context structure
- `askingArticleSource`: the user is in this state if and only if `msgs` is 1 single text. Just take the first message and process.
- `askingArticleSubmissionConsent`, `choosingArticle`, `initState`, `processMedia`: process the first message for now. Will change in the second PR.

