### PR TITLE
fix: shorten AI reply sender name

### DIFF
--- a/i18n/ja.po
+++ b/i18n/ja.po
@@ -1190,10 +1190,6 @@ msgstr ""
 msgid "Is the AI analysis helpful?"
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:687
-msgid "Automated analysis by AI"
-msgstr ""
-
 #: src/liff/pages/AiReplyFeedback.svelte:43
 msgid "Thank you for providing feedback to the automated analysis."
 msgstr ""
@@ -1204,4 +1200,9 @@ msgstr ""
 
 #: src/liff/pages/AiReplyFeedback.svelte:64
 msgid "Report AI analysis not helpful"
+msgstr ""
+
+#: src/webhook/handlers/utils.ts:687
+#. t: max 20 characters 
+msgid "AI analysis"
 msgstr ""

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -1191,10 +1191,6 @@ msgstr "評價 AI 自動分析"
 msgid "Is the AI analysis helpful?"
 msgstr "這則 AI 分析是否有幫助？"
 
-#: src/webhook/handlers/utils.ts:687
-msgid "Automated analysis by AI"
-msgstr "AI 自動分析"
-
 #: src/liff/pages/AiReplyFeedback.svelte:43
 msgid "Thank you for providing feedback to the automated analysis."
 msgstr "謝謝您提供對 AI 自動分析的回饋。"
@@ -1206,3 +1202,8 @@ msgstr "回報 AI 分析有幫助"
 #: src/liff/pages/AiReplyFeedback.svelte:64
 msgid "Report AI analysis not helpful"
 msgstr "回報 AI 分析沒幫助"
+
+#: src/webhook/handlers/utils.ts:687
+#. t: max 20 characters
+msgid "AI analysis"
+msgstr "AI 自動分析"

--- a/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/askingArticleSubmissionConsent.test.ts.snap
@@ -262,7 +262,7 @@ Object {
       "createdAt": undefined,
       "sender": Object {
         "iconUrl": "/static/img/aireply.png?cachebust=20230405",
-        "name": "Automated analysis by AI",
+        "name": "AI analysis",
       },
       "text": "Hello from ChatGPT",
       "type": "text",

--- a/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.ts.snap
+++ b/src/webhook/handlers/__tests__/__snapshots__/choosingArticle.test.ts.snap
@@ -1851,7 +1851,7 @@ Don’t trust the message just yet!",
       "createdAt": "2018-01-09T05:52:12.658Z",
       "sender": Object {
         "iconUrl": "/static/img/aireply.png?cachebust=20230405",
-        "name": "Automated analysis by AI",
+        "name": "AI analysis",
       },
       "text": "Hello from ChatGPT",
       "type": "text",

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -684,7 +684,7 @@ export async function createAIReply(
           text: createAIReply?.text,
           createdAt: createAIReply?.createdAt,
           sender: {
-            name: t`Automated analysis by AI`,
+            name: t`AI analysis`, // Max 20 characters
             iconUrl: `${process.env.RUMORS_LINE_BOT_URL}/static/img/aireply.png?cachebust=${AI_REPLY_IMAGE_VERSION}`,
           },
         },

--- a/src/webhook/handlers/utils.ts
+++ b/src/webhook/handlers/utils.ts
@@ -684,7 +684,7 @@ export async function createAIReply(
           text: createAIReply?.text,
           createdAt: createAIReply?.createdAt,
           sender: {
-            name: t`AI analysis`, // Max 20 characters
+            name: /* t: max 20 characters */ t`AI analysis`,
             iconUrl: `${process.env.RUMORS_LINE_BOT_URL}/static/img/aireply.png?cachebust=${AI_REPLY_IMAGE_VERSION}`,
           },
         },


### PR DESCRIPTION
Current english LINE bot will break when AI reply is shown due to this error.
```json
{
   "message": "sender.name length is invalid"
}
```

This is because the name of sender is limited to 20 characters. 

Ref: https://developers.line.biz/en/reference/messaging-api/#icon-nickname-switch

This PR shortens the English name of sender so that it can be shown correctly.

![圖片](https://github.com/user-attachments/assets/2b1eeb0b-c9aa-4c55-affa-9b2b43d843f8)
