### PR TITLE
feat(liff): embed mgp award

### DIFF
--- a/src/liff/App.svelte
+++ b/src/liff/App.svelte
@@ -5,6 +5,7 @@
   import Comment from './pages/Comment.svelte';
   import UserSetting from './pages/UserSetting.svelte';
   import Feedback from './pages/Feedback.svelte';
+  import Mgp from './pages/Mgp.svelte';
 
   const routes = {
     article: Article,
@@ -12,6 +13,7 @@
     setting: UserSetting,
     comment: Comment,
     feedback: Feedback,
+    mgp: Mgp,
   };
 
   // Send pageview with correct path on each page change.

--- a/src/liff/index.js
+++ b/src/liff/index.js
@@ -18,7 +18,17 @@ liff.init({ liffId: LIFF_ID }).then(() => {
       redirectUri: location.href,
     });
   } else {
-    dataLayer.push({ userId: liff.getDecodedIDToken().sub });
+    const userId = liff.getDecodedIDToken().sub;
+    dataLayer.push({ userId });
+
+    const params = new URLSearchParams(location.search);
+    if (params.get('p') === 'mgp') {
+      // Replace login with survey
+      window.location.replace(
+        `https://www.surveycake.com/s/eqNpB?ssn0=${userId}&ssn58=cofacts`
+      );
+      return;
+    }
 
     // Kickstart app loading; fire assertions
     new App({ target: document.body });

--- a/src/liff/index.js
+++ b/src/liff/index.js
@@ -18,15 +18,7 @@ liff.init({ liffId: LIFF_ID }).then(() => {
       redirectUri: location.href,
     });
   } else {
-    const userId = liff.getDecodedIDToken().sub;
-    dataLayer.push({ userId });
-
-    const params = new URLSearchParams(location.search);
-    if (params.get('p') === 'mgp') {
-      // Replace login with survey
-      window.location.href = `https://www.surveycake.com/s/eqNpB?ssn0=${userId}&ssn58=cofacts&openExternalBrowser=1`;
-      return;
-    }
+    dataLayer.push({ userId: liff.getDecodedIDToken().sub });
 
     // Kickstart app loading; fire assertions
     new App({ target: document.body });

--- a/src/liff/index.js
+++ b/src/liff/index.js
@@ -24,9 +24,7 @@ liff.init({ liffId: LIFF_ID }).then(() => {
     const params = new URLSearchParams(location.search);
     if (params.get('p') === 'mgp') {
       // Replace login with survey
-      window.location.replace(
-        `https://www.surveycake.com/s/eqNpB?ssn0=${userId}&ssn58=cofacts`
-      );
+      window.location.href = `https://www.surveycake.com/s/eqNpB?ssn0=${userId}&ssn58=cofacts&openExternalBrowser=1`;
       return;
     }
 

--- a/src/liff/pages/Mgp.svelte
+++ b/src/liff/pages/Mgp.svelte
@@ -1,0 +1,18 @@
+<script>
+  const userId = liff.getDecodedIDToken().sub;
+  let iframeUrl = `https://www.surveycake.com/s/eqNpB?ssn0=${userId}&ssn58=cofacts`
+</script>
+
+<style>
+  iframe {
+    width: 100vw;
+    height: 100vh;
+    border: 0;
+  }
+</style>
+
+<svelte:head>
+  <title>Cofacts x 第四屆 MyGoPen 謠言惑眾獎</title>
+</svelte:head>
+
+<iframe title="謠言惑眾獎" src={iframeUrl} />


### PR DESCRIPTION
Add MyGoPen 謠言惑眾獎 feature on LIFF

We use iframe to
- Avoids opening new browsers
- Avoid 3rd party content snackbar confuses the user
- Make URL simple when being shared (user may accidentally share an url with their own user id to others if we don't mask them......)
