### PR TITLE
Handle network errors

### DIFF
--- a/i18n/ja.po
+++ b/i18n/ja.po
@@ -65,9 +65,9 @@ msgstr "他のリプライを見たい場合、こちらに：${ articleUrl }"
 msgid "Choose this one"
 msgstr "これを選ぶ"
 
-#: src/webhook/handlers/askingCooccurrence.ts:274
+#: src/webhook/handlers/askingCooccurrence.ts:287
 #: src/webhook/handlers/initState.ts:191
-#: src/webhook/handlers/processMedia.ts:157
+#: src/webhook/handlers/processMedia.ts:177
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid ""
@@ -114,8 +114,8 @@ msgstr "いいえ"
 
 #: src/webhook/handlers/initState.ts:146
 #: src/webhook/handlers/initState.ts:164
-#: src/webhook/handlers/processMedia.ts:112
-#: src/webhook/handlers/processMedia.ts:130
+#: src/webhook/handlers/processMedia.ts:132
+#: src/webhook/handlers/processMedia.ts:150
 msgid "None of these messages matches mine :("
 msgstr "確認したい情報が見つかりません (T_T)"
 
@@ -126,13 +126,13 @@ msgid_plural "${ positive } users consider this helpful"
 msgstr[0] "${positive} 人がこのリプライは役に立っていると思っています"
 
 #: src/webhook/handlers/initState.ts:162
-#: src/webhook/handlers/processMedia.ts:128
+#: src/webhook/handlers/processMedia.ts:148
 msgid "Tell us more"
 msgstr "情報を報告する"
 
-#: src/webhook/handlers/askingCooccurrence.ts:279
+#: src/webhook/handlers/askingCooccurrence.ts:292
 #: src/webhook/handlers/initState.ts:178
-#: src/webhook/handlers/processMedia.ts:144
+#: src/webhook/handlers/processMedia.ts:164
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid "Please choose the most similar message from the list."
@@ -156,14 +156,14 @@ msgstr "${similarityPercentage}% 似ています"
 msgid "Wrong usage"
 msgstr "使い方は間違いました"
 
-#: src/webhook/handlers/singleUserHandler.ts:285
+#: src/webhook/handlers/singleUserHandler.ts:284
 #. Reuse existing context
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "新規の情報を検索しているため、先ほどまでの検索ボタンは無効になります。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:205
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:221
 #, javascript-format
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "提供していただいた情報はこちらに登録されています ${ articleUrl }"
@@ -669,7 +669,7 @@ msgstr ""
 
 #: src/webhook/handlers/askingArticleSource.ts:188
 #: src/webhook/handlers/choosingArticle.ts:117
-#: src/webhook/handlers/processMedia.ts:175
+#: src/webhook/handlers/processMedia.ts:195
 msgid "Do you want someone to fact-check this message?"
 msgstr ""
 
@@ -677,19 +677,19 @@ msgstr ""
 msgid "The message has not been reported and won’t be fact-checked. Thanks anyway!"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:226
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:236
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:252
 msgid ""
 "The message has now been recorded at Cofacts for volunteers to fact-check. "
 "Thank you for submitting!"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:258
 #: src/webhook/handlers/choosingArticle.ts:432
 msgid "View reported message"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:254
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:270
 #: src/webhook/handlers/choosingArticle.ts:378
 msgid "In the meantime, you can:"
 msgstr ""
@@ -737,31 +737,31 @@ msgid ""
 "still like to help."
 msgstr ""
 
-#: src/webhook/handlers/processMedia.ts:153
+#: src/webhook/handlers/processMedia.ts:173
 msgid "There are some messages that looks similar to the one you have sent to me."
 msgstr ""
 
-#: src/webhook/handlers/processMedia.ts:173
+#: src/webhook/handlers/processMedia.ts:193
 #. submit
 msgid ""
 "Unfortunately, I currently don’t recognize this message, but I would still "
 "like to help."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:113
+#: src/webhook/handlers/askingCooccurrence.ts:126
 #: src/webhook/handlers/utils.ts:163
 msgid "Report to database"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:221
+#: src/webhook/handlers/askingCooccurrence.ts:234
 #: src/webhook/handlers/utils.ts:262
 msgid ""
 "and have volunteers fact-check it. This way you can help the people who "
 "receive the same message in the future."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:243
-#: src/webhook/handlers/askingCooccurrence.ts:245
+#: src/webhook/handlers/askingCooccurrence.ts:256
+#: src/webhook/handlers/askingCooccurrence.ts:258
 #: src/webhook/handlers/utils.ts:290
 #: src/webhook/handlers/utils.ts:292
 msgid "Don’t report"
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "I choose ${ displayTextWhenChosen }"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:270
+#: src/webhook/handlers/askingCooccurrence.ts:283
 #. Get first few search results for each message, and make at most 10 options
 #. 
 msgid "There are some messages that looks similar to the ones you have sent to me."
@@ -1067,7 +1067,7 @@ msgid ""
 "articleDate }:"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:259
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:275
 msgid ""
 "This article is still under verification, please refrain from believing it "
 "for now. \n"
@@ -1075,34 +1075,34 @@ msgid ""
 "with some insights."
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:263
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:279
 #: src/webhook/handlers/choosingArticle.ts:406
 msgid "After reading the automatic analysis by the bot above, you can:"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:181
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:197
 msgid ""
 "Thank you for submitting! Now the messages has been recorded in the Cofacts "
 "database."
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:184
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:188
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:200
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:204
 msgid "Please choose the messages you would like to view"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:119
+#: src/webhook/handlers/askingCooccurrence.ts:132
 msgid "Be the first to report these messages"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:133
+#: src/webhook/handlers/askingCooccurrence.ts:146
 #, javascript-format
 msgid ""
 "The ${ notInDbMsgIndexes.length } messages that you have sent are not "
 "within the Cofacts database."
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:134
+#: src/webhook/handlers/askingCooccurrence.ts:147
 #, javascript-format
 msgid ""
 "Out of the ${ totalCount } messages you sent, ${ notInDbMsgIndexes.length } "
@@ -1113,33 +1113,33 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:143
+#: src/webhook/handlers/askingCooccurrence.ts:156
 #: src/webhook/handlers/utils.ts:184
 msgid "If you believe:"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:163
+#: src/webhook/handlers/askingCooccurrence.ts:176
 #. t: If you believe ~ a rumor 
 msgid "That they are most likely "
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:167
+#: src/webhook/handlers/askingCooccurrence.ts:180
 #. t: If you believe that it is most likely ~ 
 msgid "rumors,"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:195
+#: src/webhook/handlers/askingCooccurrence.ts:208
 #: src/webhook/handlers/utils.ts:236
 #. t: ~ make this messasge public 
 msgid "And you are willing to "
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:199
+#: src/webhook/handlers/askingCooccurrence.ts:212
 #. t: and you are willing to ~ 
 msgid "make these messages public"
 msgstr ""
 
-#: src/webhook/handlers/askingCooccurrence.ts:215
+#: src/webhook/handlers/askingCooccurrence.ts:228
 #, javascript-format
 msgid "Press “${ btnText }” to make these messages public on Cofacts website "
 msgstr ""
@@ -1201,18 +1201,18 @@ msgstr ""
 msgid "AI analysis"
 msgstr ""
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:209
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:225
 msgid ""
 "I am now generating automated analysis for the message you have submitted, "
 "please wait."
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1513
+#: src/webhook/handlers/utils.ts:1515
 msgid "I am still processing your request. Please wait."
 msgstr ""
 
-#: src/webhook/handlers/utils.ts:1547
-#: src/webhook/handlers/utils.ts:1552
+#: src/webhook/handlers/utils.ts:1549
+#: src/webhook/handlers/utils.ts:1554
 msgid "OK, proceed."
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 msgstr ""
 
 #: src/webhook/handlers/askingCooccurrence.ts:77
-#: src/webhook/handlers/askingCooccurrence.ts:91
+#: src/webhook/handlers/askingCooccurrence.ts:93
 #, javascript-format
 msgid ""
 "Out of the ${ context.msgs.length } message(s) you have submitted, I am "
@@ -1233,4 +1233,17 @@ msgstr ""
 
 #: src/webhook/handlers/processMedia.ts:41
 msgid "I am still analyzing the media file you have submitted."
+msgstr ""
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:183
+#: src/webhook/handlers/askingCooccurrence.ts:105
+msgid ""
+"Sorry, I encountered an error while analyzing the messages. Please try "
+"sending them to me again later."
+msgstr ""
+
+#: src/webhook/handlers/processMedia.ts:61
+msgid ""
+"Sorry, I encountered an error while processing your media. Please try again "
+"later."
 msgstr ""

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -65,9 +65,9 @@ msgstr "更多回應請到：${ articleUrl }"
 msgid "Choose this one"
 msgstr "選擇這篇"
 
-#: src/webhook/handlers/askingCooccurrence.ts:274
+#: src/webhook/handlers/askingCooccurrence.ts:287
 #: src/webhook/handlers/initState.ts:191
-#: src/webhook/handlers/processMedia.ts:157
+#: src/webhook/handlers/processMedia.ts:177
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid ""
@@ -114,8 +114,8 @@ msgstr "否"
 
 #: src/webhook/handlers/initState.ts:146
 #: src/webhook/handlers/initState.ts:164
-#: src/webhook/handlers/processMedia.ts:112
-#: src/webhook/handlers/processMedia.ts:130
+#: src/webhook/handlers/processMedia.ts:132
+#: src/webhook/handlers/processMedia.ts:150
 msgid "None of these messages matches mine :("
 msgstr "找不到我想查的訊息 QQ"
 
@@ -126,13 +126,13 @@ msgid_plural "${ positive } users consider this helpful"
 msgstr[0] "有 ${positive} 人覺得此回應有幫助"
 
 #: src/webhook/handlers/initState.ts:162
-#: src/webhook/handlers/processMedia.ts:128
+#: src/webhook/handlers/processMedia.ts:148
 msgid "Tell us more"
 msgstr "回報此訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:279
+#: src/webhook/handlers/askingCooccurrence.ts:292
 #: src/webhook/handlers/initState.ts:178
-#: src/webhook/handlers/processMedia.ts:144
+#: src/webhook/handlers/processMedia.ts:164
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid "Please choose the most similar message from the list."
@@ -156,14 +156,14 @@ msgstr "看起來 ${similarityPercentage}% 像"
 msgid "Wrong usage"
 msgstr "這不是這樣用的"
 
-#: src/webhook/handlers/singleUserHandler.ts:285
+#: src/webhook/handlers/singleUserHandler.ts:284
 #. Reuse existing context
 msgid ""
 "You are currently searching for another message, buttons from previous "
 "search sessions do not work now."
 msgstr "您已經在搜尋新的訊息了，過去查過的訊息的按鈕已經失效囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:205
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:221
 #, javascript-format
 msgid "Your submission is now recorded at ${ articleUrl }"
 msgstr "您回報的訊息已經被收錄至 ${ articleUrl }"
@@ -806,7 +806,7 @@ msgstr "此訊息不存在。"
 msgid "The reply does not exist. Maybe it has been deleted by its author."
 msgstr "此回應不存在。或許已經被作者刪掉囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:258
 #: src/webhook/handlers/choosingArticle.ts:432
 msgid "View reported message"
 msgstr "檢視回報訊息"
@@ -835,7 +835,7 @@ msgstr ""
 "此訊息已經被收錄至 Cofacts 有待好心人來查證。\n"
 "請先不要相信這個訊息唷！"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:254
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:270
 #: src/webhook/handlers/choosingArticle.ts:378
 msgid "In the meantime, you can:"
 msgstr "接下來您可以："
@@ -907,7 +907,7 @@ msgstr "這樣呀。請先不要相信這個訊息唷！"
 
 #: src/webhook/handlers/askingArticleSource.ts:188
 #: src/webhook/handlers/choosingArticle.ts:117
-#: src/webhook/handlers/processMedia.ts:175
+#: src/webhook/handlers/processMedia.ts:195
 msgid "Do you want someone to fact-check this message?"
 msgstr "你要請人查查這則訊息嗎？"
 
@@ -915,8 +915,8 @@ msgstr "你要請人查查這則訊息嗎？"
 msgid "The message has not been reported and won’t be fact-checked. Thanks anyway!"
 msgstr "好的，那就不查囉。還是謝謝你！"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:226
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:236
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:242
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:252
 msgid ""
 "The message has now been recorded at Cofacts for volunteers to fact-check. "
 "Thank you for submitting!"
@@ -936,20 +936,20 @@ msgid ""
 "still like to help."
 msgstr "抱歉我目前還不認得「${ inputSummary }」這個訊息，可是我還是想幫你查證。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:113
+#: src/webhook/handlers/askingCooccurrence.ts:126
 #: src/webhook/handlers/utils.ts:163
 msgid "Report to database"
 msgstr "送進資料庫查核"
 
-#: src/webhook/handlers/askingCooccurrence.ts:221
+#: src/webhook/handlers/askingCooccurrence.ts:234
 #: src/webhook/handlers/utils.ts:262
 msgid ""
 "and have volunteers fact-check it. This way you can help the people who "
 "receive the same message in the future."
 msgstr "、讓好心人查證與回覆。您可以幫助到未來同樣收到這份訊息的人。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:243
-#: src/webhook/handlers/askingCooccurrence.ts:245
+#: src/webhook/handlers/askingCooccurrence.ts:256
+#: src/webhook/handlers/askingCooccurrence.ts:258
 #: src/webhook/handlers/utils.ts:290
 #: src/webhook/handlers/utils.ts:292
 msgid "Don’t report"
@@ -978,7 +978,7 @@ msgstr "想先請教您一個問題："
 msgid "Provide better reply"
 msgstr "提供更好的回應"
 
-#: src/webhook/handlers/processMedia.ts:153
+#: src/webhook/handlers/processMedia.ts:173
 msgid "There are some messages that looks similar to the one you have sent to me."
 msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 
@@ -986,7 +986,7 @@ msgstr "資料庫裡有幾篇訊息，跟您傳給我的有些接近。"
 msgid "I am sorry you cannot find the information you are looking for."
 msgstr "抱歉沒有找到你想要查詢的訊息。"
 
-#: src/webhook/handlers/processMedia.ts:173
+#: src/webhook/handlers/processMedia.ts:193
 #. submit
 msgid ""
 "Unfortunately, I currently don’t recognize this message, but I would still "
@@ -1031,7 +1031,7 @@ msgstr "逐字稿內的字"
 msgid "I choose ${ displayTextWhenChosen }"
 msgstr "我選 ${ displayTextWhenChosen }"
 
-#: src/webhook/handlers/askingCooccurrence.ts:270
+#: src/webhook/handlers/askingCooccurrence.ts:283
 #. Get first few search results for each message, and make at most 10 options
 #.
 msgid "There are some messages that looks similar to the ones you have sent to me."
@@ -1067,7 +1067,7 @@ msgid ""
 "articleDate }:"
 msgstr "網路上有人這樣回應這則 ${articleDate} 回報的訊息："
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:259
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:275
 msgid ""
 "This article is still under verification, please refrain from believing it "
 "for now. \n"
@@ -1077,34 +1077,34 @@ msgstr ""
 "這篇文章尚待查核中，請先不要相信這篇文章。\n"
 "以下是機器人初步分析此篇訊息的結果，希望能帶給你一些想法。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:263
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:279
 #: src/webhook/handlers/choosingArticle.ts:406
 msgid "After reading the automatic analysis by the bot above, you can:"
 msgstr "讀完以上機器人的自動分析後，您可以："
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:181
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:197
 msgid ""
 "Thank you for submitting! Now the messages has been recorded in the Cofacts "
 "database."
 msgstr "感謝提供！現在資料庫裡有這些訊息囉。"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:184
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:188
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:200
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:204
 msgid "Please choose the messages you would like to view"
 msgstr "請選擇要查看的訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:119
+#: src/webhook/handlers/askingCooccurrence.ts:132
 msgid "Be the first to report these messages"
 msgstr "成為全球首位回報這些訊息的人"
 
-#: src/webhook/handlers/askingCooccurrence.ts:133
+#: src/webhook/handlers/askingCooccurrence.ts:146
 #, javascript-format
 msgid ""
 "The ${ notInDbMsgIndexes.length } messages that you have sent are not "
 "within the Cofacts database."
 msgstr "您傳的 ${ notInDbMsgIndexes.length } 則訊息，目前都不在 Cofacts 資料庫裡。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:134
+#: src/webhook/handlers/askingCooccurrence.ts:147
 #, javascript-format
 msgid ""
 "Out of the ${ totalCount } messages you sent, ${ notInDbMsgIndexes.length } "
@@ -1114,33 +1114,33 @@ msgid_plural ""
 "are not within the Cofacts database."
 msgstr[0] "在您傳的 ${ totalCount } 則訊息中，有 ${ notInDbMsgIndexes.length } 則不在 Cofacts 資料庫裡。"
 
-#: src/webhook/handlers/askingCooccurrence.ts:143
+#: src/webhook/handlers/askingCooccurrence.ts:156
 #: src/webhook/handlers/utils.ts:184
 msgid "If you believe:"
 msgstr "若您覺得："
 
-#: src/webhook/handlers/askingCooccurrence.ts:163
+#: src/webhook/handlers/askingCooccurrence.ts:176
 #. t: If you believe ~ a rumor
 msgid "That they are most likely "
 msgstr "它們很可能是"
 
-#: src/webhook/handlers/askingCooccurrence.ts:167
+#: src/webhook/handlers/askingCooccurrence.ts:180
 #. t: If you believe that it is most likely ~
 msgid "rumors,"
 msgstr "謠言"
 
-#: src/webhook/handlers/askingCooccurrence.ts:195
+#: src/webhook/handlers/askingCooccurrence.ts:208
 #: src/webhook/handlers/utils.ts:236
 #. t: ~ make this messasge public
 msgid "And you are willing to "
 msgstr "您願意"
 
-#: src/webhook/handlers/askingCooccurrence.ts:199
+#: src/webhook/handlers/askingCooccurrence.ts:212
 #. t: and you are willing to ~
 msgid "make these messages public"
 msgstr "公開這些訊息"
 
-#: src/webhook/handlers/askingCooccurrence.ts:215
+#: src/webhook/handlers/askingCooccurrence.ts:228
 #, javascript-format
 msgid "Press “${ btnText }” to make these messages public on Cofacts website "
 msgstr "請按「${ btnText }」在 Cofacts 網站公開它們"
@@ -1202,18 +1202,18 @@ msgstr "回報 AI 分析沒幫助"
 msgid "AI analysis"
 msgstr "AI 自動分析"
 
-#: src/webhook/handlers/askingArticleSubmissionConsent.ts:209
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:225
 msgid ""
 "I am now generating automated analysis for the message you have submitted, "
 "please wait."
 msgstr "我正在為您所回報的訊息生成 AI 自動分析，請稍等。"
 
-#: src/webhook/handlers/utils.ts:1513
+#: src/webhook/handlers/utils.ts:1515
 msgid "I am still processing your request. Please wait."
 msgstr "我還在處理您的需求，請稍等。"
 
-#: src/webhook/handlers/utils.ts:1547
-#: src/webhook/handlers/utils.ts:1552
+#: src/webhook/handlers/utils.ts:1549
+#: src/webhook/handlers/utils.ts:1554
 msgid "OK, proceed."
 msgstr "好，請繼續。"
 
@@ -1225,7 +1225,7 @@ msgid ""
 msgstr "我現在正將您的 ${ msgsToSubmit.length } 則新訊息送進資料庫。"
 
 #: src/webhook/handlers/askingCooccurrence.ts:77
-#: src/webhook/handlers/askingCooccurrence.ts:91
+#: src/webhook/handlers/askingCooccurrence.ts:93
 #, javascript-format
 msgid ""
 "Out of the ${ context.msgs.length } message(s) you have submitted, I am "
@@ -1235,3 +1235,16 @@ msgstr "我仍在分析您所送出的 ${ context.msgs.length } 則訊息的其�
 #: src/webhook/handlers/processMedia.ts:41
 msgid "I am still analyzing the media file you have submitted."
 msgstr "我仍在分析您傳來的影音檔案。"
+
+#: src/webhook/handlers/askingArticleSubmissionConsent.ts:183
+#: src/webhook/handlers/askingCooccurrence.ts:105
+msgid ""
+"Sorry, I encountered an error while analyzing the messages. Please try "
+"sending them to me again later."
+msgstr "抱歉，我分析訊息時發生錯誤，請稍後再試。"
+
+#: src/webhook/handlers/processMedia.ts:61
+msgid ""
+"Sorry, I encountered an error while processing your media. Please try again "
+"later."
+msgstr "抱歉，我替您處理影音檔案時發生錯誤，請稍後再試。"

--- a/src/lib/detectDialogflowIntent.ts
+++ b/src/lib/detectDialogflowIntent.ts
@@ -49,6 +49,6 @@ export default async function (input: string) {
     const responses = await sessionClient.detectIntent(request);
     return responses[0];
   } catch (error) {
-    console.error(error);
+    console.error('[Dialogflow]', error);
   }
 }

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -45,6 +45,7 @@ function getGraphQLRespLoader(url: string) {
         //
         body: JSON.stringify(queryAndVariables),
       });
+      return await resp.json();
     } catch (error) {
       console.error(`Failed to fetch GraphQL response from ${url}:`, {
         status: resp?.status,
@@ -53,8 +54,6 @@ function getGraphQLRespLoader(url: string) {
       });
       throw error;
     }
-
-    return resp.json();
   }));
 }
 

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -32,19 +32,29 @@ function getGraphQLRespLoader(url: string) {
     // Clear dataloader so that next batch will get a fresh dataloader
     delete loaders[url];
 
-    // Implements Apollo's transport layer batching
-    // https://www.apollographql.com/blog/apollo-client/performance/query-batching/#1bce
-    //
-    return (
-      await fetch(url, {
+    let resp;
+    try {
+      resp = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'x-app-secret': process.env.APP_SECRET ?? '',
         },
+        // Implements Apollo's transport layer batching
+        // https://www.apollographql.com/blog/apollo-client/performance/query-batching/#1bce
+        //
         body: JSON.stringify(queryAndVariables),
-      })
-    ).json();
+      });
+    } catch (error) {
+      console.error(`Failed to fetch GraphQL response from ${url}:`, {
+        status: resp?.status,
+        statusText: resp?.statusText,
+        error,
+      });
+      throw error;
+    }
+
+    return resp.json();
   }));
 }
 

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -74,7 +74,7 @@ export default (query: TemplateStringsArray, ...substitutions: string[]) =>
     return getGraphQLRespLoader(URL)
       .load(queryAndVariable)
       .then((resp) => {
-        // We cannot get status code in transport layer batching.
+        // We cannot get status code of individual request in transport layer batching.
         // but we can guess that it's not 2xx if `data` is null or does not exist.
         // Ref: https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#status-codes
         //

--- a/src/lib/gql.ts
+++ b/src/lib/gql.ts
@@ -50,6 +50,9 @@ function getGraphQLRespLoader(url: string) {
       console.error(`Failed to fetch GraphQL response from ${url}:`, {
         status: resp?.status,
         statusText: resp?.statusText,
+        headers: resp?.headers
+          ? JSON.stringify(Object.fromEntries(resp.headers.entries()))
+          : undefined,
         error,
       });
       throw error;

--- a/src/lib/redisClient.js
+++ b/src/lib/redisClient.js
@@ -38,7 +38,7 @@ function get(key) {
         } catch (e) /* istanbul ignore next */ {
           // Gracefully fallback, in case the stuff in redis is a mess
           //
-          console.error(e);
+          console.error('[redisClient]', e);
           rollbar.error(e);
           resolve({});
         }

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -163,11 +163,23 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
     // Also include those messages that are similar for users to choose.
     //
     const searchResults = await Promise.all(
-      context.msgs.map(async (msg) =>
-        msg.type === 'text'
-          ? searchText(msg.text)
-          : searchMedia(getLineContentProxyURL(msg.id), userId)
-      )
+      context.msgs.map(async (msg) => {
+        try {
+          return msg.type === 'text'
+            ? searchText(msg.text)
+            : searchMedia(getLineContentProxyURL(msg.id), userId);
+        } /* istanbul ignore next */ catch (error) {
+          console.error('[askingArticleSubmissionConsent] Error searching media:', error);
+          return {
+            context,
+            replies: [
+              createTextMessage({
+                text: t`Sorry, I encountered an error while analyzing the messages. Please try sending them to me again later.`,
+              }),
+            ],
+          };
+        }
+      })
     );
     await Promise.all([
       addReplyRequestForUnrepliedCooccurredArticles(searchResults, userId),

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -162,28 +162,29 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
     // Search again, this time all messages should be in the database.
     // Also include those messages that are similar for users to choose.
     //
-    const searchResults = await Promise.all(
-      context.msgs.map(async (msg) => {
-        try {
-          return msg.type === 'text'
+    let searchResults;
+    try {
+      searchResults = await Promise.all(
+        context.msgs.map(async (msg) =>
+          msg.type === 'text'
             ? searchText(msg.text)
-            : searchMedia(getLineContentProxyURL(msg.id), userId);
-        } /* istanbul ignore next */ catch (error) {
-          console.error(
-            '[askingArticleSubmissionConsent] Error searching media:',
-            error
-          );
-          return {
-            context,
-            replies: [
-              createTextMessage({
-                text: t`Sorry, I encountered an error while analyzing the messages. Please try sending them to me again later.`,
-              }),
-            ],
-          };
-        }
-      })
-    );
+            : searchMedia(getLineContentProxyURL(msg.id), userId)
+        )
+      );
+    } /* istanbul ignore next */ catch (error) {
+      console.error(
+        '[askingArticleSubmissionConsent] Error searching media:',
+        error
+      );
+      return {
+        context,
+        replies: [
+          createTextMessage({
+            text: t`Sorry, I encountered an error while analyzing the messages. Please try sending them to me again later.`,
+          }),
+        ],
+      };
+    }
     await Promise.all([
       addReplyRequestForUnrepliedCooccurredArticles(searchResults, userId),
       setExactMatchesAsCooccurrence(searchResults, userId),

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -169,7 +169,10 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
             ? searchText(msg.text)
             : searchMedia(getLineContentProxyURL(msg.id), userId);
         } /* istanbul ignore next */ catch (error) {
-          console.error('[askingArticleSubmissionConsent] Error searching media:', error);
+          console.error(
+            '[askingArticleSubmissionConsent] Error searching media:',
+            error
+          );
           return {
             context,
             replies: [

--- a/src/webhook/handlers/askingArticleSubmissionConsent.ts
+++ b/src/webhook/handlers/askingArticleSubmissionConsent.ts
@@ -171,7 +171,7 @@ const askingArticleSubmissionConsent: ChatbotPostbackHandler = async ({
             : searchMedia(getLineContentProxyURL(msg.id), userId)
         )
       );
-    } /* istanbul ignore next */ catch (error) {
+    } catch (error) /* istanbul ignore next */ {
       console.error(
         '[askingArticleSubmissionConsent] Error searching media:',
         error

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -78,24 +78,26 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
       );
       await displayLoadingAnimation(userId);
 
-      const searchResults = await Promise.all(
-        context.msgs.map(async (msg) => {
-          let result;
-          try {
-            result = await (msg.type === 'text'
+      let searchResults;
+      try {
+        searchResults = await Promise.all(
+          context.msgs.map(async (msg) =>
+            msg.type === 'text'
               ? searchText(msg.text)
-              : searchMedia(getLineContentProxyURL(msg.id), userId));
-          } /* istanbul ignore next */ catch (error) {
-            console.error('[askingCooccurrence] Error searching media:', error);
-            return {
-              context,
-              replies: [
-                createTextMessage({
-                  text: t`Sorry, I encountered an error while analyzing the messages. Please try sending them to me again later.`,
-                }),
-              ],
-            };
-          }
+              : searchMedia(getLineContentProxyURL(msg.id), userId)
+          )
+        );
+      } /* istanbul ignore next */ catch (error) {
+        console.error('[askingCooccurrence] Error searching media:', error);
+        return {
+          context,
+          replies: [
+            createTextMessage({
+              text: t`Sorry, I encountered an error while analyzing the messages. Please try sending them to me again later.`,
+            }),
+          ],
+        };
+      }
 
           processingCount -= 1;
           // Update reply token collector message with latest number of messages that is still being analyzed

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -71,14 +71,7 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
         })
         .send();
 
-      const processingCount = context.msgs.length;
-      await setReplyTokenCollectorMsg(
-        userId,
-        t`Out of the ${context.msgs.length} message(s) you have submitted, I am still analyzing ${processingCount} of them.`
-      );
-      await displayLoadingAnimation(userId);
-
-      const processingCount = context.msgs.length;
+      let processingCount = context.msgs.length;
       await setReplyTokenCollectorMsg(
         userId,
         t`Out of the ${context.msgs.length} message(s) you have submitted, I am still analyzing ${processingCount} of them.`

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -96,7 +96,7 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
             return result;
           })
         );
-      } /* istanbul ignore next */ catch (error) {
+      } catch (error) /* istanbul ignore next */ {
         console.error('[askingCooccurrence] Error searching media:', error);
         return {
           context,

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -71,7 +71,7 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
         })
         .send();
 
-      let processingCount = context.msgs.length;
+      const processingCount = context.msgs.length;
       await setReplyTokenCollectorMsg(
         userId,
         t`Out of the ${context.msgs.length} message(s) you have submitted, I am still analyzing ${processingCount} of them.`
@@ -98,7 +98,6 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
           ],
         };
       }
-
 
       const notInDbMsgIndexes = searchResults.reduce((indexes, result, idx) => {
         const firstResult = result.edges[0];

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -80,9 +80,22 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
 
       const searchResults = await Promise.all(
         context.msgs.map(async (msg) => {
-          const result = await (msg.type === 'text'
-            ? searchText(msg.text)
-            : searchMedia(getLineContentProxyURL(msg.id), userId));
+          let result;
+          try {
+            result = await (msg.type === 'text'
+              ? searchText(msg.text)
+              : searchMedia(getLineContentProxyURL(msg.id), userId));
+          } /* istanbul ignore next */ catch (error) {
+            console.error('[askingCooccurrence] Error searching media:', error);
+            return {
+              context,
+              replies: [
+                createTextMessage({
+                  text: t`Sorry, I encountered an error while analyzing the messages. Please try sending them to me again later.`,
+                }),
+              ],
+            };
+          }
 
           processingCount -= 1;
           // Update reply token collector message with latest number of messages that is still being analyzed

--- a/src/webhook/handlers/askingCooccurrence.ts
+++ b/src/webhook/handlers/askingCooccurrence.ts
@@ -99,16 +99,6 @@ const askingCooccurence: ChatbotPostbackHandler = async ({
         };
       }
 
-          processingCount -= 1;
-          // Update reply token collector message with latest number of messages that is still being analyzed
-          await setReplyTokenCollectorMsg(
-            userId,
-            t`Out of the ${context.msgs.length} message(s) you have submitted, I am still analyzing ${processingCount} of them.`
-          );
-
-          return result;
-        })
-      );
 
       const notInDbMsgIndexes = searchResults.reduce((indexes, result, idx) => {
         const firstResult = result.edges[0];

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -45,7 +45,7 @@ export default async function (message: CooccurredMessage, userId: string) {
   let result;
   try {
     result = await searchMedia(proxyUrl, userId);
-  } catch (error) {
+  /* istanbul ignore next */ catch (error) {
     console.error('[processMedia] Error searching media:', error);
     visitor.event({
       ec: 'Error',

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -42,7 +42,27 @@ export default async function (message: CooccurredMessage, userId: string) {
   );
   await displayLoadingAnimation(userId);
 
-  const result = await searchMedia(proxyUrl, userId);
+  let result;
+  try {
+    result = await searchMedia(proxyUrl, userId);
+  } catch (error) {
+    console.error('[processMedia] Error searching media:', error);
+    visitor.event({
+      ec: 'Error',
+      ea: 'ProcessMedia',
+      el: error instanceof Error ? error.message : 'Unknown error',
+    });
+    visitor.send();
+
+    return {
+      context,
+      replies: [
+        createTextMessage({
+          text: t`Sorry, I encountered an error while processing your media. Please try again later.`,
+        }),
+      ],
+    };
+  }
 
   if (result && result.edges.length) {
     // Track if find similar Articles in DB.

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -45,7 +45,7 @@ export default async function (message: CooccurredMessage, userId: string) {
   let result;
   try {
     result = await searchMedia(proxyUrl, userId);
-  } /* istanbul ignore next */ catch (error) {
+  } catch (error) /* istanbul ignore next */ {
     console.error('[processMedia] Error searching media:', error);
     visitor.event({
       ec: 'Error',

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -45,7 +45,7 @@ export default async function (message: CooccurredMessage, userId: string) {
   let result;
   try {
     result = await searchMedia(proxyUrl, userId);
-  /* istanbul ignore next */ catch (error) {
+  } /* istanbul ignore next */ catch (error) {
     console.error('[processMedia] Error searching media:', error);
     visitor.event({
       ec: 'Error',

--- a/src/webhook/handlers/processMedia.ts
+++ b/src/webhook/handlers/processMedia.ts
@@ -47,11 +47,6 @@ export default async function (message: CooccurredMessage, userId: string) {
     result = await searchMedia(proxyUrl, userId);
   } catch (error) /* istanbul ignore next */ {
     console.error('[processMedia] Error searching media:', error);
-    visitor.event({
-      ec: 'Error',
-      ea: 'ProcessMedia',
-      el: error instanceof Error ? error.message : 'Unknown error',
-    });
     visitor.send();
 
     return {

--- a/src/webhook/lineClient.js
+++ b/src/webhook/lineClient.js
@@ -84,7 +84,7 @@ async function getContent(messageId, options = {}) {
 
   if (resp.status !== 200) {
     const err = await resp.json();
-    console.error(JSON.stringify(err, null, '  '));
+    console.error('[LINE Client]', JSON.stringify(err, null, '  '));
 
     rollbar.error(
       `[LINE Client] ${resp.status}: ${err.message}.`,


### PR DESCRIPTION
In #401, we replaced the universal "Line bot is busy, or we cannot handle this message." timeout handling with a reply token collection mechanism.

However, it is possible that network errors occur so that the LINE client never gets the response back. Without proper error handling of network requests, the LINE user will wait indefinitely.

In this PR, we add back the error handling to long-running `searchMedia()` calls. When such error occurs, we would ask the user to try again later, which is a clear call-to-action message for the user.

![圖片](https://github.com/user-attachments/assets/f6885a55-f9b2-48af-aba5-9aa76edcfc9b)

Also, we add several logging labels to help debugging issues.

![image](https://github.com/user-attachments/assets/04fc6b2b-a559-4d39-8868-25676686ab2c)
