### PR TITLE
feat: add ga to processBatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,6 @@ We use dimension `Message Source` (Custom Dimemsion1) to classify different even
 
 1. User sends a message to us
   - `UserInput` / `MessageType` / `<text | image | video | ...>`
-  - For the time being, we only process message with "text" type. The following events only applies
-    for text messages.
-
   - If we found a articles in database that matches the message:
     - `UserInput` / `ArticleSearch` / `ArticleFound`
     - `Article` / `Search` / `<article id>` for each article found

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -36,10 +36,11 @@ export default function ga(
   let events: EventBatch['events'] = [];
   const extra: Record<string, unknown> = {};
 
-  return {
+  const visitorToReturn = {
     set(key: string, value: unknown) {
       extra[key] = value;
-      return visitor.set(key, value);
+      visitor.set(key, value);
+      return visitorToReturn;
     },
 
     event(evt: EventParams) {
@@ -50,7 +51,8 @@ export default function ga(
         value: evt.ev === undefined ? null : +evt.ev,
         time: new Date(),
       });
-      return visitor.event(evt);
+      visitor.event(evt);
+      return visitorToReturn;
     },
 
     send() {
@@ -71,7 +73,10 @@ export default function ga(
         rollbar.error(`[insertAnalytics] ${e.message}`, e);
       });
       events = [];
-      return visitor.send();
+      visitor.send();
+      return visitorToReturn;
     },
   };
+
+  return visitorToReturn;
 }

--- a/src/webhook/handlers/processBatch.ts
+++ b/src/webhook/handlers/processBatch.ts
@@ -9,14 +9,31 @@ import {
   createPostbackAction,
   createTextMessage,
 } from './utils';
+import ga from 'src/lib/ga';
 
-async function processBatch(messages: CooccurredMessage[]) {
+async function processBatch(messages: CooccurredMessage[], userId: string) {
   const context: Context = {
     sessionId: Date.now(),
     msgs: messages,
   };
 
   const msgCount = messages.length;
+
+  const visitor = ga(
+    userId,
+    '__PROCESS_BATCH__',
+    `Batch: ${msgCount} messages`
+  );
+
+  // Track media message type send by user
+  messages.forEach((message) => {
+    visitor.event({
+      ec: 'UserInput',
+      ea: 'MessageType',
+      el: message.type,
+    });
+  });
+  visitor.send();
 
   const replies: Message[] = [
     {

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -195,7 +195,7 @@ const singleUserHandler = async (
       // we wait first and check if there are new messages.
       //
       await sleep(TIMEOUT_BEFORE_ASKING_COOCCURRENCES);
-      return send(await processBatch(messages), msg);
+      return send(await processBatch(messages, userId), msg);
     }
 
     // Now there is only one message in the batch;


### PR DESCRIPTION
`processBatch` now sends `UserInput` event with `text` starting with "Batch" to BigQuery.

Also fixes a bug that `ga().event().send()` actually do not call `insertEventBatch()`, 

## Screenshot

After sending 2 images and say "Yes" on cooccurrence:
![截圖 2024-02-08 下午10 27 18](https://github.com/cofacts/rumors-line-bot/assets/108608/45699a2b-de66-4336-b918-598eb761254d)
