### PR TITLE
Long resp handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ client_secret.json
 data/
 
 storybook-static
+.eslintcache

--- a/i18n/ja.po
+++ b/i18n/ja.po
@@ -6,11 +6,11 @@ msgstr ""
 "mime-version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/webhook/handlers/utils.ts:98
+#: src/webhook/handlers/utils.ts:106
 msgid "No feedback yet"
 msgstr "まだリプライはありません"
 
-#: src/webhook/handlers/utils.ts:112
+#: src/webhook/handlers/utils.ts:120
 msgid "${ negative } user consider this not useful"
 msgid_plural "${ negative } users consider this not useful"
 msgstr[0] "${negative} 人がこのリプライは役に立っていないと思っています"
@@ -31,15 +31,15 @@ msgstr "個人の意見が含まれています"
 msgid "Invalid request"
 msgstr "検証の範囲外"
 
-#: src/webhook/handlers/utils.ts:139
+#: src/webhook/handlers/utils.ts:147
 msgid "different opinions"
 msgstr "違う観点"
 
-#: src/webhook/handlers/utils.ts:139
+#: src/webhook/handlers/utils.ts:147
 msgid "references"
 msgstr "情報源"
 
-#: src/webhook/handlers/utils.ts:145
+#: src/webhook/handlers/utils.ts:153
 #, javascript-format
 msgid "This reply has no ${ prompt } and it may be biased"
 msgstr "このリプライは${prompt}がありませんので、信頼性を見直す必要があります。"
@@ -61,13 +61,13 @@ msgstr "見てみましょう"
 msgid "Visit ${ articleUrl } for more replies."
 msgstr "他のリプライを見たい場合、こちらに：${ articleUrl }"
 
-#: src/webhook/handlers/utils.ts:1263
+#: src/webhook/handlers/utils.ts:1271
 msgid "Choose this one"
 msgstr "これを選ぶ"
 
-#: src/webhook/handlers/askingCooccurrence.ts:257
-#: src/webhook/handlers/initState.ts:188
-#: src/webhook/handlers/processMedia.ts:150
+#: src/webhook/handlers/askingCooccurrence.ts:263
+#: src/webhook/handlers/initState.ts:191
+#: src/webhook/handlers/processMedia.ts:155
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid ""
@@ -77,18 +77,18 @@ msgstr ""
 "デマ情報はよく何度も編集され発送されます。\n"
 "最も関連するバージョンを選んでください"
 
-#: src/webhook/handlers/utils.ts:737
+#: src/webhook/handlers/utils.ts:745
 #, javascript-format
 msgid "Therefore, the author think the message ${ typeStr }."
 msgstr "以上により、リプライ者が次のように考えています ${typeStr}。"
 
-#: src/webhook/handlers/utils.ts:740
+#: src/webhook/handlers/utils.ts:748
 msgid ""
 "There are different replies for the message. Read them all here before "
 "making judgements:"
 msgstr "この情報に様々なリプライがあるため、読み通してから判断するようにお薦めします："
 
-#: src/webhook/handlers/utils.ts:742
+#: src/webhook/handlers/utils.ts:750
 msgid "If you have different thoughts, you may have your say here:"
 msgstr "違う見方をお持ちの方は、どうぞ気軽に新規リプライを投稿してください："
 
@@ -100,39 +100,39 @@ msgstr "以上のリプライは役に立ちましたか？"
 
 #: src/liff/components/FeedbackForm.svelte:27
 #: src/webhook/handlers/choosingReply.ts:63
-#: src/webhook/handlers/processBatch.ts:48
-#: src/webhook/handlers/utils.ts:806
+#: src/webhook/handlers/processBatch.ts:46
+#: src/webhook/handlers/utils.ts:814
 msgid "Yes"
 msgstr "はい"
 
 #: src/liff/components/FeedbackForm.svelte:30
 #: src/webhook/handlers/choosingReply.ts:73
-#: src/webhook/handlers/processBatch.ts:58
-#: src/webhook/handlers/utils.ts:816
+#: src/webhook/handlers/processBatch.ts:56
+#: src/webhook/handlers/utils.ts:824
 msgid "No"
 msgstr "いいえ"
 
-#: src/webhook/handlers/initState.ts:143
-#: src/webhook/handlers/initState.ts:161
-#: src/webhook/handlers/processMedia.ts:105
-#: src/webhook/handlers/processMedia.ts:123
+#: src/webhook/handlers/initState.ts:146
+#: src/webhook/handlers/initState.ts:164
+#: src/webhook/handlers/processMedia.ts:110
+#: src/webhook/handlers/processMedia.ts:128
 msgid "None of these messages matches mine :("
 msgstr "確認したい情報が見つかりません (T_T)"
 
-#: src/webhook/handlers/utils.ts:103
+#: src/webhook/handlers/utils.ts:111
 #, javascript-format
 msgid "${ positive } user considers this helpful"
 msgid_plural "${ positive } users consider this helpful"
 msgstr[0] "${positive} 人がこのリプライは役に立っていると思っています"
 
-#: src/webhook/handlers/initState.ts:159
-#: src/webhook/handlers/processMedia.ts:121
+#: src/webhook/handlers/initState.ts:162
+#: src/webhook/handlers/processMedia.ts:126
 msgid "Tell us more"
 msgstr "情報を報告する"
 
-#: src/webhook/handlers/askingCooccurrence.ts:262
-#: src/webhook/handlers/initState.ts:175
-#: src/webhook/handlers/processMedia.ts:137
+#: src/webhook/handlers/askingCooccurrence.ts:268
+#: src/webhook/handlers/initState.ts:178
+#: src/webhook/handlers/processMedia.ts:142
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid "Please choose the most similar message from the list."
@@ -147,29 +147,23 @@ msgstr "以下から調べたいリプライを選んでください。"
 msgid "Someone thinks it ${ typeWords }"
 msgstr "誰かが次のように考えています ${typeWords}"
 
-#: src/webhook/handlers/utils.ts:1173
+#: src/webhook/handlers/utils.ts:1181
 #, javascript-format
 msgid "Looks ${ similarityPercentage }% similar"
 msgstr "${similarityPercentage}% 似ています"
 
-#: src/webhook/handlers/singleUserHandler.ts:82
-msgid ""
-"Line bot is busy, or we cannot handle this message. Maybe you can try again "
-"a few minutes later."
-msgstr "申し訳ございません！只今、混み合っているため、この情報をすぐに処理できません。恐れ入りますが、しばらくたってからご利用ください。"
-
-#: src/webhook/handlers/handlePostback.ts:86
+#: src/webhook/handlers/handlePostback.ts:95
 msgid "Wrong usage"
 msgstr "使い方は間違いました"
 
-#: src/webhook/handlers/singleUserHandler.ts:283
+#: src/webhook/handlers/singleUserHandler.ts:275
 #. Reuse existing context
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "新規の情報を検索しているため、先ほどまでの検索ボタンは無効になります。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:197
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:203
 #, javascript-format
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "提供していただいた情報はこちらに登録されています ${ articleUrl }"
@@ -210,8 +204,8 @@ msgid "Share to friends"
 msgstr "友達にシェアする"
 
 #: src/webhook/handlers/askingArticleSource.ts:34
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:55
-#: src/webhook/handlers/askingCooccurrence.ts:40
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:56
+#: src/webhook/handlers/askingCooccurrence.ts:41
 #: src/webhook/handlers/choosingArticle.ts:72
 #: src/webhook/handlers/choosingReply.ts:152
 msgid "Please choose from provided options."
@@ -262,7 +256,7 @@ msgid "There is ${ otherReplyRequestCount } user also waiting for clarification.
 msgid_plural "There are ${ otherReplyRequestCount } users also waiting for clarification."
 msgstr[0] "計 ${ otherReplyRequestCount } 人がこの情報に関するリプライをチェックしたいと思っています。"
 
-#: src/webhook/handlers/initState.ts:184
+#: src/webhook/handlers/initState.ts:187
 #, javascript-format
 msgid ""
 "There are some messages that looks similar to \"${ inputSummary }\" you "
@@ -273,29 +267,29 @@ msgstr "データベースにいくつかの情報は、送ってくれた「${ 
 msgid "Please proceed on your mobile phone."
 msgstr "スマホで操作を続けてください。"
 
-#: src/webhook/handlers/utils.ts:159
+#: src/webhook/handlers/utils.ts:167
 msgid "Be the first to report the message"
 msgstr "この情報にリプライする最初の人になりましょう"
 
-#: src/webhook/handlers/utils.ts:341
+#: src/webhook/handlers/utils.ts:349
 msgid "Share on LINE"
 msgstr "LINE で聞く"
 
-#: src/webhook/handlers/utils.ts:343
+#: src/webhook/handlers/utils.ts:351
 #, javascript-format
 msgid "Please help me verify if this is true: ${ articleUrl }"
 msgstr "これは本当かどうか見てもらえませんか：${ articleUrl }"
 
-#: src/webhook/handlers/utils.ts:353
+#: src/webhook/handlers/utils.ts:361
 msgid "Share on Facebook"
 msgstr "Facebook で聞く"
 
-#: src/webhook/handlers/utils.ts:357
+#: src/webhook/handlers/utils.ts:365
 #. t: Facebook hash tag 
 msgid "ReportedToCofacts"
 msgstr "Cofacts に問い合せる"
 
-#: src/webhook/handlers/utils.ts:455
+#: src/webhook/handlers/utils.ts:463
 msgid ""
 "We suggest forwarding the message to the following fact-checkers instead. "
 "They have 💁 1-on-1 Q&A service to respond to your questions."
@@ -469,11 +463,11 @@ msgstr "今のところ設定のオプションはありません :)"
 msgid "You can configure Cofacts here to meet your need."
 msgstr "ここでニーズに応じて Cofacts の設定ができます。"
 
-#: src/webhook/handlers/utils.ts:406
+#: src/webhook/handlers/utils.ts:414
 msgid "Go to settings"
 msgstr "設定する"
 
-#: src/webhook/handlers/utils.ts:382
+#: src/webhook/handlers/utils.ts:390
 msgid "Receive updates"
 msgstr "通知をオンにする"
 
@@ -604,7 +598,7 @@ msgid ""
 "database."
 msgstr "検査結果は見当たらなかった場合、この情報をデータベースに入れるかどうかについてあなたの許可をお尋ねします。"
 
-#: src/webhook/handlers/utils.ts:738
+#: src/webhook/handlers/utils.ts:746
 msgid ""
 "This content is provided by Cofact message reporting chatbot and "
 "crowd-sourced fact-checking community under CC BY-SA 4.0 license. Please "
@@ -641,7 +635,7 @@ msgstr ""
 
 #: src/webhook/handlers/askingArticleSource.ts:77
 #: src/webhook/handlers/choosingArticle.ts:444
-#: src/webhook/handlers/utils.ts:838
+#: src/webhook/handlers/utils.ts:846
 msgid "Provide more detail"
 msgstr ""
 
@@ -675,27 +669,27 @@ msgstr ""
 
 #: src/webhook/handlers/askingArticleSource.ts:188
 #: src/webhook/handlers/choosingArticle.ts:117
-#: src/webhook/handlers/processMedia.ts:168
+#: src/webhook/handlers/processMedia.ts:173
 msgid "Do you want someone to fact-check this message?"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:81
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:82
 msgid "The message has not been reported and won’t be fact-checked. Thanks anyway!"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:214
 #: src/webhook/handlers/askingArticleSubmissionConsent.ts:224
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:234
 msgid ""
 "The message has now been recorded at Cofacts for volunteers to fact-check. "
 "Thank you for submitting!"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:230
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:240
 #: src/webhook/handlers/choosingArticle.ts:432
 msgid "View reported message"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:252
 #: src/webhook/handlers/choosingArticle.ts:378
 msgid "In the meantime, you can:"
 msgstr ""
@@ -708,7 +702,7 @@ msgid ""
 msgstr ""
 
 #: src/webhook/handlers/choosingArticle.ts:104
-#: src/webhook/handlers/initState.ts:206
+#: src/webhook/handlers/initState.ts:209
 msgid "May I ask you a quick question?"
 msgstr ""
 
@@ -736,82 +730,82 @@ msgstr ""
 msgid "Hi i am cofacts chat bot"
 msgstr ""
 
-#: src/webhook/handlers/initState.ts:204
+#: src/webhook/handlers/initState.ts:207
 #, javascript-format
 msgid ""
 "Unfortunately, I currently don’t recognize “${ inputSummary }”, but I would "
 "still like to help."
 msgstr ""
 
-#: src/webhook/handlers/processMedia.ts:146
+#: src/webhook/handlers/processMedia.ts:151
 msgid "There are some messages that looks similar to the one you have sent to me."
 msgstr ""
 
-#: src/webhook/handlers/processMedia.ts:166
+#: src/webhook/handlers/processMedia.ts:171
 #. submit
 msgid ""
 "Unfortunately, I currently don’t recognize this message, but I would still "
 "like to help."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:96
-#: src/webhook/handlers/utils.ts:155
+#: src/webhook/handlers/askingCooccurrence.ts:102
+#: src/webhook/handlers/utils.ts:163
 msgid "Report to database"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:204
-#: src/webhook/handlers/utils.ts:254
+#: src/webhook/handlers/askingCooccurrence.ts:210
+#: src/webhook/handlers/utils.ts:262
 msgid ""
 "and have volunteers fact-check it. This way you can help the people who "
 "receive the same message in the future."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:226
-#: src/webhook/handlers/askingCooccurrence.ts:228
-#: src/webhook/handlers/utils.ts:282
-#: src/webhook/handlers/utils.ts:284
+#: src/webhook/handlers/askingCooccurrence.ts:232
+#: src/webhook/handlers/askingCooccurrence.ts:234
+#: src/webhook/handlers/utils.ts:290
+#: src/webhook/handlers/utils.ts:292
 msgid "Don’t report"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:328
+#: src/webhook/handlers/utils.ts:336
 msgid ""
 "We all get by with a little help from our friends 🌟 Share your question to "
 "friends, someone might be able to help!"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:393
+#: src/webhook/handlers/utils.ts:401
 msgid ""
 "You can turn on notifications if you want Cofacts to notify you when "
 "someone replies to this message."
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:713
+#: src/webhook/handlers/utils.ts:721
 msgid "Thank you for sharing “${ inputSummary }”"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:713
+#: src/webhook/handlers/utils.ts:721
 msgid "I found that there are some disagreement to the message:"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:851
+#: src/webhook/handlers/utils.ts:859
 msgid "It would help fact checkers a lot if you provide more detail :)"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:864
+#: src/webhook/handlers/utils.ts:872
 msgid "Provide detail"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:943
+#: src/webhook/handlers/utils.ts:951
 msgid "Did you forward this message as a whole to me from the LINE app?"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:969
-#: src/webhook/handlers/utils.ts:971
+#: src/webhook/handlers/utils.ts:977
+#: src/webhook/handlers/utils.ts:979
 msgid "Yes, I forwarded it as a whole"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:981
-#: src/webhook/handlers/utils.ts:983
+#: src/webhook/handlers/utils.ts:989
+#: src/webhook/handlers/utils.ts:991
 msgid "No, typed it myself"
 msgstr ""
 
@@ -1016,64 +1010,64 @@ msgstr ""
 msgid "${ dateStr } ago"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1175
+#: src/webhook/handlers/utils.ts:1183
 msgid "Similar file"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1176
+#: src/webhook/handlers/utils.ts:1184
 msgid "Contains relevant text"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1185
+#: src/webhook/handlers/utils.ts:1193
 msgid "(Text in the hyperlink)"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1189
+#: src/webhook/handlers/utils.ts:1197
 msgid "(Text in transcript)"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1265
+#: src/webhook/handlers/utils.ts:1273
 #, javascript-format
 msgid "I choose ${ displayTextWhenChosen }"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:253
+#: src/webhook/handlers/askingCooccurrence.ts:259
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid "There are some messages that looks similar to the ones you have sent to me."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:58
+#: src/webhook/handlers/askingCooccurrence.ts:59
 msgid "Please send me the messages separately."
 msgstr ""
 
-#: src/webhook/handlers/processBatch.ts:41
+#: src/webhook/handlers/processBatch.ts:39
 #, javascript-format
 msgid ""
 "May I ask if the ${ msgCount } messages above were sent by the same person "
 "at the same time?"
 msgstr ""
 
-#: src/webhook/handlers/processBatch.ts:50
+#: src/webhook/handlers/processBatch.ts:48
 msgid "Yes, same person at same time"
 msgstr ""
 
-#: src/webhook/handlers/processBatch.ts:60
+#: src/webhook/handlers/processBatch.ts:58
 msgid "No, from different person or at different time"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:141
+#: src/webhook/handlers/utils.ts:149
 msgid "replied at"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:642
+#: src/webhook/handlers/utils.ts:650
 #, javascript-format
 msgid ""
 "Someone on the internet replies to the message first reported on ${ "
 "articleDate }:"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:247
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:257
 msgid ""
 "This article is still under verification, please refrain from believing it "
 "for now. \n"
@@ -1081,34 +1075,34 @@ msgid ""
 "with some insights."
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:251
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:261
 #: src/webhook/handlers/choosingArticle.ts:406
 msgid "After reading the automatic analysis by the bot above, you can:"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:173
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:179
 msgid ""
 "Thank you for submitting! Now the messages has been recorded in the Cofacts "
 "database."
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:176
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:180
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:182
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:186
 msgid "Please choose the messages you would like to view"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:102
+#: src/webhook/handlers/askingCooccurrence.ts:108
 msgid "Be the first to report these messages"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:116
+#: src/webhook/handlers/askingCooccurrence.ts:122
 #, javascript-format
 msgid ""
 "The ${ notInDbMsgIndexes.length } messages that you have sent are not "
 "within the Cofacts database."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:117
+#: src/webhook/handlers/askingCooccurrence.ts:123
 #, javascript-format
 msgid ""
 "Out of the ${ totalCount } messages you sent, ${ notInDbMsgIndexes.length } "
@@ -1119,57 +1113,57 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:126
-#: src/webhook/handlers/utils.ts:176
+#: src/webhook/handlers/askingCooccurrence.ts:132
+#: src/webhook/handlers/utils.ts:184
 msgid "If you believe:"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:146
+#: src/webhook/handlers/askingCooccurrence.ts:152
 #. t: If you believe ~ a rumor 
 msgid "That they are most likely "
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:150
+#: src/webhook/handlers/askingCooccurrence.ts:156
 #. t: If you believe that it is most likely ~ 
 msgid "rumors,"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:178
-#: src/webhook/handlers/utils.ts:228
+#: src/webhook/handlers/askingCooccurrence.ts:184
+#: src/webhook/handlers/utils.ts:236
 #. t: ~ make this messasge public 
 msgid "And you are willing to "
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:182
+#: src/webhook/handlers/askingCooccurrence.ts:188
 #. t: and you are willing to ~ 
 msgid "make these messages public"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:198
+#: src/webhook/handlers/askingCooccurrence.ts:204
 #, javascript-format
 msgid "Press “${ btnText }” to make these messages public on Cofacts website "
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:171
+#: src/webhook/handlers/utils.ts:179
 msgid "We currently don’t have this message in our database."
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:196
+#: src/webhook/handlers/utils.ts:204
 #. t: If you believe ~ a rumor 
 msgid "That it is most likely "
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:200
+#: src/webhook/handlers/utils.ts:208
 #. t: If you believe that it is most likely ~ 
 msgid "a rumor,"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:232
+#: src/webhook/handlers/utils.ts:240
 #. t: and you are willing to ~ 
 msgid "make this message public"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:248
+#: src/webhook/handlers/utils.ts:256
 #, javascript-format
 msgid "Press “${ btnText }” to make this message public on Cofacts website "
 msgstr ""
@@ -1182,11 +1176,11 @@ msgstr ""
 msgid "unknown time"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:776
+#: src/webhook/handlers/utils.ts:784
 msgid "Provide feedback to AI analysis"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:791
+#: src/webhook/handlers/utils.ts:799
 msgid "Is the AI analysis helpful?"
 msgstr ""
 
@@ -1202,7 +1196,42 @@ msgstr ""
 msgid "Report AI analysis not helpful"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:687
+#: src/webhook/handlers/utils.ts:695
 #. t: max 20 characters 
 msgid "AI analysis"
+msgstr ""
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:92
+#, javascript-format
+msgid ""
+"I will spend some time processing the ${ msgsToSubmit.length } new "
+"message(s) you have submitted."
+msgstr ""
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:207
+msgid ""
+"I am now generating automated analysis for the message you have submitted, "
+"please wait."
+msgstr ""
+
+#: src/webhook/handlers/askingCooccurrence.ts:76
+#, javascript-format
+msgid ""
+"I will spend some time analyzing the ${ context.msgs.length } message(s) "
+"you have submitted, and will get back to you ASAP."
+msgstr ""
+
+#: src/webhook/handlers/processMedia.ts:40
+msgid ""
+"I will spend some time analyzing the message you have submitted, and will "
+"get back to you ASAP."
+msgstr ""
+
+#: src/webhook/handlers/utils.ts:1486
+msgid "I am still processing your request. Please wait."
+msgstr ""
+
+#: src/webhook/handlers/utils.ts:1542
+#: src/webhook/handlers/utils.ts:1547
+msgid "OK, proceed."
 msgstr ""

--- a/i18n/ja.po
+++ b/i18n/ja.po
@@ -65,9 +65,9 @@ msgstr "他のリプライを見たい場合、こちらに：${ articleUrl }"
 msgid "Choose this one"
 msgstr "これを選ぶ"
 
-#: src/webhook/handlers/askingCooccurrence.ts:263
+#: src/webhook/handlers/askingCooccurrence.ts:274
 #: src/webhook/handlers/initState.ts:191
-#: src/webhook/handlers/processMedia.ts:155
+#: src/webhook/handlers/processMedia.ts:157
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid ""
@@ -114,8 +114,8 @@ msgstr "いいえ"
 
 #: src/webhook/handlers/initState.ts:146
 #: src/webhook/handlers/initState.ts:164
-#: src/webhook/handlers/processMedia.ts:110
-#: src/webhook/handlers/processMedia.ts:128
+#: src/webhook/handlers/processMedia.ts:112
+#: src/webhook/handlers/processMedia.ts:130
 msgid "None of these messages matches mine :("
 msgstr "確認したい情報が見つかりません (T_T)"
 
@@ -126,13 +126,13 @@ msgid_plural "${ positive } users consider this helpful"
 msgstr[0] "${positive} 人がこのリプライは役に立っていると思っています"
 
 #: src/webhook/handlers/initState.ts:162
-#: src/webhook/handlers/processMedia.ts:126
+#: src/webhook/handlers/processMedia.ts:128
 msgid "Tell us more"
 msgstr "情報を報告する"
 
-#: src/webhook/handlers/askingCooccurrence.ts:268
+#: src/webhook/handlers/askingCooccurrence.ts:279
 #: src/webhook/handlers/initState.ts:178
-#: src/webhook/handlers/processMedia.ts:142
+#: src/webhook/handlers/processMedia.ts:144
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid "Please choose the most similar message from the list."
@@ -156,14 +156,14 @@ msgstr "${similarityPercentage}% 似ています"
 msgid "Wrong usage"
 msgstr "使い方は間違いました"
 
-#: src/webhook/handlers/singleUserHandler.ts:275
+#: src/webhook/handlers/singleUserHandler.ts:285
 #. Reuse existing context
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "新規の情報を検索しているため、先ほどまでの検索ボタンは無効になります。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:203
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:205
 #, javascript-format
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "提供していただいた情報はこちらに登録されています ${ articleUrl }"
@@ -204,7 +204,7 @@ msgid "Share to friends"
 msgstr "友達にシェアする"
 
 #: src/webhook/handlers/askingArticleSource.ts:34
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:56
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:57
 #: src/webhook/handlers/askingCooccurrence.ts:41
 #: src/webhook/handlers/choosingArticle.ts:72
 #: src/webhook/handlers/choosingReply.ts:152
@@ -669,27 +669,27 @@ msgstr ""
 
 #: src/webhook/handlers/askingArticleSource.ts:188
 #: src/webhook/handlers/choosingArticle.ts:117
-#: src/webhook/handlers/processMedia.ts:173
+#: src/webhook/handlers/processMedia.ts:175
 msgid "Do you want someone to fact-check this message?"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:82
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:83
 msgid "The message has not been reported and won’t be fact-checked. Thanks anyway!"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:224
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:234
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:226
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:236
 msgid ""
 "The message has now been recorded at Cofacts for volunteers to fact-check. "
 "Thank you for submitting!"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:240
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
 #: src/webhook/handlers/choosingArticle.ts:432
 msgid "View reported message"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:252
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:254
 #: src/webhook/handlers/choosingArticle.ts:378
 msgid "In the meantime, you can:"
 msgstr ""
@@ -737,31 +737,31 @@ msgid ""
 "still like to help."
 msgstr ""
 
-#: src/webhook/handlers/processMedia.ts:151
+#: src/webhook/handlers/processMedia.ts:153
 msgid "There are some messages that looks similar to the one you have sent to me."
 msgstr ""
 
-#: src/webhook/handlers/processMedia.ts:171
+#: src/webhook/handlers/processMedia.ts:173
 #. submit
 msgid ""
 "Unfortunately, I currently don’t recognize this message, but I would still "
 "like to help."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:102
+#: src/webhook/handlers/askingCooccurrence.ts:113
 #: src/webhook/handlers/utils.ts:163
 msgid "Report to database"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:210
+#: src/webhook/handlers/askingCooccurrence.ts:221
 #: src/webhook/handlers/utils.ts:262
 msgid ""
 "and have volunteers fact-check it. This way you can help the people who "
 "receive the same message in the future."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:232
-#: src/webhook/handlers/askingCooccurrence.ts:234
+#: src/webhook/handlers/askingCooccurrence.ts:243
+#: src/webhook/handlers/askingCooccurrence.ts:245
 #: src/webhook/handlers/utils.ts:290
 #: src/webhook/handlers/utils.ts:292
 msgid "Don’t report"
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "I choose ${ displayTextWhenChosen }"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:259
+#: src/webhook/handlers/askingCooccurrence.ts:270
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid "There are some messages that looks similar to the ones you have sent to me."
@@ -1067,7 +1067,7 @@ msgid ""
 "articleDate }:"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:257
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:259
 msgid ""
 "This article is still under verification, please refrain from believing it "
 "for now. \n"
@@ -1075,34 +1075,34 @@ msgid ""
 "with some insights."
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:261
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:263
 #: src/webhook/handlers/choosingArticle.ts:406
 msgid "After reading the automatic analysis by the bot above, you can:"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:179
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:181
 msgid ""
 "Thank you for submitting! Now the messages has been recorded in the Cofacts "
 "database."
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:182
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:186
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:184
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:188
 msgid "Please choose the messages you would like to view"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:108
+#: src/webhook/handlers/askingCooccurrence.ts:119
 msgid "Be the first to report these messages"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:122
+#: src/webhook/handlers/askingCooccurrence.ts:133
 #, javascript-format
 msgid ""
 "The ${ notInDbMsgIndexes.length } messages that you have sent are not "
 "within the Cofacts database."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:123
+#: src/webhook/handlers/askingCooccurrence.ts:134
 #, javascript-format
 msgid ""
 "Out of the ${ totalCount } messages you sent, ${ notInDbMsgIndexes.length } "
@@ -1113,33 +1113,33 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:132
+#: src/webhook/handlers/askingCooccurrence.ts:143
 #: src/webhook/handlers/utils.ts:184
 msgid "If you believe:"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:152
+#: src/webhook/handlers/askingCooccurrence.ts:163
 #. t: If you believe ~ a rumor 
 msgid "That they are most likely "
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:156
+#: src/webhook/handlers/askingCooccurrence.ts:167
 #. t: If you believe that it is most likely ~ 
 msgid "rumors,"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:184
+#: src/webhook/handlers/askingCooccurrence.ts:195
 #: src/webhook/handlers/utils.ts:236
 #. t: ~ make this messasge public 
 msgid "And you are willing to "
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:188
+#: src/webhook/handlers/askingCooccurrence.ts:199
 #. t: and you are willing to ~ 
 msgid "make these messages public"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:204
+#: src/webhook/handlers/askingCooccurrence.ts:215
 #, javascript-format
 msgid "Press “${ btnText }” to make these messages public on Cofacts website "
 msgstr ""
@@ -1201,37 +1201,36 @@ msgstr ""
 msgid "AI analysis"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:92
-#, javascript-format
-msgid ""
-"I will spend some time processing the ${ msgsToSubmit.length } new "
-"message(s) you have submitted."
-msgstr ""
-
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:207
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:209
 msgid ""
 "I am now generating automated analysis for the message you have submitted, "
 "please wait."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:76
-#, javascript-format
-msgid ""
-"I will spend some time analyzing the ${ context.msgs.length } message(s) "
-"you have submitted, and will get back to you ASAP."
-msgstr ""
-
-#: src/webhook/handlers/processMedia.ts:40
-msgid ""
-"I will spend some time analyzing the message you have submitted, and will "
-"get back to you ASAP."
-msgstr ""
-
-#: src/webhook/handlers/utils.ts:1486
+#: src/webhook/handlers/utils.ts:1513
 msgid "I am still processing your request. Please wait."
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1542
 #: src/webhook/handlers/utils.ts:1547
+#: src/webhook/handlers/utils.ts:1552
 msgid "OK, proceed."
+msgstr ""
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:93
+#, javascript-format
+msgid ""
+"I am currently sending the ${ msgsToSubmit.length } new message(s) you have "
+"submitted to the database."
+msgstr ""
+
+#: src/webhook/handlers/askingCooccurrence.ts:77
+#: src/webhook/handlers/askingCooccurrence.ts:91
+#, javascript-format
+msgid ""
+"Out of the ${ context.msgs.length } message(s) you have submitted, I am "
+"still analyzing ${ processingCount } of them."
+msgstr ""
+
+#: src/webhook/handlers/processMedia.ts:41
+msgid "I am still analyzing the media file you have submitted."
 msgstr ""

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -65,9 +65,9 @@ msgstr "更多回應請到：${ articleUrl }"
 msgid "Choose this one"
 msgstr "選擇這篇"
 
-#: src/webhook/handlers/askingCooccurrence.ts:263
+#: src/webhook/handlers/askingCooccurrence.ts:274
 #: src/webhook/handlers/initState.ts:191
-#: src/webhook/handlers/processMedia.ts:155
+#: src/webhook/handlers/processMedia.ts:157
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid ""
@@ -114,8 +114,8 @@ msgstr "否"
 
 #: src/webhook/handlers/initState.ts:146
 #: src/webhook/handlers/initState.ts:164
-#: src/webhook/handlers/processMedia.ts:110
-#: src/webhook/handlers/processMedia.ts:128
+#: src/webhook/handlers/processMedia.ts:112
+#: src/webhook/handlers/processMedia.ts:130
 msgid "None of these messages matches mine :("
 msgstr "找不到我想查的訊息 QQ"
 
@@ -126,13 +126,13 @@ msgid_plural "${ positive } users consider this helpful"
 msgstr[0] "有 ${positive} 人覺得此回應有幫助"
 
 #: src/webhook/handlers/initState.ts:162
-#: src/webhook/handlers/processMedia.ts:126
+#: src/webhook/handlers/processMedia.ts:128
 msgid "Tell us more"
 msgstr "回報此訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:268
+#: src/webhook/handlers/askingCooccurrence.ts:279
 #: src/webhook/handlers/initState.ts:178
-#: src/webhook/handlers/processMedia.ts:142
+#: src/webhook/handlers/processMedia.ts:144
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid "Please choose the most similar message from the list."
@@ -156,14 +156,14 @@ msgstr "看起來 ${similarityPercentage}% 像"
 msgid "Wrong usage"
 msgstr "這不是這樣用的"
 
-#: src/webhook/handlers/singleUserHandler.ts:275
+#: src/webhook/handlers/singleUserHandler.ts:285
 #. Reuse existing context
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "您已經在搜尋新的訊息了，過去查過的訊息的按鈕已經失效囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:203
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:205
 #, javascript-format
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "您回報的訊息已經被收錄至 ${ articleUrl }"
@@ -204,7 +204,7 @@ msgid "Share to friends"
 msgstr "分享給朋友"
 
 #: src/webhook/handlers/askingArticleSource.ts:34
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:56
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:57
 #: src/webhook/handlers/askingCooccurrence.ts:41
 #: src/webhook/handlers/choosingArticle.ts:72
 #: src/webhook/handlers/choosingReply.ts:152
@@ -806,7 +806,7 @@ msgstr "此訊息不存在。"
 msgid "The reply does not exist. Maybe it has been deleted by its author."
 msgstr "此回應不存在。或許已經被作者刪掉囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:240
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
 #: src/webhook/handlers/choosingArticle.ts:432
 msgid "View reported message"
 msgstr "檢視回報訊息"
@@ -835,7 +835,7 @@ msgstr ""
 "此訊息已經被收錄至 Cofacts 有待好心人來查證。\n"
 "請先不要相信這個訊息唷！"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:252
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:254
 #: src/webhook/handlers/choosingArticle.ts:378
 msgid "In the meantime, you can:"
 msgstr "接下來您可以："
@@ -907,16 +907,16 @@ msgstr "這樣呀。請先不要相信這個訊息唷！"
 
 #: src/webhook/handlers/askingArticleSource.ts:188
 #: src/webhook/handlers/choosingArticle.ts:117
-#: src/webhook/handlers/processMedia.ts:173
+#: src/webhook/handlers/processMedia.ts:175
 msgid "Do you want someone to fact-check this message?"
 msgstr "你要請人查查這則訊息嗎？"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:82
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:83
 msgid "The message has not been reported and won’t be fact-checked. Thanks anyway!"
 msgstr "好的，那就不查囉。還是謝謝你！"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:224
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:234
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:226
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:236
 msgid ""
 "The message has now been recorded at Cofacts for volunteers to fact-check. "
 "Thank you for submitting!"
@@ -936,20 +936,20 @@ msgid ""
 "still like to help."
 msgstr "抱歉我目前還不認得「${ inputSummary }」這個訊息，可是我還是想幫你查證。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:102
+#: src/webhook/handlers/askingCooccurrence.ts:113
 #: src/webhook/handlers/utils.ts:163
 msgid "Report to database"
 msgstr "送進資料庫查核"
 
-#: src/webhook/handlers/askingCooccurrence.ts:210
+#: src/webhook/handlers/askingCooccurrence.ts:221
 #: src/webhook/handlers/utils.ts:262
 msgid ""
 "and have volunteers fact-check it. This way you can help the people who "
 "receive the same message in the future."
 msgstr "、讓好心人查證與回覆。您可以幫助到未來同樣收到這份訊息的人。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:232
-#: src/webhook/handlers/askingCooccurrence.ts:234
+#: src/webhook/handlers/askingCooccurrence.ts:243
+#: src/webhook/handlers/askingCooccurrence.ts:245
 #: src/webhook/handlers/utils.ts:290
 #: src/webhook/handlers/utils.ts:292
 msgid "Don’t report"
@@ -978,7 +978,7 @@ msgstr "想先請教您一個問題："
 msgid "Provide better reply"
 msgstr "提供更好的回應"
 
-#: src/webhook/handlers/processMedia.ts:151
+#: src/webhook/handlers/processMedia.ts:153
 msgid "There are some messages that looks similar to the one you have sent to me."
 msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 
@@ -986,7 +986,7 @@ msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 msgid "I am sorry you cannot find the information you are looking for."
 msgstr "抱歉沒有找到你想要查詢的訊息。"
 
-#: src/webhook/handlers/processMedia.ts:171
+#: src/webhook/handlers/processMedia.ts:173
 #. submit
 msgid ""
 "Unfortunately, I currently don’t recognize this message, but I would still "
@@ -1031,7 +1031,7 @@ msgstr "逐字稿內的字"
 msgid "I choose ${ displayTextWhenChosen }"
 msgstr "我選 ${ displayTextWhenChosen }"
 
-#: src/webhook/handlers/askingCooccurrence.ts:259
+#: src/webhook/handlers/askingCooccurrence.ts:270
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid "There are some messages that looks similar to the ones you have sent to me."
@@ -1067,7 +1067,7 @@ msgid ""
 "articleDate }:"
 msgstr "網路上有人這樣回應這則 ${articleDate} 回報的訊息："
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:257
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:259
 msgid ""
 "This article is still under verification, please refrain from believing it "
 "for now. \n"
@@ -1077,34 +1077,34 @@ msgstr ""
 "這篇文章尚待查核中，請先不要相信這篇文章。\n"
 "以下是機器人初步分析此篇訊息的結果，希望能帶給你一些想法。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:261
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:263
 #: src/webhook/handlers/choosingArticle.ts:406
 msgid "After reading the automatic analysis by the bot above, you can:"
 msgstr "讀完以上機器人的自動分析後，您可以："
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:179
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:181
 msgid ""
 "Thank you for submitting! Now the messages has been recorded in the Cofacts "
 "database."
 msgstr "感謝提供！現在資料庫裡有這些訊息囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:182
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:186
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:184
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:188
 msgid "Please choose the messages you would like to view"
 msgstr "請選擇要查看的訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:108
+#: src/webhook/handlers/askingCooccurrence.ts:119
 msgid "Be the first to report these messages"
 msgstr "成為全球首位回報這些訊息的人"
 
-#: src/webhook/handlers/askingCooccurrence.ts:122
+#: src/webhook/handlers/askingCooccurrence.ts:133
 #, javascript-format
 msgid ""
 "The ${ notInDbMsgIndexes.length } messages that you have sent are not "
 "within the Cofacts database."
 msgstr "您傳的 ${ notInDbMsgIndexes.length } 則訊息，目前都不在 Cofacts 資料庫裡。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:123
+#: src/webhook/handlers/askingCooccurrence.ts:134
 #, javascript-format
 msgid ""
 "Out of the ${ totalCount } messages you sent, ${ notInDbMsgIndexes.length } "
@@ -1114,33 +1114,33 @@ msgid_plural ""
 "are not within the Cofacts database."
 msgstr[0] "在您傳的 ${ totalCount } 則訊息中，有 ${ notInDbMsgIndexes.length } 則不在 Cofacts 資料庫裡。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:132
+#: src/webhook/handlers/askingCooccurrence.ts:143
 #: src/webhook/handlers/utils.ts:184
 msgid "If you believe:"
 msgstr "若您覺得："
 
-#: src/webhook/handlers/askingCooccurrence.ts:152
+#: src/webhook/handlers/askingCooccurrence.ts:163
 #. t: If you believe ~ a rumor
 msgid "That they are most likely "
 msgstr "它們很可能是"
 
-#: src/webhook/handlers/askingCooccurrence.ts:156
+#: src/webhook/handlers/askingCooccurrence.ts:167
 #. t: If you believe that it is most likely ~
 msgid "rumors,"
 msgstr "謠言"
 
-#: src/webhook/handlers/askingCooccurrence.ts:184
+#: src/webhook/handlers/askingCooccurrence.ts:195
 #: src/webhook/handlers/utils.ts:236
 #. t: ~ make this messasge public
 msgid "And you are willing to "
 msgstr "您願意"
 
-#: src/webhook/handlers/askingCooccurrence.ts:188
+#: src/webhook/handlers/askingCooccurrence.ts:199
 #. t: and you are willing to ~
 msgid "make these messages public"
 msgstr "公開這些訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:204
+#: src/webhook/handlers/askingCooccurrence.ts:215
 #, javascript-format
 msgid "Press “${ btnText }” to make these messages public on Cofacts website "
 msgstr "請按「${ btnText }」在 Cofacts 網站公開它們"
@@ -1202,37 +1202,36 @@ msgstr "回報 AI 分析沒幫助"
 msgid "AI analysis"
 msgstr "AI 自動分析"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:92
-#, javascript-format
-msgid ""
-"I will spend some time processing the ${ msgsToSubmit.length } new "
-"message(s) you have submitted."
-msgstr "我會花點時間處理您送進資料庫的 ${ msgsToSubmit.length } 則新訊息。"
-
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:207
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:209
 msgid ""
 "I am now generating automated analysis for the message you have submitted, "
 "please wait."
-msgstr "我正在為您回報的訊息生成 AI 自動分析，請稍等。"
+msgstr "我正在為您所回報的訊息生成 AI 自動分析，請稍等。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:76
-#, javascript-format
-msgid ""
-"I will spend some time analyzing the ${ context.msgs.length } message(s) "
-"you have submitted, and will get back to you ASAP."
-msgstr "我會花點時間分析您傳給我的 ${ context.msgs.length } 則訊息，並會盡快回覆您。"
-
-#: src/webhook/handlers/processMedia.ts:40
-msgid ""
-"I will spend some time analyzing the message you have submitted, and will "
-"get back to you ASAP."
-msgstr "我會花點時間分析您傳給我的訊息，並會盡快回覆您。"
-
-#: src/webhook/handlers/utils.ts:1486
+#: src/webhook/handlers/utils.ts:1513
 msgid "I am still processing your request. Please wait."
-msgstr "我還在處理您的請求，請稍等。"
+msgstr "我還在處理您的需求，請稍等。"
 
-#: src/webhook/handlers/utils.ts:1542
 #: src/webhook/handlers/utils.ts:1547
+#: src/webhook/handlers/utils.ts:1552
 msgid "OK, proceed."
 msgstr "好，請繼續。"
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:93
+#, javascript-format
+msgid ""
+"I am currently sending the ${ msgsToSubmit.length } new message(s) you have "
+"submitted to the database."
+msgstr "我現在正將您的 ${ msgsToSubmit.length } 則新訊息送進資料庫。"
+
+#: src/webhook/handlers/askingCooccurrence.ts:77
+#: src/webhook/handlers/askingCooccurrence.ts:91
+#, javascript-format
+msgid ""
+"Out of the ${ context.msgs.length } message(s) you have submitted, I am "
+"still analyzing ${ processingCount } of them."
+msgstr "我仍在分析您所送出的 ${ context.msgs.length } 則訊息的其中 ${ processingCount } 則。"
+
+#: src/webhook/handlers/processMedia.ts:41
+msgid "I am still analyzing the media file you have submitted."
+msgstr "我仍在分析您傳來的影音檔案。"

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -6,11 +6,11 @@ msgstr ""
 "mime-version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/webhook/handlers/utils.ts:98
+#: src/webhook/handlers/utils.ts:106
 msgid "No feedback yet"
 msgstr "還沒有人針對此回應評價"
 
-#: src/webhook/handlers/utils.ts:112
+#: src/webhook/handlers/utils.ts:120
 msgid "${ negative } user consider this not useful"
 msgid_plural "${ negative } users consider this not useful"
 msgstr[0] "有 ${negative} 人覺得此回應沒幫助"
@@ -31,15 +31,15 @@ msgstr "含有個人意見"
 msgid "Invalid request"
 msgstr "不在查證範圍"
 
-#: src/webhook/handlers/utils.ts:139
+#: src/webhook/handlers/utils.ts:147
 msgid "different opinions"
 msgstr "不同觀點"
 
-#: src/webhook/handlers/utils.ts:139
+#: src/webhook/handlers/utils.ts:147
 msgid "references"
 msgstr "出處"
 
-#: src/webhook/handlers/utils.ts:145
+#: src/webhook/handlers/utils.ts:153
 #, javascript-format
 msgid "This reply has no ${ prompt } and it may be biased"
 msgstr "此回應沒有${prompt}，請自行斟酌回應之可信度。"
@@ -61,13 +61,13 @@ msgstr "看他怎麼說"
 msgid "Visit ${ articleUrl } for more replies."
 msgstr "更多回應請到：${ articleUrl }"
 
-#: src/webhook/handlers/utils.ts:1263
+#: src/webhook/handlers/utils.ts:1271
 msgid "Choose this one"
 msgstr "選擇這篇"
 
-#: src/webhook/handlers/askingCooccurrence.ts:257
-#: src/webhook/handlers/initState.ts:188
-#: src/webhook/handlers/processMedia.ts:150
+#: src/webhook/handlers/askingCooccurrence.ts:263
+#: src/webhook/handlers/initState.ts:191
+#: src/webhook/handlers/processMedia.ts:155
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid ""
@@ -77,18 +77,18 @@ msgstr ""
 "不實訊息常常會被人修改重發。\n"
 "請選擇比較接近的版本"
 
-#: src/webhook/handlers/utils.ts:737
+#: src/webhook/handlers/utils.ts:745
 #, javascript-format
 msgid "Therefore, the author think the message ${ typeStr }."
 msgstr "綜合以上，回應者認為它${typeStr}。"
 
-#: src/webhook/handlers/utils.ts:740
+#: src/webhook/handlers/utils.ts:748
 msgid ""
 "There are different replies for the message. Read them all here before "
 "making judgements:"
 msgstr "這則訊息有很多不同回應，建議到這裡一次讀完再下判斷："
 
-#: src/webhook/handlers/utils.ts:742
+#: src/webhook/handlers/utils.ts:750
 msgid "If you have different thoughts, you may have your say here:"
 msgstr "如果你對這則訊息有不同看法，歡迎到下面這裡寫入新的回應："
 
@@ -100,39 +100,39 @@ msgstr "請問上面回應是否有幫助？"
 
 #: src/liff/components/FeedbackForm.svelte:27
 #: src/webhook/handlers/choosingReply.ts:63
-#: src/webhook/handlers/processBatch.ts:48
-#: src/webhook/handlers/utils.ts:806
+#: src/webhook/handlers/processBatch.ts:46
+#: src/webhook/handlers/utils.ts:814
 msgid "Yes"
 msgstr "是"
 
 #: src/liff/components/FeedbackForm.svelte:30
 #: src/webhook/handlers/choosingReply.ts:73
-#: src/webhook/handlers/processBatch.ts:58
-#: src/webhook/handlers/utils.ts:816
+#: src/webhook/handlers/processBatch.ts:56
+#: src/webhook/handlers/utils.ts:824
 msgid "No"
 msgstr "否"
 
-#: src/webhook/handlers/initState.ts:143
-#: src/webhook/handlers/initState.ts:161
-#: src/webhook/handlers/processMedia.ts:105
-#: src/webhook/handlers/processMedia.ts:123
+#: src/webhook/handlers/initState.ts:146
+#: src/webhook/handlers/initState.ts:164
+#: src/webhook/handlers/processMedia.ts:110
+#: src/webhook/handlers/processMedia.ts:128
 msgid "None of these messages matches mine :("
 msgstr "找不到我想查的訊息 QQ"
 
-#: src/webhook/handlers/utils.ts:103
+#: src/webhook/handlers/utils.ts:111
 #, javascript-format
 msgid "${ positive } user considers this helpful"
 msgid_plural "${ positive } users consider this helpful"
 msgstr[0] "有 ${positive} 人覺得此回應有幫助"
 
-#: src/webhook/handlers/initState.ts:159
-#: src/webhook/handlers/processMedia.ts:121
+#: src/webhook/handlers/initState.ts:162
+#: src/webhook/handlers/processMedia.ts:126
 msgid "Tell us more"
 msgstr "回報此訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:262
-#: src/webhook/handlers/initState.ts:175
-#: src/webhook/handlers/processMedia.ts:137
+#: src/webhook/handlers/askingCooccurrence.ts:268
+#: src/webhook/handlers/initState.ts:178
+#: src/webhook/handlers/processMedia.ts:142
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid "Please choose the most similar message from the list."
@@ -147,29 +147,23 @@ msgstr "請從下列選擇您要查看的回應。"
 msgid "Someone thinks it ${ typeWords }"
 msgstr "有人認為它${typeWords}"
 
-#: src/webhook/handlers/utils.ts:1173
+#: src/webhook/handlers/utils.ts:1181
 #, javascript-format
 msgid "Looks ${ similarityPercentage }% similar"
 msgstr "看起來 ${similarityPercentage}% 像"
 
-#: src/webhook/handlers/singleUserHandler.ts:82
-msgid ""
-"Line bot is busy, or we cannot handle this message. Maybe you can try again "
-"a few minutes later."
-msgstr "不好意思！系統可能在忙線中，無法及時處理您傳的訊息。請稍等幾分鐘再試試看唷。"
-
-#: src/webhook/handlers/handlePostback.ts:86
+#: src/webhook/handlers/handlePostback.ts:95
 msgid "Wrong usage"
 msgstr "這不是這樣用的"
 
-#: src/webhook/handlers/singleUserHandler.ts:283
+#: src/webhook/handlers/singleUserHandler.ts:275
 #. Reuse existing context
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "您已經在搜尋新的訊息了，過去查過的訊息的按鈕已經失效囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:197
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:203
 #, javascript-format
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "您回報的訊息已經被收錄至 ${ articleUrl }"
@@ -210,8 +204,8 @@ msgid "Share to friends"
 msgstr "分享給朋友"
 
 #: src/webhook/handlers/askingArticleSource.ts:34
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:55
-#: src/webhook/handlers/askingCooccurrence.ts:40
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:56
+#: src/webhook/handlers/askingCooccurrence.ts:41
 #: src/webhook/handlers/choosingArticle.ts:72
 #: src/webhook/handlers/choosingReply.ts:152
 msgid "Please choose from provided options."
@@ -262,7 +256,7 @@ msgid "There is ${ otherReplyRequestCount } user also waiting for clarification.
 msgid_plural "There are ${ otherReplyRequestCount } users also waiting for clarification."
 msgstr[0] "另有 ${ otherReplyRequestCount } 人跟您一樣渴望看到針對這篇訊息的回應。"
 
-#: src/webhook/handlers/initState.ts:184
+#: src/webhook/handlers/initState.ts:187
 #, javascript-format
 msgid ""
 "There are some messages that looks similar to \"${ inputSummary }\" you "
@@ -273,29 +267,29 @@ msgstr "資料庫裡有幾篇訊息，跟您傳給我的「${ inputSummary }」�
 msgid "Please proceed on your mobile phone."
 msgstr "請在您的手機上繼續操作。"
 
-#: src/webhook/handlers/utils.ts:159
+#: src/webhook/handlers/utils.ts:167
 msgid "Be the first to report the message"
 msgstr "成為全球首位回報此訊息的人"
 
-#: src/webhook/handlers/utils.ts:341
+#: src/webhook/handlers/utils.ts:349
 msgid "Share on LINE"
 msgstr "在 LINE 上問人"
 
-#: src/webhook/handlers/utils.ts:343
+#: src/webhook/handlers/utils.ts:351
 #, javascript-format
 msgid "Please help me verify if this is true: ${ articleUrl }"
 msgstr "請幫我看看這是真的還是假的：${ articleUrl }"
 
-#: src/webhook/handlers/utils.ts:353
+#: src/webhook/handlers/utils.ts:361
 msgid "Share on Facebook"
 msgstr "請教臉書大神"
 
-#: src/webhook/handlers/utils.ts:357
+#: src/webhook/handlers/utils.ts:365
 #. t: Facebook hash tag
 msgid "ReportedToCofacts"
 msgstr "Cofacts求解惑"
 
-#: src/webhook/handlers/utils.ts:455
+#: src/webhook/handlers/utils.ts:463
 msgid ""
 "We suggest forwarding the message to the following fact-checkers instead. "
 "They have 💁 1-on-1 Q&A service to respond to your questions."
@@ -467,11 +461,11 @@ msgstr "目前沒有設定選項 :)"
 msgid "You can configure Cofacts here to meet your need."
 msgstr "您可以在這裡設定 Cofacts 以符合需求。"
 
-#: src/webhook/handlers/utils.ts:406
+#: src/webhook/handlers/utils.ts:414
 msgid "Go to settings"
 msgstr "前往設定"
 
-#: src/webhook/handlers/utils.ts:382
+#: src/webhook/handlers/utils.ts:390
 msgid "Receive updates"
 msgstr "開啟小鈴鐺"
 
@@ -602,7 +596,7 @@ msgid ""
 "database."
 msgstr "如果我找不到的話，會徵求你的同意，看看要不要把這個訊息送進資料庫唷。"
 
-#: src/webhook/handlers/utils.ts:738
+#: src/webhook/handlers/utils.ts:746
 msgid ""
 "This content is provided by Cofact message reporting chatbot and "
 "crowd-sourced fact-checking community under CC BY-SA 4.0 license. Please "
@@ -611,7 +605,7 @@ msgstr ""
 "此內容由「Cofacts 真的假的」訊息回報機器人與查核協作社群提供，以創用 CC 姓名標示-相同方式分享 4.0 國際 "
 "授權條款釋出。請斟酌出處與理由，自行思考判斷。"
 
-#: src/webhook/handlers/utils.ts:713
+#: src/webhook/handlers/utils.ts:721
 msgid "I found that there are some disagreement to the message:"
 msgstr "剛剛這則訊息，我查過似乎發現有點問題。有另外一種說法是："
 
@@ -619,7 +613,7 @@ msgstr "剛剛這則訊息，我查過似乎發現有點問題。有另外一種
 msgid "Hi i am cofacts chat bot"
 msgstr "Hi 我是「Cofacts 真的假的」訊息查證機器人～"
 
-#: src/webhook/handlers/utils.ts:713
+#: src/webhook/handlers/utils.ts:721
 msgid "Thank you for sharing “${ inputSummary }”"
 msgstr "感謝您的分享 “${ inputSummary }”"
 
@@ -812,22 +806,22 @@ msgstr "此訊息不存在。"
 msgid "The reply does not exist. Maybe it has been deleted by its author."
 msgstr "此回應不存在。或許已經被作者刪掉囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:230
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:240
 #: src/webhook/handlers/choosingArticle.ts:432
 msgid "View reported message"
 msgstr "檢視回報訊息"
 
 #: src/webhook/handlers/askingArticleSource.ts:77
 #: src/webhook/handlers/choosingArticle.ts:444
-#: src/webhook/handlers/utils.ts:838
+#: src/webhook/handlers/utils.ts:846
 msgid "Provide more detail"
 msgstr "提供更多情報"
 
-#: src/webhook/handlers/utils.ts:851
+#: src/webhook/handlers/utils.ts:859
 msgid "It would help fact checkers a lot if you provide more detail :)"
 msgstr "您可以提供更多關於此訊息的情報給查證志工，讓好心人更容易查真假唷！"
 
-#: src/webhook/handlers/utils.ts:864
+#: src/webhook/handlers/utils.ts:872
 msgid "Provide detail"
 msgstr "提供更多情報"
 
@@ -841,18 +835,18 @@ msgstr ""
 "此訊息已經被收錄至 Cofacts 有待好心人來查證。\n"
 "請先不要相信這個訊息唷！"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:252
 #: src/webhook/handlers/choosingArticle.ts:378
 msgid "In the meantime, you can:"
 msgstr "接下來您可以："
 
-#: src/webhook/handlers/utils.ts:328
+#: src/webhook/handlers/utils.ts:336
 msgid ""
 "We all get by with a little help from our friends 🌟 Share your question to "
 "friends, someone might be able to help!"
 msgstr "遠親不如近鄰🌟問問親友總沒錯。把訊息分享給朋友們，說不定有人能幫你解惑！"
 
-#: src/webhook/handlers/utils.ts:393
+#: src/webhook/handlers/utils.ts:401
 msgid ""
 "You can turn on notifications if you want Cofacts to notify you when "
 "someone replies to this message."
@@ -913,16 +907,16 @@ msgstr "這樣呀。請先不要相信這個訊息唷！"
 
 #: src/webhook/handlers/askingArticleSource.ts:188
 #: src/webhook/handlers/choosingArticle.ts:117
-#: src/webhook/handlers/processMedia.ts:168
+#: src/webhook/handlers/processMedia.ts:173
 msgid "Do you want someone to fact-check this message?"
 msgstr "你要請人查查這則訊息嗎？"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:81
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:82
 msgid "The message has not been reported and won’t be fact-checked. Thanks anyway!"
 msgstr "好的，那就不查囉。還是謝謝你！"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:214
 #: src/webhook/handlers/askingArticleSubmissionConsent.ts:224
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:234
 msgid ""
 "The message has now been recorded at Cofacts for volunteers to fact-check. "
 "Thank you for submitting!"
@@ -935,48 +929,48 @@ msgid ""
 "looking for. But I would still like to help."
 msgstr "抱歉沒有找到你想要查詢的「${ inputSummary }」。可是我還是想幫你查證。"
 
-#: src/webhook/handlers/initState.ts:204
+#: src/webhook/handlers/initState.ts:207
 #, javascript-format
 msgid ""
 "Unfortunately, I currently don’t recognize “${ inputSummary }”, but I would "
 "still like to help."
 msgstr "抱歉我目前還不認得「${ inputSummary }」這個訊息，可是我還是想幫你查證。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:96
-#: src/webhook/handlers/utils.ts:155
+#: src/webhook/handlers/askingCooccurrence.ts:102
+#: src/webhook/handlers/utils.ts:163
 msgid "Report to database"
 msgstr "送進資料庫查核"
 
-#: src/webhook/handlers/askingCooccurrence.ts:204
-#: src/webhook/handlers/utils.ts:254
+#: src/webhook/handlers/askingCooccurrence.ts:210
+#: src/webhook/handlers/utils.ts:262
 msgid ""
 "and have volunteers fact-check it. This way you can help the people who "
 "receive the same message in the future."
 msgstr "、讓好心人查證與回覆。您可以幫助到未來同樣收到這份訊息的人。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:226
-#: src/webhook/handlers/askingCooccurrence.ts:228
-#: src/webhook/handlers/utils.ts:282
-#: src/webhook/handlers/utils.ts:284
+#: src/webhook/handlers/askingCooccurrence.ts:232
+#: src/webhook/handlers/askingCooccurrence.ts:234
+#: src/webhook/handlers/utils.ts:290
+#: src/webhook/handlers/utils.ts:292
 msgid "Don’t report"
 msgstr "我不想回報訊息"
 
-#: src/webhook/handlers/utils.ts:943
+#: src/webhook/handlers/utils.ts:951
 msgid "Did you forward this message as a whole to me from the LINE app?"
 msgstr "請問這個訊息是你從 LINE 裡整篇分享給我的嗎？"
 
-#: src/webhook/handlers/utils.ts:969
-#: src/webhook/handlers/utils.ts:971
+#: src/webhook/handlers/utils.ts:977
+#: src/webhook/handlers/utils.ts:979
 msgid "Yes, I forwarded it as a whole"
 msgstr "是，我整篇分享過來的"
 
-#: src/webhook/handlers/utils.ts:981
-#: src/webhook/handlers/utils.ts:983
+#: src/webhook/handlers/utils.ts:989
+#: src/webhook/handlers/utils.ts:991
 msgid "No, typed it myself"
 msgstr "否，我自行打字輸入的"
 
 #: src/webhook/handlers/choosingArticle.ts:104
-#: src/webhook/handlers/initState.ts:206
+#: src/webhook/handlers/initState.ts:209
 msgid "May I ask you a quick question?"
 msgstr "想先請教您一個問題："
 
@@ -984,7 +978,7 @@ msgstr "想先請教您一個問題："
 msgid "Provide better reply"
 msgstr "提供更好的回應"
 
-#: src/webhook/handlers/processMedia.ts:146
+#: src/webhook/handlers/processMedia.ts:151
 msgid "There are some messages that looks similar to the one you have sent to me."
 msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 
@@ -992,7 +986,7 @@ msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 msgid "I am sorry you cannot find the information you are looking for."
 msgstr "抱歉沒有找到你想要查詢的訊息。"
 
-#: src/webhook/handlers/processMedia.ts:166
+#: src/webhook/handlers/processMedia.ts:171
 #. submit
 msgid ""
 "Unfortunately, I currently don’t recognize this message, but I would still "
@@ -1016,64 +1010,64 @@ msgstr "尚未支援預覽"
 msgid "An audio"
 msgstr "語音訊息一則"
 
-#: src/webhook/handlers/utils.ts:1175
+#: src/webhook/handlers/utils.ts:1183
 msgid "Similar file"
 msgstr "相似檔案"
 
-#: src/webhook/handlers/utils.ts:1176
+#: src/webhook/handlers/utils.ts:1184
 msgid "Contains relevant text"
 msgstr "含有相關文字"
 
-#: src/webhook/handlers/utils.ts:1185
+#: src/webhook/handlers/utils.ts:1193
 msgid "(Text in the hyperlink)"
 msgstr "網址內的字"
 
-#: src/webhook/handlers/utils.ts:1189
+#: src/webhook/handlers/utils.ts:1197
 msgid "(Text in transcript)"
 msgstr "逐字稿內的字"
 
-#: src/webhook/handlers/utils.ts:1265
+#: src/webhook/handlers/utils.ts:1273
 #, javascript-format
 msgid "I choose ${ displayTextWhenChosen }"
 msgstr "我選 ${ displayTextWhenChosen }"
 
-#: src/webhook/handlers/askingCooccurrence.ts:253
+#: src/webhook/handlers/askingCooccurrence.ts:259
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid "There are some messages that looks similar to the ones you have sent to me."
 msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:58
+#: src/webhook/handlers/askingCooccurrence.ts:59
 msgid "Please send me the messages separately."
 msgstr "好的，那再請您將這些訊息一則一則分開傳給我唷。"
 
-#: src/webhook/handlers/processBatch.ts:41
+#: src/webhook/handlers/processBatch.ts:39
 #, javascript-format
 msgid ""
 "May I ask if the ${ msgCount } messages above were sent by the same person "
 "at the same time?"
 msgstr "請問這 ${ msgCount } 則訊息，是由同一個人、同時傳送的嗎？"
 
-#: src/webhook/handlers/processBatch.ts:50
+#: src/webhook/handlers/processBatch.ts:48
 msgid "Yes, same person at same time"
 msgstr "是同一人、同時傳送的"
 
-#: src/webhook/handlers/processBatch.ts:60
+#: src/webhook/handlers/processBatch.ts:58
 msgid "No, from different person or at different time"
 msgstr "是由不同人、或不同時間傳的"
 
-#: src/webhook/handlers/utils.ts:141
+#: src/webhook/handlers/utils.ts:149
 msgid "replied at"
 msgstr "回應日期"
 
-#: src/webhook/handlers/utils.ts:642
+#: src/webhook/handlers/utils.ts:650
 #, javascript-format
 msgid ""
 "Someone on the internet replies to the message first reported on ${ "
 "articleDate }:"
 msgstr "網路上有人這樣回應這則 ${articleDate} 回報的訊息："
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:247
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:257
 msgid ""
 "This article is still under verification, please refrain from believing it "
 "for now. \n"
@@ -1083,34 +1077,34 @@ msgstr ""
 "這篇文章尚待查核中，請先不要相信這篇文章。\n"
 "以下是機器人初步分析此篇訊息的結果，希望能帶給你一些想法。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:251
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:261
 #: src/webhook/handlers/choosingArticle.ts:406
 msgid "After reading the automatic analysis by the bot above, you can:"
 msgstr "讀完以上機器人的自動分析後，您可以："
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:173
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:179
 msgid ""
 "Thank you for submitting! Now the messages has been recorded in the Cofacts "
 "database."
 msgstr "感謝提供！現在資料庫裡有這些訊息囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:176
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:180
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:182
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:186
 msgid "Please choose the messages you would like to view"
 msgstr "請選擇要查看的訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:102
+#: src/webhook/handlers/askingCooccurrence.ts:108
 msgid "Be the first to report these messages"
 msgstr "成為全球首位回報這些訊息的人"
 
-#: src/webhook/handlers/askingCooccurrence.ts:116
+#: src/webhook/handlers/askingCooccurrence.ts:122
 #, javascript-format
 msgid ""
 "The ${ notInDbMsgIndexes.length } messages that you have sent are not "
 "within the Cofacts database."
 msgstr "您傳的 ${ notInDbMsgIndexes.length } 則訊息，目前都不在 Cofacts 資料庫裡。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:117
+#: src/webhook/handlers/askingCooccurrence.ts:123
 #, javascript-format
 msgid ""
 "Out of the ${ totalCount } messages you sent, ${ notInDbMsgIndexes.length } "
@@ -1120,57 +1114,57 @@ msgid_plural ""
 "are not within the Cofacts database."
 msgstr[0] "在您傳的 ${ totalCount } 則訊息中，有 ${ notInDbMsgIndexes.length } 則不在 Cofacts 資料庫裡。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:126
-#: src/webhook/handlers/utils.ts:176
+#: src/webhook/handlers/askingCooccurrence.ts:132
+#: src/webhook/handlers/utils.ts:184
 msgid "If you believe:"
 msgstr "若您覺得："
 
-#: src/webhook/handlers/askingCooccurrence.ts:146
+#: src/webhook/handlers/askingCooccurrence.ts:152
 #. t: If you believe ~ a rumor
 msgid "That they are most likely "
 msgstr "它們很可能是"
 
-#: src/webhook/handlers/askingCooccurrence.ts:150
+#: src/webhook/handlers/askingCooccurrence.ts:156
 #. t: If you believe that it is most likely ~
 msgid "rumors,"
 msgstr "謠言"
 
-#: src/webhook/handlers/askingCooccurrence.ts:178
-#: src/webhook/handlers/utils.ts:228
+#: src/webhook/handlers/askingCooccurrence.ts:184
+#: src/webhook/handlers/utils.ts:236
 #. t: ~ make this messasge public
 msgid "And you are willing to "
 msgstr "您願意"
 
-#: src/webhook/handlers/askingCooccurrence.ts:182
+#: src/webhook/handlers/askingCooccurrence.ts:188
 #. t: and you are willing to ~
 msgid "make these messages public"
 msgstr "公開這些訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:198
+#: src/webhook/handlers/askingCooccurrence.ts:204
 #, javascript-format
 msgid "Press “${ btnText }” to make these messages public on Cofacts website "
 msgstr "請按「${ btnText }」在 Cofacts 網站公開它們"
 
-#: src/webhook/handlers/utils.ts:171
+#: src/webhook/handlers/utils.ts:179
 msgid "We currently don’t have this message in our database."
 msgstr "目前資料庫裡沒有您傳的訊息。"
 
-#: src/webhook/handlers/utils.ts:196
+#: src/webhook/handlers/utils.ts:204
 #. t: If you believe ~ a rumor
 msgid "That it is most likely "
 msgstr "它很可能是"
 
-#: src/webhook/handlers/utils.ts:200
+#: src/webhook/handlers/utils.ts:208
 #. t: If you believe that it is most likely ~
 msgid "a rumor,"
 msgstr "謠言"
 
-#: src/webhook/handlers/utils.ts:232
+#: src/webhook/handlers/utils.ts:240
 #. t: and you are willing to ~
 msgid "make this message public"
 msgstr "公開這則訊息"
 
-#: src/webhook/handlers/utils.ts:248
+#: src/webhook/handlers/utils.ts:256
 #, javascript-format
 msgid "Press “${ btnText }” to make this message public on Cofacts website "
 msgstr "請按「${ btnText }」在 Cofacts 網站公開它"
@@ -1183,11 +1177,11 @@ msgstr "未知日期"
 msgid "unknown time"
 msgstr "未知時間"
 
-#: src/webhook/handlers/utils.ts:776
+#: src/webhook/handlers/utils.ts:784
 msgid "Provide feedback to AI analysis"
 msgstr "評價 AI 自動分析"
 
-#: src/webhook/handlers/utils.ts:791
+#: src/webhook/handlers/utils.ts:799
 msgid "Is the AI analysis helpful?"
 msgstr "這則 AI 分析是否有幫助？"
 
@@ -1203,7 +1197,42 @@ msgstr "回報 AI 分析有幫助"
 msgid "Report AI analysis not helpful"
 msgstr "回報 AI 分析沒幫助"
 
-#: src/webhook/handlers/utils.ts:687
+#: src/webhook/handlers/utils.ts:695
 #. t: max 20 characters
 msgid "AI analysis"
 msgstr "AI 自動分析"
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:92
+#, javascript-format
+msgid ""
+"I will spend some time processing the ${ msgsToSubmit.length } new "
+"message(s) you have submitted."
+msgstr "我會花點時間處理您送進資料庫的 ${ msgsToSubmit.length } 則新訊息。"
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:207
+msgid ""
+"I am now generating automated analysis for the message you have submitted, "
+"please wait."
+msgstr "我正在為您回報的訊息生成 AI 自動分析，請稍等。"
+
+#: src/webhook/handlers/askingCooccurrence.ts:76
+#, javascript-format
+msgid ""
+"I will spend some time analyzing the ${ context.msgs.length } message(s) "
+"you have submitted, and will get back to you ASAP."
+msgstr "我會花點時間分析您傳給我的 ${ context.msgs.length } 則訊息，並會盡快回覆您。"
+
+#: src/webhook/handlers/processMedia.ts:40
+msgid ""
+"I will spend some time analyzing the message you have submitted, and will "
+"get back to you ASAP."
+msgstr "我會花點時間分析您傳給我的訊息，並會盡快回覆您。"
+
+#: src/webhook/handlers/utils.ts:1486
+msgid "I am still processing your request. Please wait."
+msgstr "我還在處理您的請求，請稍等。"
+
+#: src/webhook/handlers/utils.ts:1542
+#: src/webhook/handlers/utils.ts:1547
+msgid "OK, proceed."
+msgstr "好，請繼續。"

--- a/scripts/setup-jest.js
+++ b/scripts/setup-jest.js
@@ -6,8 +6,11 @@ require('dotenv').config({
 
 // Must import Client after dotenv, so that MONGODB_URI in mongoClient file can get correct value
 const { default: Client } = require('../src/database/mongoClient');
+const { default: redis } = require('../src/lib/redisClient');
 
 afterAll(async () => {
-  // Close MongoDB connection after each test
+  // Close MongoDB connection after test
   await (await Client.getInstance()).close();
+  // Close redis connection after test
+  await redis.quit();
 });

--- a/scripts/setup-jest.js
+++ b/scripts/setup-jest.js
@@ -9,8 +9,8 @@ const { default: Client } = require('../src/database/mongoClient');
 const { default: redis } = require('../src/lib/redisClient');
 
 afterAll(async () => {
-  // Close MongoDB connection after test
+  // Close MongoDB connection after each test
   await (await Client.getInstance()).close();
-  // Close redis connection after test
+  // Close redis connection after each test
   await redis.quit();
 });

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -8,6 +8,7 @@ export type ChatbotState =
   | 'ASKING_ARTICLE_SOURCE'
   | 'ASKING_ARTICLE_SUBMISSION_CONSENT'
   | 'ASKING_COOCCURRENCE'
+  | 'CONTINUE' // quick reply from reply token collection
   | 'Error';
 
 export type LegacyContext = {
@@ -34,6 +35,12 @@ export type Context = {
   /** Used to differientiate different search sessions (searched text or media) */
   sessionId: number;
   msgs: ReadonlyArray<CooccurredMessage>;
+
+  /** Latest reply token that is not consumed yet */
+  replyToken?: {
+    token: string;
+    receivedAt: number;
+  };
 };
 
 /** A single messages in the same co-occurrence */

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -35,6 +35,11 @@ export type Context = {
   /** Used to differientiate different search sessions (searched text or media) */
   sessionId: number;
   msgs: ReadonlyArray<CooccurredMessage>;
+
+  /**
+   * Message to show when sending reply token collector before the current reply token expires.
+   */
+  replyTokenCollectorMsg?: string;
 };
 
 /** Latest reply token in Redis that is not consumed yet */

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -35,13 +35,12 @@ export type Context = {
   /** Used to differientiate different search sessions (searched text or media) */
   sessionId: number;
   msgs: ReadonlyArray<CooccurredMessage>;
+};
 
-  /** Latest reply token that is not consumed yet */
-  replyToken?: {
-    token: string;
-    // Is this field used anywhere, AI?
-    receivedAt: number;
-  };
+/** Latest reply token in Redis that is not consumed yet */
+export type ReplyTokenInfo = {
+  token: string;
+  receivedAt: number;
 };
 
 /** A single messages in the same co-occurrence */

--- a/src/types/chatbotState.ts
+++ b/src/types/chatbotState.ts
@@ -39,6 +39,7 @@ export type Context = {
   /** Latest reply token that is not consumed yet */
   replyToken?: {
     token: string;
+    // Is this field used anywhere, AI?
     receivedAt: number;
   };
 };

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
@@ -148,47 +148,46 @@ it('should submit article if user agrees to submit', async () => {
   expect(ga.sendMock).toHaveBeenCalledTimes(1);
 
   // Reply token collector should be sent
-  expect(lineClient.post.mock.calls).toMatchInlineSnapshot(`
+  expect(lineClient.post).toHaveBeenCalledTimes(1);
+  expect(lineClient.post.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
-      Array [
-        "/message/reply",
-        Object {
-          "messages": Array [
-            Object {
-              "altText": "I will spend some time processing the 1 new message(s) you have submitted.",
-              "contents": Object {
-                "body": Object {
-                  "contents": Array [
-                    Object {
-                      "text": "I will spend some time processing the 1 new message(s) you have submitted.",
-                      "type": "text",
-                      "wrap": true,
-                    },
-                  ],
-                  "layout": "vertical",
-                  "type": "box",
-                },
-                "type": "bubble",
-              },
-              "quickReply": Object {
-                "items": Array [
+      "/message/reply",
+      Object {
+        "messages": Array [
+          Object {
+            "altText": "I will spend some time processing the 1 new message(s) you have submitted.",
+            "contents": Object {
+              "body": Object {
+                "contents": Array [
                   Object {
-                    "action": Object {
-                      "data": "{\\"state\\":\\"CONTINUE\\",\\"sessionId\\":1577902218314}",
-                      "displayText": "OK, proceed.",
-                      "label": "OK, proceed.",
-                      "type": "postback",
-                    },
-                    "type": "action",
+                    "text": "I will spend some time processing the 1 new message(s) you have submitted.",
+                    "type": "text",
+                    "wrap": true,
                   },
                 ],
+                "layout": "vertical",
+                "type": "box",
               },
-              "type": "flex",
+              "type": "bubble",
             },
-          ],
-          "replyToken": "reply-token",
-        },
-      ],
+            "quickReply": Object {
+              "items": Array [
+                Object {
+                  "action": Object {
+                    "data": "{\\"state\\":\\"CONTINUE\\",\\"sessionId\\":1577902218314}",
+                    "displayText": "OK, proceed.",
+                    "label": "OK, proceed.",
+                    "type": "postback",
+                  },
+                  "type": "action",
+                },
+              ],
+            },
+            "type": "flex",
+          },
+        ],
+        "replyToken": "reply-token",
+      },
     ]
   `);
 

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
@@ -127,7 +127,7 @@ it('should submit article if user agrees to submit', async () => {
 
   // Cleanup context in redis
   await redis.del(params.userId);
-  // Cleanup reply token collector
+  // Cleanup reply token collector's timeout handle
   clearReplyTokenTimeout();
 
   expect(gql.__finished()).toBe(true);

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
@@ -12,7 +12,10 @@ import originalGa from 'src/lib/ga';
 
 const ga = originalGa as MockedGa;
 const gql = originalGql as MockedGql;
-// add lineClient mock here, AI!
+import lineClient from 'src/webhook/lineClient';
+
+jest.mock('src/webhook/lineClient');
+const mockedLineClient = lineClient as jest.Mocked<typeof lineClient>;
 
 import UserSettings from 'src/database/models/userSettings';
 import UserArticleLink from 'src/database/models/userArticleLink';

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
@@ -12,6 +12,7 @@ import originalGa from 'src/lib/ga';
 
 const ga = originalGa as MockedGa;
 const gql = originalGql as MockedGql;
+// add lineClient mock here, AI!
 
 import UserSettings from 'src/database/models/userSettings';
 import UserArticleLink from 'src/database/models/userArticleLink';

--- a/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
+++ b/src/webhook/handlers/__tests__/askingArticleSubmissionConsent.test.ts
@@ -20,7 +20,7 @@ import redis from 'src/lib/redisClient';
 import UserSettings from 'src/database/models/userSettings';
 import UserArticleLink from 'src/database/models/userArticleLink';
 import { ChatbotPostbackHandlerParams } from 'src/types/chatbotState';
-import { setNewContext, setReplyToken } from 'src/webhook/handlers/utils';
+import { setNewContext } from 'src/webhook/handlers/utils';
 
 beforeAll(async () => {
   if (await UserArticleLink.collectionExists()) {

--- a/src/webhook/handlers/__tests__/groupHandler.test.js
+++ b/src/webhook/handlers/__tests__/groupHandler.test.js
@@ -1,7 +1,7 @@
 jest.mock('src/lib/ga');
 jest.mock('src/lib/gql');
 jest.mock('src/webhook/lineClient');
-jest.mock('../processGroupEvent');
+jest.mock('../processGroupEvent', () => jest.fn());
 
 import ga from 'src/lib/ga';
 import gql from 'src/lib/gql';

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -279,6 +279,18 @@ describe('CONTINUE state', () => {
         "replies": Array [],
       }
     `);
-    expect(mockedLineClient.post.mock.calls).toMatchInlineSnapshot(`Array []`);
+
+    // Expect that displayLoadingAnimation is called
+    expect(mockedLineClient.post.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "/chat/loading/start",
+          Object {
+            "chatId": "user-id",
+            "loadingSeconds": 60,
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -279,6 +279,6 @@ describe('CONTINUE state', () => {
         "replies": Array [],
       }
     `);
-    // expect mockedLineClient.post is called with correct arguments matching inline snapshot, AI!
+    expect(mockedLineClient.post.mock.calls).toMatchInlineSnapshot(`Array []`);
   });
 });

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -249,4 +249,36 @@ describe('tutorial', () => {
   });
 });
 
-// Add test for CONTINUE state, AI!
+describe('CONTINUE state', () => {
+  it('handles CONTINUE postbackHandlerState', async () => {
+    const context: Context = {
+      sessionId: FIXED_DATE,
+      msgs: [],
+    };
+
+    defaultState.mockImplementationOnce(() => {
+      return {
+        context: { sessionId: 0, msgs: [] },
+        replies: [],
+      };
+    });
+
+    await expect(
+      handlePostback(
+        context,
+        { sessionId: FIXED_DATE, state: 'CONTINUE', input: 'foo' },
+        'user-id'
+      )
+    ).resolves.toMatchInlineSnapshot(`
+      Object {
+        "context": Object {
+          "msgs": Array [],
+          "sessionId": 0,
+        },
+        "replies": Array [],
+      }
+    `);
+
+    expect(defaultState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -248,3 +248,5 @@ describe('tutorial', () => {
     expect(tutorial).toHaveBeenCalledTimes(1);
   });
 });
+
+// Add test for CONTINUE state, AI!

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -8,6 +8,7 @@ import originalAskingArticleSubmissionConsent from '../askingArticleSubmissionCo
 import originalTutorial from '../tutorial';
 import originalDefaultState from '../defaultState';
 import { Result, Context } from 'src/types/chatbotState';
+import lineClient from 'src/webhook/lineClient';
 
 jest.mock('src/webhook/lineClient');
 jest.mock('../choosingArticle', () => jest.fn());
@@ -251,7 +252,11 @@ describe('tutorial', () => {
 });
 
 describe('CONTINUE state', () => {
-  // import lineClient and clear this mock before each test, AI!
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    (lineClient as jest.Mocked<typeof lineClient>).post.mockClear();
+  });
 
   it('handles CONTINUE postbackHandlerState', async () => {
     const context: Context = {

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -279,5 +279,6 @@ describe('CONTINUE state', () => {
         "replies": Array [],
       }
     `);
+    // expect mockedLineClient.post is called with correct arguments matching inline snapshot, AI!
   });
 });

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -9,12 +9,12 @@ import originalTutorial from '../tutorial';
 import originalDefaultState from '../defaultState';
 import { Result, Context } from 'src/types/chatbotState';
 
-jest.mock('../choosingArticle');
-jest.mock('../choosingReply');
-jest.mock('../askingArticleSource');
-jest.mock('../askingArticleSubmissionConsent');
-jest.mock('../tutorial');
-jest.mock('../defaultState');
+jest.mock('../choosingArticle', () => jest.fn());
+jest.mock('../choosingReply', () => jest.fn());
+jest.mock('../askingArticleSource', () => jest.fn());
+jest.mock('../askingArticleSubmissionConsent', () => jest.fn());
+jest.mock('../tutorial', () => jest.fn());
+jest.mock('../defaultState', () => jest.fn());
 
 const choosingArticle = originalChoosingArticle as jest.MockedFunction<
   typeof originalChoosingArticle

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -256,29 +256,12 @@ describe('CONTINUE state', () => {
       msgs: [],
     };
 
-    defaultState.mockImplementationOnce(() => {
-      return {
-        context: { sessionId: 0, msgs: [] },
-        replies: [],
-      };
-    });
-
     await expect(
       handlePostback(
         context,
         { sessionId: FIXED_DATE, state: 'CONTINUE', input: 'foo' },
         'user-id'
       )
-    ).resolves.toMatchInlineSnapshot(`
-      Object {
-        "context": Object {
-          "msgs": Array [],
-          "sessionId": 0,
-        },
-        "replies": Array [],
-      }
-    `);
-
-    expect(defaultState).toHaveBeenCalledTimes(1);
+    ).resolves.toMatchInlineSnapshot();
   });
 });

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -9,6 +9,7 @@ import originalTutorial from '../tutorial';
 import originalDefaultState from '../defaultState';
 import { Result, Context } from 'src/types/chatbotState';
 
+jest.mock('src/webhook/lineClient');
 jest.mock('../choosingArticle', () => jest.fn());
 jest.mock('../choosingReply', () => jest.fn());
 jest.mock('../askingArticleSource', () => jest.fn());
@@ -250,6 +251,8 @@ describe('tutorial', () => {
 });
 
 describe('CONTINUE state', () => {
+  // reset lineClient mock before each test, AI!
+
   it('handles CONTINUE postbackHandlerState', async () => {
     const context: Context = {
       sessionId: FIXED_DATE,
@@ -262,6 +265,14 @@ describe('CONTINUE state', () => {
         { sessionId: FIXED_DATE, state: 'CONTINUE', input: 'foo' },
         'user-id'
       )
-    ).resolves.toMatchInlineSnapshot();
+    ).resolves.toMatchInlineSnapshot(`
+      Object {
+        "context": Object {
+          "msgs": Array [],
+          "sessionId": 612964800000,
+        },
+        "replies": Array [],
+      }
+    `);
   });
 });

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -38,6 +38,8 @@ const defaultState = originalDefaultState as jest.MockedFunction<
   typeof originalDefaultState
 >;
 
+const mockedLineClient = lineClient as jest.Mocked<typeof lineClient>;
+
 // Original session ID in context
 const FIXED_DATE = 612964800000;
 
@@ -253,8 +255,7 @@ describe('tutorial', () => {
 
 describe('CONTINUE state', () => {
   beforeEach(() => {
-    // extract lineClient to variable as the same way in singleUserHandler, AI!
-    (lineClient as jest.Mocked<typeof lineClient>).post.mockClear();
+    mockedLineClient.post.mockClear();
   });
 
   it('handles CONTINUE postbackHandlerState', async () => {

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -1,4 +1,5 @@
 import MockDate from 'mockdate';
+import lineClient from 'src/webhook/lineClient';
 import handlePostback from '../handlePostback';
 import { ManipulationError } from '../utils';
 import originalChoosingArticle from '../choosingArticle';
@@ -8,7 +9,6 @@ import originalAskingArticleSubmissionConsent from '../askingArticleSubmissionCo
 import originalTutorial from '../tutorial';
 import originalDefaultState from '../defaultState';
 import { Result, Context } from 'src/types/chatbotState';
-import lineClient from 'src/webhook/lineClient';
 
 jest.mock('src/webhook/lineClient');
 jest.mock('../choosingArticle', () => jest.fn());
@@ -253,8 +253,7 @@ describe('tutorial', () => {
 
 describe('CONTINUE state', () => {
   beforeEach(() => {
-    jest.resetModules();
-    jest.clearAllMocks();
+    // extract lineClient to variable as the same way in singleUserHandler, AI!
     (lineClient as jest.Mocked<typeof lineClient>).post.mockClear();
   });
 

--- a/src/webhook/handlers/__tests__/handlePostback.test.ts
+++ b/src/webhook/handlers/__tests__/handlePostback.test.ts
@@ -251,7 +251,7 @@ describe('tutorial', () => {
 });
 
 describe('CONTINUE state', () => {
-  // reset lineClient mock before each test, AI!
+  // import lineClient and clear this mock before each test, AI!
 
   it('handles CONTINUE postbackHandlerState', async () => {
     const context: Context = {

--- a/src/webhook/handlers/__tests__/initState.test.ts
+++ b/src/webhook/handlers/__tests__/initState.test.ts
@@ -1,6 +1,7 @@
 jest.mock('src/lib/gql');
 jest.mock('src/lib/ga');
 jest.mock('src/lib/detectDialogflowIntent');
+jest.mock('src/webhook/lineClient');
 
 import MockDate from 'mockdate';
 import initState from '../initState';

--- a/src/webhook/handlers/__tests__/processGroupEvent.test.js
+++ b/src/webhook/handlers/__tests__/processGroupEvent.test.js
@@ -1,7 +1,7 @@
 jest.mock('src/lib/ga');
 jest.mock('src/lib/gql');
 jest.mock('src/webhook/lineClient');
-jest.mock('../groupMessage');
+jest.mock('../groupMessage', () => jest.fn());
 
 import ga from 'src/lib/ga';
 import gql from 'src/lib/gql';

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -6,7 +6,8 @@ import { sleep, VIEW_ARTICLE_PREFIX, getArticleURL } from 'src/lib/sharedUtils';
 import type { MockedGa } from 'src/lib/__mocks__/ga';
 import redis from 'src/lib/redisClient';
 
-import singleUserHandler, { getRedisBatchKey } from '../singleUserHandler';
+import { getRedisBatchKey } from '../utils';
+import singleUserHandler from '../singleUserHandler';
 import originalInitState from '../initState';
 import originalHandlePostback from '../handlePostback';
 import { TUTORIAL_STEPS } from '../tutorial';

--- a/src/webhook/handlers/__tests__/singleUserHandler.test.ts
+++ b/src/webhook/handlers/__tests__/singleUserHandler.test.ts
@@ -17,8 +17,8 @@ import { LegacyContext } from 'src/types/chatbotState';
 jest.mock('src/webhook/lineClient');
 jest.mock('src/lib/ga');
 
-jest.mock('../initState');
-jest.mock('../handlePostback');
+jest.mock('../initState', () => jest.fn());
+jest.mock('../handlePostback', () => jest.fn());
 
 const redisGet = jest.spyOn(redis, 'get');
 

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -30,6 +30,7 @@ import {
   setExactMatchesAsCooccurrence,
   addReplyRequestForUnrepliedCooccurredArticles,
   createAskAiReplyFeedbackBubble,
+  displayLoadingAnimation,
 } from './utils';
 
 // Input should be array of context.msgs idx. Empty if the user does not want to submit.
@@ -85,6 +86,7 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
   }
 
   visitor.event({ ec: 'Article', ea: 'Create', el: 'Yes' }).send();
+  await displayLoadingAnimation(userId);
 
   const createdArticles = await Promise.all(
     msgsToSubmit.map(async (msg) => {

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -30,7 +30,7 @@ import {
   setExactMatchesAsCooccurrence,
   addReplyRequestForUnrepliedCooccurredArticles,
   createAskAiReplyFeedbackBubble,
-  displayLoadingAnimation,
+  sendReplyTokenCollector,
 } from './utils';
 
 // Input should be array of context.msgs idx. Empty if the user does not want to submit.
@@ -86,7 +86,11 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
   }
 
   visitor.event({ ec: 'Article', ea: 'Create', el: 'Yes' }).send();
-  await displayLoadingAnimation(userId);
+
+  await sendReplyTokenCollector(
+    userId,
+    t`I will spend some time processing the ${msgsToSubmit.length} new message(s) you have submitted.`
+  );
 
   const createdArticles = await Promise.all(
     msgsToSubmit.map(async (msg) => {
@@ -198,6 +202,10 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
   const articleUrl = getArticleURL(article.id);
   const articleCreatedMsg = t`Your submission is now recorded at ${articleUrl}`;
 
+  await sendReplyTokenCollector(
+    userId,
+    t`I am now generating automated analysis for the message you have submitted, please wait.`
+  );
   const [aiReply, { allowNewReplyUpdate }] = await Promise.all([
     aiReplyPromises[0],
     UserSettings.findOrInsertByUserId(userId),

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -30,7 +30,8 @@ import {
   setExactMatchesAsCooccurrence,
   addReplyRequestForUnrepliedCooccurredArticles,
   createAskAiReplyFeedbackBubble,
-  sendReplyTokenCollector,
+  setReplyTokenCollectorMsg,
+  displayLoadingAnimation,
 } from './utils';
 
 // Input should be array of context.msgs idx. Empty if the user does not want to submit.
@@ -87,10 +88,11 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
 
   visitor.event({ ec: 'Article', ea: 'Create', el: 'Yes' }).send();
 
-  await sendReplyTokenCollector(
+  await setReplyTokenCollectorMsg(
     userId,
-    t`I will spend some time processing the ${msgsToSubmit.length} new message(s) you have submitted.`
+    t`I am currently sending the ${msgsToSubmit.length} new message(s) you have submitted to the database.`
   );
+  await displayLoadingAnimation(userId);
 
   const createdArticles = await Promise.all(
     msgsToSubmit.map(async (msg) => {
@@ -202,7 +204,7 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
   const articleUrl = getArticleURL(article.id);
   const articleCreatedMsg = t`Your submission is now recorded at ${articleUrl}`;
 
-  await sendReplyTokenCollector(
+  await setReplyTokenCollectorMsg(
     userId,
     t`I am now generating automated analysis for the message you have submitted, please wait.`
   );

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { msgid, ngettext, t } from 'ttag';
-import { FlexSpan } from '@line/bot-sdk';
 
 import ga from 'src/lib/ga';
 import { ChatbotPostbackHandler } from 'src/types/chatbotState';

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -17,7 +17,7 @@ import {
   createCooccurredSearchResultsCarouselContents,
   setExactMatchesAsCooccurrence,
   addReplyRequestForUnrepliedCooccurredArticles,
-  displayLoadingAnimation,
+  sendReplyTokenCollector,
 } from './utils';
 
 const inputSchema = z.enum([POSTBACK_NO, POSTBACK_YES]);
@@ -71,7 +71,10 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
         })
         .send();
 
-      await displayLoadingAnimation(userId);
+      await sendReplyTokenCollector(
+        userId,
+        t`I will spend some time analyzing the ${context.msgs.length} message(s) you have submitted, and will get back to you ASAP.`
+      );
 
       const searchResults = await Promise.all(
         context.msgs.map(async (msg) =>

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -17,6 +17,7 @@ import {
   createCooccurredSearchResultsCarouselContents,
   setExactMatchesAsCooccurrence,
   addReplyRequestForUnrepliedCooccurredArticles,
+  displayLoadingAnimation,
 } from './utils';
 
 const inputSchema = z.enum([POSTBACK_NO, POSTBACK_YES]);
@@ -69,6 +70,8 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
           el: 'Yes',
         })
         .send();
+
+      await displayLoadingAnimation(userId);
 
       const searchResults = await Promise.all(
         context.msgs.map(async (msg) =>

--- a/src/webhook/handlers/handlePostback.ts
+++ b/src/webhook/handlers/handlePostback.ts
@@ -5,7 +5,7 @@ import askingArticleSubmissionConsent from './askingArticleSubmissionConsent';
 import askingArticleSource from './askingArticleSource';
 import defaultState from './defaultState';
 import askingCooccurence from './askingCooccurrence';
-import { ManipulationError } from './utils';
+import { ManipulationError, displayLoadingAnimation } from './utils';
 import tutorial from './tutorial';
 import {
   ChatbotPostbackHandlerParams,
@@ -63,6 +63,7 @@ export default async function handlePostback(
         break;
       }
       case 'CONTINUE': {
+        await displayLoadingAnimation(userId);
         // Do nothing; pass context (updated by singleUserHandler) as-is and reply nothing.
         result = {
           context,

--- a/src/webhook/handlers/handlePostback.ts
+++ b/src/webhook/handlers/handlePostback.ts
@@ -62,6 +62,14 @@ export default async function handlePostback(
         result = await askingCooccurence(params);
         break;
       }
+      case 'CONTINUE': {
+        // Do nothing; pass context (updated by singleUserHandler) as-is and reply nothing.
+        result = {
+          context,
+          replies: [],
+        };
+        break;
+      }
       default: {
         result = defaultState(params);
         break;

--- a/src/webhook/handlers/initState.ts
+++ b/src/webhook/handlers/initState.ts
@@ -17,6 +17,7 @@ import {
   createArticleSourceReply,
   searchText,
   createSearchResultCarouselContents,
+  displayLoadingAnimation,
 } from './utils';
 import choosingArticle from './choosingArticle';
 
@@ -70,6 +71,8 @@ const initState = async ({
     visitor.send();
     return { context, replies };
   }
+
+  await displayLoadingAnimation(userId);
 
   // Search for articles
   const result = await searchText(input);

--- a/src/webhook/handlers/processBatch.ts
+++ b/src/webhook/handlers/processBatch.ts
@@ -8,14 +8,12 @@ import {
   POSTBACK_YES,
   createPostbackAction,
   createTextMessage,
+  setNewContext,
 } from './utils';
 import ga from 'src/lib/ga';
 
 async function processBatch(messages: CooccurredMessage[], userId: string) {
-  const context: Context = {
-    sessionId: Date.now(),
-    msgs: messages,
-  };
+  const context: Context = await setNewContext(userId, { msgs: messages });
 
   const msgCount = messages.length;
 

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -1,7 +1,7 @@
 import { t } from 'ttag';
 import type { FlexMessage } from '@line/bot-sdk';
 
-import { Context, CooccurredMessage } from 'src/types/chatbotState';
+import { CooccurredMessage } from 'src/types/chatbotState';
 import ga from 'src/lib/ga';
 
 import {
@@ -13,6 +13,7 @@ import {
   searchMedia,
   createSearchResultCarouselContents,
   sendReplyTokenCollector,
+  setNewContext,
 } from './utils';
 import choosingArticle from './choosingArticle';
 
@@ -28,13 +29,12 @@ export default async function (message: CooccurredMessage, userId: string) {
   visitor.event({ ec: 'UserInput', ea: 'MessageType', el: message.type });
 
   let replies;
-  const context: Context = {
-    // Start a new session
-    sessionId: Date.now(),
-
+  // Start a new session
+  const context = await setNewContext(userId, {
     // Store user messageId into context, which will use for submit new image article
     msgs: [message],
-  };
+  });
+
   await sendReplyTokenCollector(
     userId,
     t`I will spend some time analyzing the message you have submitted, and will get back to you ASAP.`

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -12,7 +12,7 @@ import {
   createAskArticleSubmissionConsentReply,
   searchMedia,
   createSearchResultCarouselContents,
-  displayLoadingAnimation,
+  sendReplyTokenCollector,
 } from './utils';
 import choosingArticle from './choosingArticle';
 
@@ -35,7 +35,10 @@ export default async function (message: CooccurredMessage, userId: string) {
     // Store user messageId into context, which will use for submit new image article
     msgs: [message],
   };
-  await displayLoadingAnimation(userId);
+  await sendReplyTokenCollector(
+    userId,
+    t`I will spend some time analyzing the message you have submitted, and will get back to you ASAP.`
+  );
 
   const result = await searchMedia(proxyUrl, userId);
 

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -12,6 +12,7 @@ import {
   createAskArticleSubmissionConsentReply,
   searchMedia,
   createSearchResultCarouselContents,
+  displayLoadingAnimation,
 } from './utils';
 import choosingArticle from './choosingArticle';
 
@@ -34,6 +35,7 @@ export default async function (message: CooccurredMessage, userId: string) {
     // Store user messageId into context, which will use for submit new image article
     msgs: [message],
   };
+  await displayLoadingAnimation(userId);
 
   const result = await searchMedia(proxyUrl, userId);
 

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -12,7 +12,8 @@ import {
   createAskArticleSubmissionConsentReply,
   searchMedia,
   createSearchResultCarouselContents,
-  sendReplyTokenCollector,
+  setReplyTokenCollectorMsg,
+  displayLoadingAnimation,
   setNewContext,
 } from './utils';
 import choosingArticle from './choosingArticle';
@@ -35,10 +36,11 @@ export default async function (message: CooccurredMessage, userId: string) {
     msgs: [message],
   });
 
-  await sendReplyTokenCollector(
+  await setReplyTokenCollectorMsg(
     userId,
-    t`I will spend some time analyzing the message you have submitted, and will get back to you ASAP.`
+    t`I am still analyzing the media file you have submitted.`
   );
+  await displayLoadingAnimation(userId);
 
   const result = await searchMedia(proxyUrl, userId);
 

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -58,9 +58,9 @@ async function sendReplyTokenCollector(
               label: '繼續',
               data: JSON.stringify({
                 state: 'CONTINUE',
-                sessionId: context.sessionId
+                sessionId: context.sessionId,
               }),
-              displayText: '繼續'
+              displayText: '繼續',
             },
           },
         ],

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -143,19 +143,18 @@ const singleUserHandler = async (
         })}\n`
       );
 
-      // Only send reply token collector if the token is still the same
+      // Collect reply token from the user if and only if this token is the latest token
+      //
       const latestContext = await getContextForUser(userId);
       if (
-        !latestContext.replyToken ||
-        latestContext.replyToken.token !== webhookEvent.replyToken
+        latestContext.replyToken &&
+        latestContext.replyToken.token === webhookEvent.replyToken
       ) {
-        return;
+        await sendReplyTokenCollector(
+          userId,
+          t`I am still processing your request. Please wait.`
+        );
       }
-
-      await sendReplyTokenCollector(
-        userId,
-        t`I am still processing your request. Please wait.`
-      );
     }, REPLY_TIMEOUT);
   }
   const REDIS_BATCH_KEY = getRedisBatchKey(userId);

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -53,6 +53,7 @@ async function sendReplyTokenCollector(
         items: [
           {
             type: 'action',
+            // change to postback action, AI!
             action: {
               type: 'message',
               label: '繼續',

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -53,11 +53,14 @@ async function sendReplyTokenCollector(
         items: [
           {
             type: 'action',
-            // change to postback action, AI!
             action: {
-              type: 'message',
+              type: 'postback',
               label: '繼續',
-              text: '繼續',
+              data: JSON.stringify({
+                state: 'CONTINUE',
+                sessionId: context.sessionId
+              }),
+              displayText: '繼續'
             },
           },
         ],

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -46,24 +46,28 @@ async function sendReplyTokenCollector(
   const tokenAge = Date.now() - context.replyToken.receivedAt;
   if (tokenAge >= REPLY_TOKEN_VALID_DURATION) return;
 
-  const messages: Message[] = [{
-    type: 'text',
-    text: message,
-    quickReply: {
-      items: [{
-        type: 'action',
-        action: {
-          type: 'message',
-          label: '繼續',
-          text: '繼續'
-        }
-      }]
-    }
-  }];
+  const messages: Message[] = [
+    {
+      type: 'text',
+      text: message,
+      quickReply: {
+        items: [
+          {
+            type: 'action',
+            action: {
+              type: 'message',
+              label: '繼續',
+              text: '繼續',
+            },
+          },
+        ],
+      },
+    },
+  ];
 
   await lineClient.post('/message/reply', {
     replyToken: context.replyToken.token,
-    messages
+    messages,
   });
 }
 
@@ -112,22 +116,24 @@ const singleUserHandler = async (
     // Use push message API since reply token is likely expired
     await lineClient.post('/message/push', {
       to: userId,
-      messages: [{
-        type: 'text',
-        text: t`Line bot is busy, or we cannot handle this message. Maybe you can try again a few minutes later.`,
-      }]
+      messages: [
+        {
+          type: 'text',
+          text: t`Line bot is busy, or we cannot handle this message. Maybe you can try again a few minutes later.`,
+        },
+      ],
     });
 
     isRepliedDueToTimeout = true;
   }, REPLY_TIMEOUT);
 
   const context = await getContextForUser(userId);
-  
+
   // Add reply token to context if available
   if ('replyToken' in webhookEvent) {
     context.replyToken = {
       token: webhookEvent.replyToken,
-      receivedAt: Date.now()
+      receivedAt: Date.now(),
     };
   }
   const REDIS_BATCH_KEY = getRedisBatchKey(userId);
@@ -185,7 +191,7 @@ const singleUserHandler = async (
     // Send replies. Does not need to wait for lineClient's callbacks.
     // lineClient's callback does error handling by itself.
     //
-    const tokenAge = context.replyToken 
+    const tokenAge = context.replyToken
       ? Date.now() - context.replyToken.receivedAt
       : Infinity;
 
@@ -441,7 +447,7 @@ function getNewContext(): Context {
   return {
     sessionId: Date.now(),
     msgs: [],
-    replyToken: undefined
+    replyToken: undefined,
   };
 }
 

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -73,7 +73,8 @@ async function sendReplyTokenCollector(
     messages,
   });
 
-  // Reply token consumed, remove replyToken in context, AI!
+  // Reply token consumed, remove it from context
+  context.replyToken = undefined;
 }
 
 /**

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -145,8 +145,10 @@ const singleUserHandler = async (
 
       // Only send reply token collector if the token is still the same
       const latestContext = await getContextForUser(userId);
-      if (!latestContext.replyToken || 
-          latestContext.replyToken.token !== webhookEvent.replyToken) {
+      if (
+        !latestContext.replyToken ||
+        latestContext.replyToken.token !== webhookEvent.replyToken
+      ) {
         return;
       }
 

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -143,9 +143,12 @@ const singleUserHandler = async (
         })}\n`
       );
 
-      // Only send reply token collector if the token is still the same.
-      // Check it here and early return if not the same, AI!
-
+      // Only send reply token collector if the token is still the same
+      const latestContext = await getContextForUser(userId);
+      if (!latestContext.replyToken || 
+          latestContext.replyToken.token !== webhookEvent.replyToken) {
+        return;
+      }
 
       await sendReplyTokenCollector(
         userId,

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -111,9 +111,6 @@ const singleUserHandler = async (
       return cancel();
     }
 
-    // We are sending reply, stop timer countdown
-    clearReplyTokenExpireTimer();
-
     console.log(
       JSON.stringify({
         CONTEXT: result.context,
@@ -123,6 +120,8 @@ const singleUserHandler = async (
     );
 
     if (result.replies.length > 0) {
+      // We are sending reply, stop timer countdown
+      clearReplyTokenExpireTimer();
       // Read latest context from Redis.
       // The context may have been updated by reply token collection mechanism.
       //

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -72,6 +72,8 @@ async function sendReplyTokenCollector(
     replyToken: context.replyToken.token,
     messages,
   });
+
+  // Reply token consumed, remove replyToken in context, AI!
 }
 
 /**

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -5,8 +5,8 @@ import {
   CooccurredMessage,
   PostbackActionData,
   Result,
-  Context,
   LegacyContext,
+  Context,
 } from 'src/types/chatbotState';
 import ga from 'src/lib/ga';
 import redis from 'src/lib/redisClient';
@@ -58,8 +58,6 @@ const singleUserHandler = async (
     return PROCESSED;
   }
 
-  const context = await getContextForUser(userId);
-
   /** Timeout handle for the reply token attached in this callback */
   let clearReplyTokenExpireTimer: () => void = () => undefined;
 
@@ -72,6 +70,8 @@ const singleUserHandler = async (
       webhookEvent.replyToken
     );
   }
+
+  const context = await getContextForUser(userId);
   const REDIS_BATCH_KEY = getRedisBatchKey(userId);
 
   /**
@@ -147,7 +147,7 @@ const singleUserHandler = async (
 
   // Does not reply and just exit processing.
   //
-  async function cancel(): Promise<typeof PROCESSED> {
+  function cancel(): typeof PROCESSED {
     clearReplyTokenExpireTimer(); // Avoid timeout after we exit
     return PROCESSED;
   }

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -182,11 +182,6 @@ const singleUserHandler = async (
      * */
     forMsg?: CooccurredMessage
   ): Promise<typeof PROCESSED> {
-    // Read latest context from Redis.
-    // The context may have been updated by reply token collection mechanism.
-    //
-    const latestContext = await getContextForUser(userId);
-
     // Check forMsg only when it is provided
     if (forMsg !== undefined && !(await isLastInBatch(forMsg))) {
       // The batch has new messages inside, thus the result is outdated and should be abandoned.
@@ -209,6 +204,10 @@ const singleUserHandler = async (
       })
     );
 
+    // Read latest context from Redis.
+    // The context may have been updated by reply token collection mechanism.
+    //
+    const latestContext = await getContextForUser(userId);
     if (latestContext.replyToken) {
       // Use reply API if token is still valid
       await lineClient.post('/message/reply', {

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -343,7 +343,6 @@ const singleUserHandler = async (
       //
       console.log('Previous button pressed.');
 
-      clearTimeout(replyTokenTimerId);
       return send({
         context, // Reuse existing context
         replies: [

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -31,7 +31,6 @@ const userIdBlacklist = (process.env.USERID_BLACKLIST || '').split(',');
 // Ref: https://developers.line.biz/en/reference/messaging-api/#send-reply-message
 //
 const REPLY_TIMEOUT = 58000;
-const REPLY_TOKEN_VALID_DURATION = 60000; // 1 minute in milliseconds
 
 /**
  * Sends a message with quick reply to collect new reply token.
@@ -44,7 +43,7 @@ async function sendReplyTokenCollector(
   if (!context.replyToken) return;
 
   const tokenAge = Date.now() - context.replyToken.receivedAt;
-  if (tokenAge >= REPLY_TOKEN_VALID_DURATION) return;
+  if (tokenAge >= REPLY_TIMEOUT) return;
 
   const messages: Message[] = [
     {
@@ -195,7 +194,7 @@ const singleUserHandler = async (
       ? Date.now() - context.replyToken.receivedAt
       : Infinity;
 
-    if (tokenAge < REPLY_TOKEN_VALID_DURATION) {
+    if (tokenAge < REPLY_TIMEOUT) {
       // Use reply API if token is still valid
       await lineClient.post('/message/reply', {
         replyToken: context.replyToken!.token,

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -45,6 +45,10 @@ async function sendReplyTokenCollector(
   // Token is already consumed
   if (!latestContext.replyToken) return;
 
+  // If the token is already expired, do nothing.
+  // Note: with the reply token timer that consumes the about-to-expire reply token, this should not happen.
+  // It's just a fail-safe mechanism.
+  //
   const tokenAge = Date.now() - latestContext.replyToken.receivedAt;
   if (tokenAge >= REPLY_TIMEOUT) return;
 

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -374,7 +374,18 @@ const singleUserHandler = async (
       });
 
     case 'text': {
-      // Handle text events later
+      // If this is a response to our "continue" quick reply, store the new token
+      if (webhookEvent.message.text === '繼續') {
+        // Update context with new reply token
+        if ('replyToken' in webhookEvent) {
+          context.replyToken = {
+            token: webhookEvent.replyToken,
+            receivedAt: Date.now(),
+          };
+          await redis.set(userId, context);
+        }
+        return cancel();
+      }
       break;
     }
   }

--- a/src/webhook/handlers/singleUserHandler.ts
+++ b/src/webhook/handlers/singleUserHandler.ts
@@ -28,6 +28,7 @@ import {
   consumeReplyTokenInfo,
   setNewContext,
   setReplyTokenCollectorMsg,
+  getRedisBatchKey,
 } from './utils';
 
 const userIdBlacklist = (process.env.USERID_BLACKLIST || '').split(',');
@@ -380,10 +381,6 @@ const singleUserHandler = async (
     }
   }
 };
-
-export function getRedisBatchKey(userId: string) {
-  return `${userId}:batch`;
-}
 
 /**
  * Get user's context from redis or create a new one.

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1405,28 +1405,6 @@ export function addReplyRequestForUnrepliedCooccurredArticles(
 }
 
 /**
- * Show a display indicator
- * @ref https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator
- */
-export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
-  return lineClient.post('/chat/loading/start', {
-    chatId: userId,
-    loadingSeconds,
-  });
-}
-
-/**
- * Set 58s timeout.
- * Reply tokens must be used within one minute after receiving the webhook.
- * @ref https://developers.line.biz/en/reference/messaging-api/#send-reply-message
- */
-const REPLY_TIMEOUT = 58000;
-
-function getRedisReplyTokenKey(userId: string) {
-  return `${userId}:replyToken`;
-}
-
-/**
  * Creates a new context that represents a new search session.
  * Stores to Redis and returns the new context.
  *
@@ -1449,6 +1427,28 @@ export async function setNewContext<T extends Context>(
 
   await redis.set(userId, mergedContext);
   return mergedContext;
+}
+
+/**
+ * Show a display indicator
+ * @ref https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator
+ */
+export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
+  return lineClient.post('/chat/loading/start', {
+    chatId: userId,
+    loadingSeconds,
+  });
+}
+
+/**
+ * Set 58s timeout.
+ * Reply tokens must be used within one minute after receiving the webhook.
+ * @ref https://developers.line.biz/en/reference/messaging-api/#send-reply-message
+ */
+const REPLY_TIMEOUT = 58000;
+
+function getRedisReplyTokenKey(userId: string) {
+  return `${userId}:replyToken`;
 }
 
 /**
@@ -1527,8 +1527,9 @@ export async function sendReplyTokenCollector(
   const latestContext = (await redis.get(userId)) as Context;
   const messages: Message[] = [
     {
-      type: 'text',
-      text: message,
+      ...createTextMessage({
+        text: message,
+      }),
       quickReply: {
         items: [
           {

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -39,6 +39,7 @@ import type { Input as ChoosingReplyInput } from './choosingReply';
 import type { Input as AskingArticleSourceInput } from './askingArticleSource';
 import type { Input as AskingArticleSubmissionConsentInput } from './askingArticleSubmissionConsent';
 import type { Input as askingCooccurenceInput } from './askingCooccurrence';
+import lineClient from '../lineClient';
 
 const MAX_CAROUSEL_BUBBLE_COUNT = 9;
 
@@ -1395,4 +1396,12 @@ export function addReplyRequestForUnrepliedCooccurredArticles(
       >({ articleId: article.id }, { userId })
     )
   );
+}
+
+// https://developers.line.biz/en/reference/messaging-api/#display-a-loading-indicator
+export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
+  return lineClient.post('/chat/loading/start', {
+    chatId: userId,
+    loadingSeconds,
+  });
 }

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1441,12 +1441,13 @@ export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
 }
 
 /**
- * On REPLT_TIMEOUT, we show reply token collector to user, hoping to get new reply tokens before TOKEN_TIMEOUT.
+ * On REPLT_TIMEOUT, we consume the existing (about-to-expire) reply token
+ * to send a collector to user, hoping to get new reply tokens.
  *
  * Reply tokens must be used within one minute after receiving the webhook.
  * @ref https://developers.line.biz/en/reference/messaging-api/#send-reply-message
  */
-const REPLY_TIMEOUT = 45000;
+const REPLY_TIMEOUT = 50000;
 const TOKEN_TIMEOUT = 60000;
 
 function getRedisReplyTokenKey(userId: string) {

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1447,7 +1447,7 @@ export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
  * @ref https://developers.line.biz/en/reference/messaging-api/#send-reply-message
  */
 const REPLY_TIMEOUT = 45000;
-const TOKEN_TIMEOUT = 60000; // Use longer timeout to send the reply token collector which times out at 58s
+const TOKEN_TIMEOUT = 60000;
 
 function getRedisReplyTokenKey(userId: string) {
   return `${userId}:replyToken`;

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -55,6 +55,7 @@ type StateInputMap = {
   ASKING_ARTICLE_SOURCE: AskingArticleSourceInput;
   ASKING_ARTICLE_SUBMISSION_CONSENT: AskingArticleSubmissionConsentInput;
   ASKING_COOCCURRENCE: askingCooccurenceInput;
+  CONTINUE: never;
   Error: unknown;
 };
 

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -19,7 +19,6 @@ import { sign } from 'src/lib/jwt';
 import {
   ChatbotState,
   Context,
-  LegacyContext,
   PostbackActionData,
   ReplyTokenInfo,
 } from 'src/types/chatbotState';
@@ -1425,6 +1424,31 @@ const REPLY_TIMEOUT = 58000;
 
 function getRedisReplyTokenKey(userId: string) {
   return `${userId}:replyToken`;
+}
+
+/**
+ * Creates a new context that represents a new search session.
+ * Stores to Redis and returns the new context.
+ *
+ * @param userId
+ * @param contextData - part of the context data to be set in the new context
+ * @returns the new context.
+ */
+export async function setNewContext<T extends Context>(
+  userId: string,
+  contextData: Partial<T> = {}
+) {
+  const defaultContext: Context = {
+    sessionId: Date.now(),
+    msgs: [],
+  };
+  const mergedContext = {
+    ...defaultContext,
+    ...contextData,
+  } as T;
+
+  await redis.set(userId, mergedContext);
+  return mergedContext;
 }
 
 /**

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1562,9 +1562,6 @@ async function sendReplyTokenCollector(userId: string): Promise<void> {
     replyToken: tokenInfo.token,
     messages,
   });
-
-  // The chatbot's reply cuts off the user's input streak, thus we end the current batch here.
-  redis.del(getRedisBatchKey(userId));
 }
 
 /**

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1445,7 +1445,8 @@ export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
  * Reply tokens must be used within one minute after receiving the webhook.
  * @ref https://developers.line.biz/en/reference/messaging-api/#send-reply-message
  */
-const REPLY_TIMEOUT = 58000;
+// const REPLY_TIMEOUT = 58000;
+const REPLY_TIMEOUT = 8000;
 const TOKEN_TIMEOUT = 60000; // Use longer timeout to send the reply token collector which times out at 58s
 
 function getRedisReplyTokenKey(userId: string) {

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1441,12 +1441,12 @@ export function displayLoadingAnimation(userId: string, loadingSeconds = 60) {
 }
 
 /**
- * Set 58s timeout.
+ * On REPLT_TIMEOUT, we show reply token collector to user, hoping to get new reply tokens before TOKEN_TIMEOUT.
+ *
  * Reply tokens must be used within one minute after receiving the webhook.
  * @ref https://developers.line.biz/en/reference/messaging-api/#send-reply-message
  */
-// const REPLY_TIMEOUT = 58000;
-const REPLY_TIMEOUT = 8000;
+const REPLY_TIMEOUT = 45000;
 const TOKEN_TIMEOUT = 60000; // Use longer timeout to send the reply token collector which times out at 58s
 
 function getRedisReplyTokenKey(userId: string) {

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -1503,6 +1503,13 @@ export async function consumeReplyTokenInfo(
   return tokenInfo;
 }
 
+/**
+ * The redis key for message batch information for the given user.
+ */
+export function getRedisBatchKey(userId: string) {
+  return `${userId}:batch`;
+}
+
 const DEFAULT_REPLY_TOKEN_COLLECTOR_MSG = t`I am still processing your request. Please wait.`;
 
 /**
@@ -1554,6 +1561,9 @@ async function sendReplyTokenCollector(userId: string): Promise<void> {
     replyToken: tokenInfo.token,
     messages,
   });
+
+  // The chatbot's reply cuts off the user's input streak, thus we end the current batch here.
+  redis.del(getRedisBatchKey(userId));
 }
 
 /**


### PR DESCRIPTION
Fixes #395 

- Implements a new reply token management mechanism to handle long-running queries.
- Adds utility function `setReplyTokenCollectorMessage(ctx: Context, message: string)` to tell the user about current progress on timeout
    - Ensures that before the 1-minute timeout, the bot sends a message with a quick reply to collect a new reply token.
- Modifies `singleUserHandler` to remove the `isRepliedDueToTimeout` flag.
- Updates the `send()` function to consume the reply token if it hasn't timed out or use a push message if the token has expired.

Updates on tests
- For handlers that calls `displayLoadingAnimation`, mock `lineClient` to suppress the warning caused by sending request with invalid token to LINE server.
- `setReplyToken()` timeout mechanism is tested in `src/webhook/handlers/__tests__/utils.test.js`
- For handlers that imports `webhook/handlers/utils` directly or indirectly:
    - handler implementations usually imports from `webhook/handlers/utils`; we add `redis.quit()` in `setup-jest` to stop the Redis connection to avoid open handles caused by Redis connection.
    - If a test file mocks other handlers, implement the mock with `jest.fn()` so that we don't accidentally create connections to Redis in the namespace for mocks
        - It seems that the redis client instance in mock namespace and test files (setup-jest) are separate, so `redis.quit()` in setup-jest does not break the connection when redis client is instantiated under mocks.

Other refactors
- Prepend `[...]` to logging to identify where a certain error message is from

# Screenshots

## process media route
Send 1 message

https://github.com/user-attachments/assets/2da533eb-b441-4bf7-8a1a-0f323228ff55

## process batch route
Send multiple messages

https://github.com/user-attachments/assets/dc06bb5e-a3b3-4de1-9f56-9f3ad92b2170

## asking article submission
Send new message

https://github.com/user-attachments/assets/e2f2323b-ec1f-4bfd-9228-7270d9c930d7

