### PR TITLE
Update Cofacts API type and handle optional article createdAt issue

### DIFF
--- a/src/graphql/cofacts-api.graphql
+++ b/src/graphql/cofacts-api.graphql
@@ -177,7 +177,9 @@ type Query {
 type Article implements Node {
   id: ID!
   text: String
-  createdAt: String!
+
+  """May be null for legacy articles"""
+  createdAt: String
   updatedAt: String
   status: ReplyRequestStatusEnum!
   references: [ArticleReference]
@@ -279,6 +281,12 @@ type Article implements Node {
   """Attachment hash to search or identify files"""
   attachmentHash: String
   cooccurrences: [Cooccurrence!]
+
+  """Transcript contributors of the article"""
+  contributors: [Contributor!]!
+
+  """Time when the article was last transcribed"""
+  transcribedAt: String
 }
 
 """Basic entity. Modeled after Relay's GraphQL Server Specification."""
@@ -338,7 +346,9 @@ type ArticleReply {
   """
   ownVote: FeedbackVote
   status: ArticleReplyStatusEnum!
-  createdAt: String!
+
+  """May be null for legacy article-replies"""
+  createdAt: String
   updatedAt: String
 }
 
@@ -347,7 +357,9 @@ type Reply implements Node {
 
   """The user submitted this reply version"""
   user: User
-  createdAt: String!
+
+  """May be null for legacy replies"""
+  createdAt: String
   text: String
   type: ReplyTypeEnum!
   reference: String
@@ -980,6 +992,14 @@ type Cooccurrence implements Node {
   updatedAt: String!
 }
 
+type Contributor {
+  """The user who contributed to this article."""
+  user: User
+  userId: String!
+  appId: String!
+  updatedAt: String
+}
+
 type Ydoc {
   """Binary that stores as base64 encoded string"""
   data: String
@@ -1047,6 +1067,11 @@ input ListArticleFilter {
   articleRepliesFrom: UserAndExistInput
 
   """
+  Show only articles with(out) article transcript contributed by specified user
+  """
+  transcribedBy: UserAndExistInput
+
+  """
   
               When true, return only articles with any article replies that has more positive feedback than negative.
               When false, return articles with none of its article replies that has more positive feedback, including those with no replies yet.
@@ -1098,9 +1123,9 @@ input UserAndExistInput {
 
   """
   
-                    When true (or not specified), return only entries with the specified user's involvement.
-                    When false, return only entries that the specified user did not involve.
-                  
+          When true (or not specified), return only entries with the specified user's involvement.
+          When false, return only entries that the specified user did not involve.
+        
   """
   exists: Boolean = true
 }

--- a/src/lib/__tests__/sharedUtils.js
+++ b/src/lib/__tests__/sharedUtils.js
@@ -80,6 +80,12 @@ describe('date-fns', () => {
     expect(format(new Date(612921600000))).toMatchInlineSnapshot(
       `"Jun 4, 1989"`
     );
+
+    // Handles invalid date
+    expect(format(new Date(-Infinity))).toMatchInlineSnapshot(`"unknown date"`);
+    expect(formatDistanceToNow(new Date('wrong'))).toMatchInlineSnapshot(
+      `"unknown time"`
+    );
   });
 
   it('use other locale', () => {

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -53,11 +53,19 @@ let locale = require(`date-fns/locale/${(process.env.LOCALE || 'en_US').replace(
 locale = locale.default ? locale.default : locale;
 
 function formatAbsolute(date, format = 'PP', config = {}) {
-  return dateFnsFormat(date, format, { ...config, locale });
+  try {
+    return dateFnsFormat(date, format, { ...config, locale });
+  } catch (e) {
+    return t`unknown date`;
+  }
 }
 
 export function formatDistanceToNow(date, config = {}) {
-  return dateFnsFormatDistanceToNow(date, { ...config, locale });
+  try {
+    return dateFnsFormatDistanceToNow(date, { ...config, locale });
+  } catch (e) {
+    return t`unknown time`;
+  }
 }
 
 const THRESHOLD = 86400 * 2 * 1000; // 2 days in milliseconds

--- a/src/webhook/handlers/choosingArticle.ts
+++ b/src/webhook/handlers/choosingArticle.ts
@@ -383,7 +383,9 @@ const choosingArticle: ChatbotPostbackHandler = async (params) => {
       const aiReply = await createAIReply(selectedArticleId, userId);
 
       if (aiReply) {
-        const articleCreatedAt = new Date(GetArticle.createdAt);
+        const articleCreatedAt = new Date(
+          GetArticle.createdAt ?? -Infinity /* Triggers invalid date */
+        );
         const aiReplyCreatedAt = new Date(aiReply.createdAt);
 
         const aiReplyWithin30Days = isBefore(

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -557,7 +557,9 @@ export function createReplyMessages(
   article: CreateReplyMessagesArticleFragment,
   selectedArticleId: string
 ): Message[] {
-  const articleDate = format(new Date(article.createdAt));
+  const articleDate = format(
+    new Date(article.createdAt ?? -Infinity /* Triggers invalid date */)
+  );
   const articleUrl = getArticleURL(selectedArticleId);
   const typeStr = createTypeWords(reply.type).toLocaleLowerCase();
 

--- a/typegen/graphql.ts
+++ b/typegen/graphql.ts
@@ -166,8 +166,11 @@ export type Article = Node & {
   attachmentUrl: Maybe<Scalars['String']>;
   /** Number of normal article categories */
   categoryCount: Scalars['Int'];
+  /** Transcript contributors of the article */
+  contributors: Array<Contributor>;
   cooccurrences: Maybe<Array<Cooccurrence>>;
-  createdAt: Scalars['String'];
+  /** May be null for legacy articles */
+  createdAt: Maybe<Scalars['String']>;
   /** Hyperlinks in article text */
   hyperlinks: Maybe<Array<Maybe<Hyperlink>>>;
   id: Scalars['ID'];
@@ -184,6 +187,8 @@ export type Article = Node & {
   stats: Maybe<Array<Maybe<Analytics>>>;
   status: ReplyRequestStatusEnum;
   text: Maybe<Scalars['String']>;
+  /** Time when the article was last transcribed */
+  transcribedAt: Maybe<Scalars['String']>;
   updatedAt: Maybe<Scalars['String']>;
   /** The user submitted this article */
   user: Maybe<User>;
@@ -338,7 +343,8 @@ export type ArticleReply = {
   article: Maybe<Article>;
   articleId: Scalars['String'];
   canUpdateStatus: Scalars['Boolean'];
-  createdAt: Scalars['String'];
+  /** May be null for legacy article-replies */
+  createdAt: Maybe<Scalars['String']>;
   feedbackCount: Scalars['Int'];
   feedbacks: Array<ArticleReplyFeedback>;
   negativeFeedbackCount: Scalars['Int'];
@@ -479,6 +485,14 @@ export type Contribution = {
   date: Maybe<Scalars['String']>;
 };
 
+export type Contributor = {
+  appId: Scalars['String'];
+  updatedAt: Maybe<Scalars['String']>;
+  /** The user who contributed to this article. */
+  user: Maybe<User>;
+  userId: Scalars['String'];
+};
+
 export type Cooccurrence = Node & {
   appId: Scalars['String'];
   articleIds: Array<Scalars['String']>;
@@ -607,6 +621,8 @@ export type ListArticleFilter = {
   selfOnly: InputMaybe<Scalars['Boolean']>;
   /** Returns only articles with the specified statuses */
   statuses: InputMaybe<Array<ArticleStatusEnum>>;
+  /** Show only articles with(out) article transcript contributed by specified user */
+  transcribedBy: InputMaybe<UserAndExistInput>;
   /** Specifies how the transcript of `mediaUrl` can be used to search. Can only specify `transcript` when `mediaUrl` is specified. */
   transcript: InputMaybe<TranscriptFilter>;
   /** Show only articles created by the specific user. */
@@ -1169,7 +1185,8 @@ export type RelatedArticleOrderBy = {
 
 export type Reply = Node & {
   articleReplies: Array<ArticleReply>;
-  createdAt: Scalars['String'];
+  /** May be null for legacy replies */
+  createdAt: Maybe<Scalars['String']>;
   /** Hyperlinks in reply text or reference. May be empty array if no URLs are included. `null` when hyperlinks are still fetching. */
   hyperlinks: Maybe<Array<Maybe<Hyperlink>>>;
   id: Scalars['ID'];
@@ -1399,7 +1416,7 @@ export type GetArticleInChoosingArticleQueryVariables = Exact<{
 }>;
 
 
-export type GetArticleInChoosingArticleQuery = { GetArticle: { text: string | null, replyCount: number, articleType: ArticleTypeEnum, createdAt: string, articleReplies: Array<{ positiveFeedbackCount: number, negativeFeedbackCount: number, reply: { id: string, type: ReplyTypeEnum, text: string | null } | null }> } | null };
+export type GetArticleInChoosingArticleQuery = { GetArticle: { text: string | null, replyCount: number, articleType: ArticleTypeEnum, createdAt: string | null, articleReplies: Array<{ positiveFeedbackCount: number, negativeFeedbackCount: number, reply: { id: string, type: ReplyTypeEnum, text: string | null } | null }> } | null };
 
 export type SubmitReplyRequestWithoutReasonMutationVariables = Exact<{
   id: Scalars['String'];
@@ -1414,13 +1431,13 @@ export type GetReplyRelatedDataQueryVariables = Exact<{
 }>;
 
 
-export type GetReplyRelatedDataQuery = { GetReply: { type: ReplyTypeEnum, text: string | null, reference: string | null, createdAt: string } | null, GetArticle: { text: string | null, replyCount: number, createdAt: string, articleReplies: Array<{ replyId: string, createdAt: string }> } | null };
+export type GetReplyRelatedDataQuery = { GetReply: { type: ReplyTypeEnum, text: string | null, reference: string | null, createdAt: string | null } | null, GetArticle: { text: string | null, replyCount: number, createdAt: string | null, articleReplies: Array<{ replyId: string, createdAt: string | null }> } | null };
 
-export type CreateReferenceWordsReplyFragment = { reference: string | null, type: ReplyTypeEnum, createdAt: string };
+export type CreateReferenceWordsReplyFragment = { reference: string | null, type: ReplyTypeEnum, createdAt: string | null };
 
-export type CreateReplyMessagesReplyFragment = { text: string | null, reference: string | null, type: ReplyTypeEnum, createdAt: string };
+export type CreateReplyMessagesReplyFragment = { text: string | null, reference: string | null, type: ReplyTypeEnum, createdAt: string | null };
 
-export type CreateReplyMessagesArticleFragment = { replyCount: number, createdAt: string };
+export type CreateReplyMessagesArticleFragment = { replyCount: number, createdAt: string | null };
 
 export type CreateHighlightContentsHighlightFragment = { text: string | null, hyperlinks: Array<{ title: string | null, summary: string | null } | null> | null };
 


### PR DESCRIPTION
In new Cofacts API, createdAt can be optional (that reflects DB status quo).

This PR syncs type and adds logic to handle that situation.